### PR TITLE
fix: kill worker in solo mode and mongodb singleton

### DIFF
--- a/secator/celery_signals.py
+++ b/secator/celery_signals.py
@@ -17,7 +17,7 @@ def kill_worker():
 	""""Kill current worker using it's pid by sending a SIGTERM to Celery master process."""
 	worker_name = os.environ['WORKER_NAME']
 	if not TASK_IN_PROGRESS:
-		pid = os.getpid()
+		pid = os.getppid()
 		console.print(Info(message=f'Sending SIGTERM to worker {worker_name} with pid {pid}'))
 		os.kill(pid, signal.SIGTERM)
 	else:

--- a/secator/celery_signals.py
+++ b/secator/celery_signals.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import threading
+from pathlib import Path
 
 from celery import signals
 
@@ -8,57 +9,75 @@ from secator.config import CONFIG
 from secator.output_types import Info
 from secator.rich import console
 
-
 IDLE_TIMEOUT = CONFIG.celery.worker_kill_after_idle_seconds
-TASK_IN_PROGRESS = False
+
+# File-based state management system
+STATE_DIR = Path("/tmp/celery_state")
+STATE_DIR.mkdir(exist_ok=True, parents=True)
 
 
-def kill_worker():
-	""""Kill current worker using it's pid by sending a SIGTERM to Celery master process."""
-	worker_name = os.environ['WORKER_NAME']
-	if not TASK_IN_PROGRESS:
-		pid = os.getppid()
-		console.print(Info(message=f'Sending SIGTERM to worker {worker_name} with pid {pid}'))
-		os.kill(pid, signal.SIGTERM)
-	else:
-		console.print(Info(message=f'Cancelling worker shutdown of {worker_name} since a task is currently in progress'))
+def get_lock_file_path():
+    worker_name = os.environ.get("WORKER_NAME", f"unknown_{os.getpid()}")
+    return Path(f"/tmp/celery_worker_{worker_name}.lock")
 
 
-class IdleTimer:
-	def __init__(self, timeout):
-		self.thread = None
-		self.is_started = False
-		self.thread = threading.Timer(timeout, kill_worker)
-
-	def start(self):
-		if self.is_started:
-			self.cancel()
-		self.thread.start()
-		self.is_started = True
-
-	def cancel(self):
-		self.thread.cancel()
-		self.is_started = False
+def set_task_running(task_id):
+    """Mark that a task is running in current worker"""
+    with open(get_lock_file_path(), "w") as f:
+        f.write(task_id)
 
 
-IDLE_TIMER = IdleTimer(IDLE_TIMEOUT)
+def clear_task_running():
+    """Clear the task running state"""
+    lock_file = get_lock_file_path()
+    if lock_file.exists():
+        lock_file.unlink()
+
+
+def is_task_running():
+    """Check if a task is currently running"""
+    return get_lock_file_path().exists()
+
+
+def kill_worker(parent=False):
+    """Kill current worker using its pid by sending a SIGTERM to Celery master process."""
+    worker_name = os.environ.get('WORKER_NAME', 'unknown')
+
+    # Check if a task is running via the lock file
+    if not is_task_running():
+        pid = os.getppid() if parent else os.getpid()
+        console.print(Info(message=f'Sending SIGTERM to worker {worker_name} with pid {pid}'))
+        os.kill(pid, signal.SIGTERM)
+    else:
+        console.print(Info(message=f'Cancelling worker shutdown of {worker_name} since a task is running'))
+
+
+def setup_idle_timer(timeout):
+    """Setup a timer to kill the worker after being idle"""
+    if timeout == -1:
+        return
+
+    console.print(Info(message=f'Starting inactivity timer for {timeout} seconds ...'))
+    timer = threading.Timer(timeout, kill_worker)
+    timer.daemon = True  # Make sure timer is killed when worker exits
+    timer.start()
 
 
 def maybe_override_logging():
-	def decorator(func):
-		if CONFIG.celery.override_default_logging:
-			return signals.setup_logging.connect(func)
-		else:
-			return func
-	return decorator
+    def decorator(func):
+        if CONFIG.celery.override_default_logging:
+            return signals.setup_logging.connect(func)
+        else:
+            return func
+    return decorator
 
 
 @maybe_override_logging()
 def setup_logging(*args, **kwargs):
