### PR TITLE
fix: `nuclei`: missing template-url from JSON output

### DIFF
--- a/secator/tasks/nuclei.py
+++ b/secator/tasks/nuclei.py
@@ -85,7 +85,7 @@ class nuclei(VulnMulti):
 		data = {}
 		data['data'] = item.get('extracted-results', [])
 		data['template_id'] = item['template-id']
-		data['template_url'] = item['template-url']
+		data['template_url'] = item.get('template-url', '')
 		return data
 
 	@staticmethod


### PR DESCRIPTION
Failed to load output type when `template-url` is not in JSON output (happens when using local cloned nuclei templates repositories)