### PR TITLE
fix(celery): add no_live_updates to skip backend updates

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -100,6 +100,9 @@ def update_state(celery_task, task, force=False):
 	"""Update task state to add metadata information."""
 	if not IN_CELERY_WORKER_PROCESS:
 		return
+	if task.no_live_updates:
+		console.print('aborted update_state because no_live_updates is True')
+		return
 	if not force and not should_update(CONFIG.runners.backend_update_frequency, task.last_updated_celery):
 		return
 	task.last_updated_celery = time()

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -240,6 +240,8 @@ def mark_runner_started(results, runner, enable_hooks=True):
 	Returns:
 		list: Runner results
 	"""
+	if IN_CELERY_WORKER_PROCESS:
+		console.print(Info(message=f'Runner {runner.unique_name} has started, running mark_started'))
 	debug(f'Runner {runner.unique_name} has started, running mark_started', sub='celery')
 	if results:
 		runner.results = forward_results(results)
@@ -260,6 +262,8 @@ def mark_runner_completed(results, runner, enable_hooks=True):
 	Returns:
 		list: Final results
 	"""
+	if IN_CELERY_WORKER_PROCESS:
+		console.print(Info(message=f'Runner {runner.unique_name} has finished, running mark_completed'))
 	debug(f'Runner {runner.unique_name} has finished, running mark_completed', sub='celery')
 	results = forward_results(results)
 	runner.enable_hooks = enable_hooks

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -101,7 +101,6 @@ def update_state(celery_task, task, force=False):
 	if not IN_CELERY_WORKER_PROCESS:
 		return
 	if task.no_live_updates:
-		console.print('aborted update_state because no_live_updates is True')
 		return
 	if not force and not should_update(CONFIG.runners.backend_update_frequency, task.last_updated_celery):
 		return

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -117,6 +117,7 @@ class Runner:
 
 		# Runner process options
 		self.no_poll = self.run_opts.get('no_poll', False)
+		self.no_live_updates = self.run_opts.get('no_live_updates', False)
 		self.no_process = not self.run_opts.get('process', True)
 		self.piped_input = self.run_opts.get('piped_input', False)
 		self.piped_output = self.run_opts.get('piped_output', False)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved runtime informational messages for Celery worker execution, providing clearer status updates when runners start, complete, or when live updates are skipped.
  - Introduced a new runner option to disable live updates, offering more control over task updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->