### PR TITLE
fix(gcs): add stored_response_path to sent items

### DIFF
--- a/secator/hooks/gcs.py
+++ b/secator/hooks/gcs.py
@@ -11,7 +11,7 @@ from secator.utils import debug
 
 GCS_BUCKET_NAME = CONFIG.addons.gcs.bucket_name
 ITEMS_TO_SEND = {
-	'url': ['screenshot_path']
+	'url': ['screenshot_path', 'stored_response_path']
 }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for uploading both screenshot and stored response files to Google Cloud Storage for items of type 'url'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->