### PR TITLE
update-rich-click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   'pydantic < 3',
   'requests < 3',
   'rich < 14',
-  'rich-click < 1.7',
+  'rich-click >= 1.8',
   'click < 8.2.0', 
   'psutil < 7',
   'retry < 1',

--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -8,7 +8,8 @@ from contextlib import nullcontext
 
 import psutil
 import rich_click as click
-from rich_click.rich_click import _get_rich_console
+from rich_click.rich_help_configuration import RichHelpConfiguration
+from rich_click.rich_help_formatter import RichHelpFormatter
 
 from secator.config import CONFIG
 from secator.click import CLICK_LIST
@@ -195,7 +196,7 @@ def register_runner(cli_endpoint, config):
 	@decorate_command_options(options)
 	@click.pass_context
 	def func(ctx, **opts):
-		console = _get_rich_console()
+		console = RichHelpFormatter(RichHelpConfiguration.load_from_globals)
 		version = opts['version']
 		sync = opts['sync']
 		ws = opts.pop('workspace')
@@ -297,7 +298,8 @@ def register_runner(cli_endpoint, config):
 				if CONFIG.celery.broker_url and \
 				   (broker_protocol == 'redis' or backend_protocol == 'redis') \
 				   and not ADDONS_ENABLED['redis']:
-					_get_rich_console().print('[bold red]Missing `redis` addon: please run `secator install addons redis`[/].')
+					RichHelpFormatter(RichHelpConfiguration.load_from_globals).print(
+                            '[bold red]Missing `redis` addon: please run `secator install addons redis`[/].')
 					sys.exit(1)
 
 		from secator.utils import debug

--- a/secator/click.py
+++ b/secator/click.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
 
 import rich_click as click
-from rich_click.rich_click import _get_rich_console
+from rich_click.rich_help_configuration import RichHelpConfiguration
+from rich_click.rich_help_formatter import RichHelpFormatter
 from rich_click.rich_group import RichGroup
 
 
@@ -31,7 +32,7 @@ class OrderedGroup(RichGroup):
 		def decorator(f):
 			aliases = kwargs.pop("aliases", None)
 			if aliases:
-				max_width = _get_rich_console().width
+				max_width = RichHelpFormatter(RichHelpConfiguration.load_from_globals).width 
 				aliases_str = ', '.join(f'[bold cyan]{alias}[/]' for alias in aliases)
 				padding = max_width // 4
 
@@ -62,7 +63,7 @@ class OrderedGroup(RichGroup):
 			aliases = kwargs.pop('aliases', [])
 			aliased_group = []
 			if aliases:
-				max_width = _get_rich_console().width
+				max_width = RichHelpFormatter(RichHelpConfiguration.load_from_globals).width
 				aliases_str = ', '.join(f'[bold cyan]{alias}[/]' for alias in aliases)
 				padding = max_width // 4
 				f.__doc__ = f.__doc__ or '\0'.ljust(padding+1)


### PR DESCRIPTION
update rich-click from 1.7 to 1.8 or greater.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required version of the `rich-click` dependency to 1.8 or higher.

* **Refactor**
  * Improved how command-line help output is formatted and displayed, ensuring compatibility with the updated `rich-click` library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->