### PR TITLE
feat(`naabu`/`nmap`): help for defaults and change workflow opts

### DIFF
--- a/secator/configs/workflows/host_recon.yaml
+++ b/secator/configs/workflows/host_recon.yaml
@@ -9,6 +9,7 @@ input_types:
 tasks:
   naabu:
     description: Find open ports
+    ports: "-"  # scan all ports
   nmap:
     description: Search for vulnerabilities on open ports
     skip_host_discovery: True

--- a/secator/configs/workflows/port_scan.yaml
+++ b/secator/configs/workflows/port_scan.yaml
@@ -8,6 +8,7 @@ input_types:
 tasks:
   naabu:
     description: Find open ports
+    ports: "-"  # scan all ports
   nmap:
     description: Search for vulnerabilities on open ports
     targets_: port.host

--- a/secator/configs/workflows/port_scan.yaml
+++ b/secator/configs/workflows/port_scan.yaml
@@ -11,10 +11,10 @@ tasks:
     ports: "-"  # scan all ports
   nmap:
     description: Search for vulnerabilities on open ports
-    targets_: port.host
-    ports_: port.port
     skip_host_discovery: True
     version_detection: True
+    targets_: port.host
+    ports_: port.port
   _group:
     searchsploit:
       description: Search for related exploits

--- a/secator/configs/workflows/port_scan.yaml
+++ b/secator/configs/workflows/port_scan.yaml
@@ -5,6 +5,7 @@ description: Port scan
 tags: [recon, network, http, vuln]
 input_types:
   - host
+  - cidr_range
 tasks:
   naabu:
     description: Find open ports

--- a/secator/tasks/naabu.py
+++ b/secator/tasks/naabu.py
@@ -14,7 +14,7 @@ class naabu(ReconPort):
 	file_flag = '-list'
 	json_flag = '-json'
 	opts = {
-		PORTS: {'type': str, 'short': 'p', 'help': 'Ports'},
+		PORTS: {'type': str, 'short': 'p', 'help': 'Ports (default: nmap\'s top 100 ports'},
 		TOP_PORTS: {'type': str, 'short': 'tp', 'help': 'Top ports'},
 		'scan_type': {'type': str, 'help': 'Scan type (SYN (s)/CONNECT(c))'},
 		# 'health_check': {'is_flag': True, 'short': 'hc', 'help': 'Health check'}

--- a/secator/tasks/nmap.py
+++ b/secator/tasks/nmap.py
@@ -31,7 +31,7 @@ class nmap(VulnMulti):
 	opt_prefix = '--'
 	output_types = [Port, Vulnerability, Exploit]
 	opts = {
-		PORTS: {'type': str, 'short': 'p', 'help': 'Ports to scan'},
+		PORTS: {'type': str, 'short': 'p', 'help': 'Ports to scan (default: most common 1000 ports for each protocol)'},
 		TOP_PORTS: {'type': int, 'short': 'tp', 'help': 'Top ports to scan [full, 100, 1000]'},
 		SCRIPT: {'type': str, 'default': 'vulners', 'help': 'NSE scripts'},
 		'skip_host_discovery': {'is_flag': True, 'short': 'Pn', 'default': False, 'help': 'Skip host discovery (no ping)'},


### PR DESCRIPTION
`naabu` and `nmap` handle default ports differently:
- `naabu` scans nmap's `top-100` ports by default (see https://docs.projectdiscovery.io/tools/naabu/running#:~:text=By%20default%2C%20the%20Naabu%20checks%20for%20nmap%E2%80%99s%20Top%20100%20ports.%20It%20supports%20the%20following%20in%2Dbuilt%20port%20lists%20%2D)
- `nmap` scans 1-1023 (top 1000) of each protocol by default (see https://nmap.org/book/man-port-specification.html#:~:text=By%20default%2C%20Nmap%20scans%20the%20most%20common%201%2C000%20ports%20for%20each%20protocol.)