-	"""Override celery's logging setup to prevent it from altering our settings.
-	github.com/celery/celery/issues/1867
-	"""
-	pass
+    """Override celery's logging setup to prevent it from altering our settings.
+    github.com/celery/celery/issues/1867
+    """
+    pass
 
 
 def capture_worker_name(sender, instance, **kwargs):
@@ -66,38 +85,57 @@ def capture_worker_name(sender, instance, **kwargs):
 
 
 def worker_init_handler(**kwargs):
-	if IDLE_TIMEOUT != -1:
-		console.print(Info(message=f'Starting inactivity timer for {IDLE_TIMEOUT} seconds ...'))
-		IDLE_TIMER.start()
+    if IDLE_TIMEOUT != -1:
+        setup_idle_timer(IDLE_TIMEOUT)
 
 
-def task_prerun_handler(**kwargs):
-	global TASK_IN_PROGRESS, IDLE_TIMER
-	TASK_IN_PROGRESS = True
-	if IDLE_TIMEOUT != -1:
-		IDLE_TIMER.cancel()
+def task_prerun_handler(task_id, **kwargs):
+    # Mark that a task is running
+    set_task_running(task_id)
 
 
 def task_postrun_handler(**kwargs):
-	global TASK_IN_PROGRESS, IDLE_TIMER
-	TASK_IN_PROGRESS = False
-	sender_name = kwargs['sender'].name
+    # Mark that no task is running
+    clear_task_running()
 
-	if CONFIG.celery.worker_kill_after_task and sender_name.startswith('secator.'):
-		worker_name = os.environ['WORKER_NAME']
-		console.print(Info(message=f'Shutdown worker {worker_name} since config celery.worker_kill_after_task is set.'))
-		IDLE_TIMER.cancel()
-		kill_worker()
-		return
+    # Get sender name from kwargs
+    sender_name = kwargs['sender'].name
 
-	if IDLE_TIMEOUT != -1:  # restart timer
-		console.print(Info(message=f'Reset inactivity timer to {IDLE_TIMEOUT} seconds'))
-		IDLE_TIMER.start()
+    if CONFIG.celery.worker_kill_after_task and sender_name.startswith('secator.'):
+        worker_name = os.environ.get('WORKER_NAME', 'unknown')
+        console.print(Info(message=f'Shutdown worker {worker_name} since config celery.worker_kill_after_task is set.'))
+        kill_worker(parent=True)
+        return
+
+    # Set up a new idle timer
+    if IDLE_TIMEOUT != -1:
+        console.print(Info(message=f'Reset inactivity timer to {IDLE_TIMEOUT} seconds'))
+        setup_idle_timer(IDLE_TIMEOUT)
+
+
+def task_revoked_handler(request=None, **kwargs):
+    """Handle revoked tasks by clearing the task running state"""
+    console.print(Info(message='Task was revoked, clearing running state'))
+    clear_task_running()
+
+    # Set up a new idle timer
+    if IDLE_TIMEOUT != -1:
+        console.print(Info(message=f'Reset inactivity timer to {IDLE_TIMEOUT} seconds after task revocation'))
+        setup_idle_timer(IDLE_TIMEOUT)
+
+
+def worker_shutdown_handler(**kwargs):
+    """Cleanup lock files when worker shuts down"""
+    lock_file = get_lock_file_path()
+    if lock_file.exists():
+        lock_file.unlink()
 
 
 def setup_handlers():
-	signals.celeryd_after_setup.connect(capture_worker_name)
-	signals.setup_logging.connect(setup_logging)
-	signals.task_prerun.connect(task_prerun_handler)
-	signals.task_postrun.connect(task_postrun_handler)
-	signals.worker_ready.connect(worker_init_handler)
+    signals.celeryd_after_setup.connect(capture_worker_name)
+    signals.setup_logging.connect(setup_logging)
+    signals.task_prerun.connect(task_prerun_handler)
+    signals.task_postrun.connect(task_postrun_handler)
+    signals.task_revoked.connect(task_revoked_handler)
+    signals.worker_ready.connect(worker_init_handler)
+    signals.worker_shutdown.connect(worker_shutdown_handler)

