### PR TITLE
fix(celery): pass mongodb uuids when enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "",
 	"scripts": {
 		"solo": "npm run venv && npm run install &&. .venv/bin/activate && .venv/bin/secator worker -r",
-		"dev": "npm run venv && npm run install &&. .venv/bin/activate && SECATOR_CELERY_BROKER_URL=redis://localhost:6379 SECATOR_CELERY_RESULT_BACKEND=redis://localhost:6379 secator worker -r",
+		"dev": "npm run venv && npm run install &&. .venv/bin/activate && SECATOR_CELERY_BROKER_URL=redis://localhost:6379 SECATOR_CELERY_RESULT_BACKEND=redis://localhost:6379 SECATOR_ADDONS_MONGODB_ENABLED=1 secator worker -r",
 		"install": ". .venv/bin/activate && pip install -e .[gcs,redis,worker,dev,mongodb]",
 		"venv": "python3 -m venv .venv",
 		"generate": "rm -r venv && npm run venv && .venv/bin/pip freeze > requirements.txt",

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -241,6 +241,7 @@ def forward_results(results):
 
 	results = flatten(results)
 	if CONFIG.addons.mongodb.enabled:
+		console.print(Info(message=f'Extracting uuids from {len(results)} results'))
 		uuids = [r._uuid for r in results if hasattr(r, '_uuid')]
 		uuids.extend([r for r in results if isinstance(r, str)])
 		results = list(set(uuids))
@@ -277,6 +278,8 @@ def mark_runner_started(results, runner, enable_hooks=True):
 	for item in results:
 		runner.add_result(item, print=False)
 	runner.mark_started()
+	if CONFIG.addons.mongodb.enabled:
+		return [r._uuid for r in runner.results]
 	return runner.results
 
 
@@ -303,6 +306,8 @@ def mark_runner_completed(results, runner, enable_hooks=True):
 	for item in results:
 		runner.add_result(item, print=False)
 	runner.mark_completed()
+	if CONFIG.addons.mongodb.enabled:
+		return [r._uuid for r in runner.results]
 	return runner.results
 
 

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -30,7 +30,8 @@ def get_mongodb_client():
 		_mongodb_client = pymongo.MongoClient(
 			escape_mongodb_url(MONGODB_URL),
 			maxPoolSize=MONGODB_MAX_POOL_SIZE,
-			serverSelectionTimeoutMS=MONGODB_CONNECT_TIMEOUT
+			serverSelectionTimeoutMS=MONGODB_CONNECT_TIMEOUT,
+			connect=False
 		)
 	return _mongodb_client
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development script to enable MongoDB addons by default when running the worker process.

- **Enhancements**
  - Improved logging for MongoDB addon integration, providing clearer informational messages during processing.
  - Adjusted internal result handling to return lists of UUIDs when MongoDB addon is enabled, ensuring more relevant output in those scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->