### PR TITLE
fix(fping): remove bad options, add new ones

### DIFF
--- a/secator/tasks/fping.py
+++ b/secator/tasks/fping.py
@@ -17,9 +17,13 @@ class fping(ReconIp):
 	file_flag = '-f'
 	input_flag = None
 	opts = {
-		'reverse_dns': {'is_flag': True, 'default': False, 'short': 'r', 'help': 'Reverse DNS lookup (slower)'}
+		'count': {'type': int, 'default': None, 'short': 'c', 'help': 'Number of request packets to send to each target'},
+		'show_name': {'is_flag': True, 'default': False, 'short': 'n', 'help': 'Show network addresses as well as hostnames'},
+		'use_dns': {'is_flag': True, 'default': False, 'short': 'd',
+			  'help': 'Use DNS to lookup address of return packet (same as -n but will force reverse-DNS lookup for hostnames)'},
+		'summary': {'is_flag': True, 'default': False, 'short': 's', 'help': 'Print cumulative statistics upon exit'},
 	}
-	opt_prefix = '--'
+	opt_prefix = '-'
 	opt_key_map = {
 		DELAY: 'period',
 		PROXY: OPT_NOT_SUPPORTED,
@@ -27,7 +31,10 @@ class fping(ReconIp):
 		RETRIES: 'retry',
 		TIMEOUT: 'timeout',
 		THREADS: OPT_NOT_SUPPORTED,
-		'reverse_dns': 'r'
+		'count': 'c',
+		'show_name': 'n',
+		'use_dns': 'd',
+		'summary': 's',
 	}
 	opt_value_map = {
 		DELAY: lambda x: x * 1000,  # convert s to ms
@@ -41,9 +48,20 @@ class fping(ReconIp):
 	@staticmethod
 	def item_loader(self, line):
 		if '(' in line:
-			host, ip = tuple(t.strip() for t in line.rstrip(')').split('('))
-			if (validators.ipv4(host) or validators.ipv6(host)):
-				host = ''
+
+			line_part = line.split(' : ')[0] if ' : ' in line else line    # Removing the stat parts that appears when using -c
+
+			start_paren = line_part.find('(')
+			end_paren = line_part.find(')', start_paren)
+
+			if start_paren != -1 and end_paren != -1:
+				host = line_part[:start_paren].strip()
+				ip = line_part[start_paren+1:end_paren].strip()
+
+				if (validators.ipv4(host) or validators.ipv6(host)):
+					host = ''
+			else:
+				return
 		else:
 			ip = line.strip()
 			host = ''
@@ -56,3 +74,4 @@ class fping(ReconIp):
 		if 'Unreachable' in line:
 			return ''  # discard line as it pollutes output
 		return line
+


### PR DESCRIPTION
## Remove options 

The option `--r` doesn't exist on `fping`. So i removed it. I also changed the `opt_prefix` to `-`, i don't really know on what was based the old task, but now it's coherent to `fping`.

## New options 

Added the options `-c`, `-n`, `-d` and `-s`
The `-c` / count option added a text to the output, making the parser not working anymore, in a more verbose way and making it works with the option. 