--- a/secator/celery_signals.py
+++ b/secator/celery_signals.py
@@ -34,17 +34,6 @@ def clear_task_running():
         lock_file.unlink()
 
 
-def kill_worker():
-	""""Kill current worker using it's pid by sending a SIGTERM to Celery master process."""
-	worker_name = os.environ['WORKER_NAME']
-	if not TASK_IN_PROGRESS:
-		pid = os.getppid()
-		console.print(Info(message=f'Sending SIGTERM to worker {worker_name} with pid {pid}'))
-		os.kill(pid, signal.SIGTERM)
-	else:
-		console.print(Info(message=f'Cancelling worker shutdown of {worker_name} since a task is currently in progress'))
-
-
 def is_task_running():
     """Check if a task is currently running"""
     return get_lock_file_path().exists()

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -171,7 +171,8 @@ def worker(hostname, concurrency, reload, queue, pool, check, dev, stop, show):
 		patterns = "celery.py;tasks/*.py;runners/*.py;serializers/*.py;output_types/*.py;hooks/*.py;exporters/*.py"
 		cmd = f'watchmedo auto-restart --directory=./ --patterns="{patterns}" --recursive -- {cmd}'
 
-	Command.execute(cmd, name='secator_worker')
+	ret = Command.execute(cmd, name='secator_worker')
+	sys.exit(ret.return_code)
 
 
 #-------#

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -111,11 +111,9 @@ def find_duplicates(self):
 	if not ws_id:
 		return
 	if self.sync:
-		debug(f'running duplicate check on workspace {ws_id}', sub='hooks.mongodb')
 		tag_duplicates(ws_id)
 	else:
-		celery_id = tag_duplicates.delay(ws_id)
-		debug(f'running duplicate check on workspace {ws_id}', id=celery_id, sub='hooks.mongodb')
+		tag_duplicates.delay(ws_id)
 
 
 def load_finding(obj):
@@ -142,6 +140,7 @@ def tag_duplicates(ws_id: str = None):
 	Args:
 		ws_id (str): Workspace id.
 	"""
+	debug(f'running duplicate check on workspace {ws_id}', sub='hooks.mongodb')
 	client = get_mongodb_client()
 	db = client.main
 	workspace_query = list(

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -20,8 +20,8 @@ MONGODB_MAX_POOL_SIZE = CONFIG.addons.mongodb.max_pool_size
 
 logger = logging.getLogger(__name__)
 
-# Replace direct client initialization with None
 _mongodb_client = None
+
 
 def get_mongodb_client():
 	"""Get or create MongoDB client"""

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -242,6 +242,6 @@ HOOKS = {
 		'on_item': [update_finding],
 		'on_duplicate': [update_finding],
 		'on_interval': [update_runner],
-		'on_end': [update_runner, find_duplicates]
+		'on_end': [update_runner]
 	}
 }

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -20,11 +20,19 @@ MONGODB_MAX_POOL_SIZE = CONFIG.addons.mongodb.max_pool_size
 
 logger = logging.getLogger(__name__)
 
-client = pymongo.MongoClient(
-	escape_mongodb_url(MONGODB_URL),
-	maxPoolSize=MONGODB_MAX_POOL_SIZE,
-	serverSelectionTimeoutMS=MONGODB_CONNECT_TIMEOUT
-)
+# Replace direct client initialization with None
+_mongodb_client = None
+
+def get_mongodb_client():
+	"""Get or create MongoDB client"""
+	global _mongodb_client
+	if _mongodb_client is None:
+		_mongodb_client = pymongo.MongoClient(
+			escape_mongodb_url(MONGODB_URL),
+			maxPoolSize=MONGODB_MAX_POOL_SIZE,
+			serverSelectionTimeoutMS=MONGODB_CONNECT_TIMEOUT
+		)
+	return _mongodb_client
 
 
 def get_runner_dbg(runner):
@@ -39,6 +47,7 @@ def get_runner_dbg(runner):
 
 
 def update_runner(self):
+	client = get_mongodb_client()
 	db = client.main
 	type = self.config.type
 	collection = f'{type}s'
@@ -72,6 +81,7 @@ def update_finding(self, item):
 	if type(item) not in FINDING_TYPES:
 		return item
 	start_time = time.time()
+	client = get_mongodb_client()
 	db = client.main
 	update = item.toDict()
 	_type = item._type
@@ -132,6 +142,7 @@ def tag_duplicates(ws_id: str = None):
 	Args:
 		ws_id (str): Workspace id.
 	"""
