### PR TITLE
Replace bs4 beautifulsoup4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "bs4 < 1",
+  "beautifulsoup4 <= 5",
   'celery < 6',
   "cpe < 2",
   "dotmap < 2",


### PR DESCRIPTION
`bs4` is a dummy package that points to `beautifulsoup4`. 

Most distributions don't ship `bs4`.