### PR TITLE
fix: katana response and testssl install deps

### DIFF
--- a/secator/tasks/katana.py
+++ b/secator/tasks/katana.py
@@ -134,6 +134,9 @@ class katana(HttpCrawler):
 						value=param,
 						extra_data={'url': url, 'value': 'FUZZ'}
 					)
+		response = item.get('response')
+		if not response:
+			return item
 		url = Url(
 			url=item['request']['endpoint'],
 			host=parsed_url.hostname,

--- a/secator/tasks/testssl.py
+++ b/secator/tasks/testssl.py
@@ -49,9 +49,9 @@ class testssl(Command):
 	proxy_socks5 = False
 	profile = 'io'
 	install_cmd_pre = {
-		'apk': ['hexdump', 'coreutils', 'procps'],
-		'pacman': ['util-linux'],
-		'*': ['bsdmainutils']
+		'apk': ['hexdump', 'coreutils', 'procps', 'bash'],
+		'pacman': ['util-linux', 'bash'],
+		'*': ['bsdmainutils', 'bash']
 	}
 	install_version = 'v3.2.0'
 	install_cmd = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent crashes when response data is unavailable during processing.
  * Added bash as an installation prerequisite for testssl.sh across multiple package managers to ensure proper setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->