### PR TITLE
fix(tasks): remove x8 since build is broken

### DIFF
--- a/secator/configs/workflows/url_params_fuzz.yaml
+++ b/secator/configs/workflows/url_params_fuzz.yaml
@@ -29,11 +29,11 @@ options:
     help: Probe URLs (httpx)
     default: False
     short: probe
-  
+
   fuzzers:
     type: list
     help: "Parameter fuzzers to use (comma-separated) (arjun, x8)"
-    default: ['arjun', 'x8']
+    default: ['arjun']
 
 tasks:
   httpx:
@@ -63,14 +63,14 @@ tasks:
         field: value
         condition: item.name == 'url_base'
       if: "'arjun' in opts.fuzzers"
-    x8:
-      description: Bruteforce URL params
-      wordlist: http_params
-      targets_:
-      - type: tag
-        field: '{value}/'
-        condition: item.name == 'url_base'
-      if: "'x8' in opts.fuzzers"
+    # x8:
+    #   description: Bruteforce URL params
+    #   wordlist: http_params
+    #   targets_:
+    #   - type: tag
+    #     field: '{value}/'
+    #     condition: item.name == 'url_base'
+    #   if: "'x8' in opts.fuzzers"
 
   ffuf:
     description: Fuzz URL params

--- a/secator/tasks/x8.py
+++ b/secator/tasks/x8.py
@@ -7,7 +7,7 @@ from secator.serializers import JSONSerializer
 from secator.tasks._categories import HttpParamsFuzzer
 
 
-@task()
+# @task()
 class x8(HttpParamsFuzzer):
 	"""Hidden parameters discovery suite written in Rust."""
 	cmd = 'x8'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled x8 fuzzer from default URL parameter fuzzing workflows. The arjun fuzzer will now be used as the sole default option for fuzzing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->