+	client = get_mongodb_client()
 	db = client.main
 	workspace_query = list(
 		db.findings.find({'_context.workspace_id': str(ws_id), '_tagged': True}).sort('_timestamp', -1))

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -166,7 +166,7 @@ class Runner:
 
 		# Process prior results
 		for result in results:
-			list(self._process_item(result, print=False))
+			list(self._process_item(result, print=False, output=False))
 
 		# Input post-process
 		self.run_hooks('before_init')
@@ -783,19 +783,20 @@ class Runner:
 				count_map[name] = count
 		return count_map
 
-	def _process_item(self, item, print=True):
+	def _process_item(self, item, print=True, output=True):
 		"""Process an item yielded by the derived runner.
 
 		Args:
 			item (dict | str): Input item.
 			print (bool): Print item in console.
+			output (bool): Add to runner output.
 
 		Yields:
 			OutputType: Output type.
 		"""
 		# Item is a string, just print it
 		if isinstance(item, str):
-			self.output += item + '\n'
+			self.output += item + '\n' if output else ''
 			self._print_item(item) if item and print else ''
 			return
 

--- a/secator/tasks/fping.py
+++ b/secator/tasks/fping.py
@@ -13,7 +13,6 @@ class fping(ReconIp):
 	cmd = 'fping -a'
 	file_flag = '-f'
 	input_flag = None
-	ignore_return_code = True
 	opt_prefix = '--'
 	opt_key_map = {
 		DELAY: 'period',

--- a/secator/tasks/gospider.py
+++ b/secator/tasks/gospider.py
@@ -55,7 +55,6 @@ class gospider(HttpCrawler):
 	}
 	install_cmd = 'go install -v github.com/jaeles-project/gospider@latest'
 	install_github_handle = 'jaeles-project/gospider'
-	ignore_return_code = True
 	proxychains = False
 	proxy_socks5 = True  # with leaks... https://github.com/jaeles-project/gospider/issues/61
 	proxy_http = True  # with leaks... https://github.com/jaeles-project/gospider/issues/61

--- a/secator/tasks/nuclei.py
+++ b/secator/tasks/nuclei.py
@@ -73,7 +73,6 @@ class nuclei(VulnMulti):
 			EXTRA_DATA: lambda x: {k: v for k, v in x.items() if k not in ['duration', 'errors', 'percent']}
 		}
 	}
-	ignore_return_code = True
 	install_pre = {
 		'*': ['git']
 	}

--- a/secator/tasks/wpscan.py
+++ b/secator/tasks/wpscan.py
@@ -82,7 +82,6 @@ class wpscan(VulnHttp):
 	proxychains = False
 	proxy_http = True
 	proxy_socks5 = False
-	ignore_return_code = True
 	profile = 'io'
 
 	@staticmethod


### PR DESCRIPTION
It seems like there are still issues preventing the container to kill itself.
Example:
[INF] Starting inactivity timer for 20 seconds ...
[INF] Sending SIGTERM to worker celery@worker-io-7vgxp-fcqr5 with pid 1
[INF] Task "httpx" running with routing key "io"
[INF] Task httpx is chunkable but not running on "poll" queue, re-routing to
"poll" queue
[INF] Shutdown worker celery@worker-io-7vgxp-fcqr5 since config
celery.worker_kill_after_task is set.
[INF] Sending SIGTERM to worker celery@worker-io-7vgxp-fcqr5 with pid 7
worker: Warm shutdown (MainProcess)
[DBG] runner.secator_worker.command Command 
/root/.local/share/pipx/venvs/secator/bin/python -m celery -A secator.celery.app
worker -n worker-io-7vgxp-fcqr5 -Q io -P prefork -c 1 finished with return code 
-9

When I send a kill signal manually, it works:

[DBG] runner.secator_worker.status : secator_worker -> SUCCESS

Maybe the SIGTERM is actually caught by secator runner, thereby not forwarding it to the actual process ?