### PR TITLE
fix(tasks): gau subs should output only subdomains, not urls

### DIFF
--- a/secator/tasks/gau.py
+++ b/secator/tasks/gau.py
@@ -66,6 +66,7 @@ class gau(HttpCrawler):
 	def on_init(self):
 		self.max_param_occurrences = self.get_opt_value('max_param_occurrences')
 		self.seen_params = defaultdict(lambda: defaultdict(int))
+		self.subdomains = []
 
 	@staticmethod
 	def on_line(self, line):
@@ -93,5 +94,9 @@ class gau(HttpCrawler):
 		if self.get_opt_value('subs'):
 			domain = extract_domain_info(parsed_url.hostname, domain_only=True)
 			if domain:
-				yield Subdomain(host=parsed_url.hostname, domain=domain)
-		yield Url(url=item['url'], host=parsed_url.hostname)
+				subdomain = Subdomain(host=parsed_url.hostname, domain=domain)
+				if subdomain not in self.subdomains:
+					self.subdomains.append(subdomain)
+					yield subdomain
+		else:
+			yield Url(url=item['url'], host=parsed_url.hostname)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subdomain output now automatically deduplicates entries, eliminating duplicate results when subdomain enumeration is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->