### PR TITLE
fix(tasks): ffuf default wordlist in fuzzing mode

### DIFF
--- a/secator/tasks/ffuf.py
+++ b/secator/tasks/ffuf.py
@@ -92,7 +92,7 @@ class ffuf(HttpFuzzer):
 			host = self.inputs[0].split('://')[1].split('/')[0]
 			opts['header']['value']['Host'] = f'FUZZ.{host}'
 			if self.get_opt_value('wordlist') == 'http':
-				self.add_result(Info(message='Changing wordlist to http_params as the default http wordlist is not suitable for fuzzing host header'))  # noqa: E501
+				self.add_result(Info(message='Changing wordlist to combined_subdomains as the default http wordlist is not suitable for fuzzing host header'))  # noqa: E501
 				opts['wordlist']['value'] = 'combined_subdomains'
 		self.headers = opts['header']['value'].copy()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wordlist handling for host header fuzzing operations. When host header fuzzing is enabled with HTTP-based wordlist sources selected, the tool now correctly applies the proper wordlist configuration, ensuring consistent and accurate fuzzing results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->