### PR TITLE
fix(nmap): undefined service name

### DIFF
--- a/secator/tasks/nmap.py
+++ b/secator/tasks/nmap.py
@@ -135,7 +135,7 @@ class nmapData(dict):
 
 				# Get extra data
 				extra_data = self._get_extra_data(port)
-				service_name = extra_data['service_name']
+				service_name = extra_data.get('service_name', '')
 				version_exact = extra_data.get('version_exact', False)
 				conf = extra_data.get('confidence')
 				if not version_exact:


### PR DESCRIPTION
In some cases, `nmap` metadata does not return the `service_name` in `extra_data`.