### PR TITLE
Build dependencies

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -27,6 +27,7 @@ ENV PATH="${PATH}:/root/.local/bin"
 ENV GOBIN="/root/.local/bin"
 COPY --from=builder /root/.local /root/.local
 RUN apk add --no-cache \
+	cairo-dev \
 	flock \
 	pipx \
 	sudo

--- a/.docker/Dockerfile.debian
+++ b/.docker/Dockerfile.debian
@@ -10,6 +10,7 @@ RUN apt update -y && \
 	git \
 	golang-go \
     jq \
+	libcairo2-dev \
     openssl \
 	pipx \
 	python3 \

--- a/.docker/Dockerfile.kali
+++ b/.docker/Dockerfile.kali
@@ -1,4 +1,4 @@
-FROM kalilinux/kali-rolling:latest
+FROM kali-rolling:latest
 
 ENV PATH="${PATH}:/root/.local/bin"
 ENV GOBIN="/root/.local/bin"
@@ -10,6 +10,7 @@ RUN apt update -y && \
 	git \
 	golang-go \
     jq \
+	libcairo2-dev \
     openssl \
 	pipx \
 	python3 \

--- a/.docker/build_all.sh
+++ b/.docker/build_all.sh
@@ -2,16 +2,28 @@
 
 # Define an array of distributions
 DISTROS=("alpine" "arch" "debian" "kali" "osx" "ubuntu")
+BUILDER=$(which docker || which podman || which buildah)
+
+if [ -z "$BUILDER" ]; then
+  echo "Error: No container builder found (docker, podman, or buildah required)"
+  exit 1
+fi
+
+echo "Using builder: $BUILDER"
+
+mkdir -p .docker/logs/
 
 # Function to build an image
 build_image() {
     local DISTRO=$1
     local DOCKERFILE=".docker/Dockerfile.${DISTRO}"
+    local STDOUT_LOG=".docker/logs/${DISTRO}.stdout"
+    local STDERR_LOG=".docker/logs/${DISTRO}.stderr"
     local IMAGE_NAME="secator-${DISTRO}"
 
     if [ -f "$DOCKERFILE" ]; then
         echo "🚀 Building $IMAGE_NAME using $DOCKERFILE..."
-        docker build -t "$IMAGE_NAME" -f "$DOCKERFILE" . && \
+        $BUILDER build -t "$IMAGE_NAME" -f "$DOCKERFILE" . > $STDOUT_LOG 2> $STDERR_LOG && \
         echo "✅ Successfully built $IMAGE_NAME" || \
         echo "❌ Failed to build $IMAGE_NAME"
     else

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-.gitignore
+.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build logs
+.docker/logs
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
When attempting builds over the last couple of days I failed to build a few of the images because of missing dependencies. This PR corrects those issues. Additionaly I do not run docker but I do run podman (which is a caching version of buildah). This updates the script to be more kind to folks like myself.