### PR TITLE
fix(tasks): extend input types support for multiple tasks

### DIFF
--- a/secator/tasks/cariddi.py
+++ b/secator/tasks/cariddi.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse, urlunparse
 from secator.decorators import task
 from secator.definitions import (DELAY, DEPTH, FILTER_CODES, FILTER_REGEX,
 							   FILTER_SIZE, FILTER_WORDS, FOLLOW_REDIRECT,
-							   HEADER, MATCH_CODES, MATCH_REGEX, MATCH_SIZE,
+							   HEADER, HOST, HOST_PORT, MATCH_CODES, MATCH_REGEX, MATCH_SIZE,
 							   MATCH_WORDS, OPT_NOT_SUPPORTED,
 							   OPT_PIPE_INPUT, PROXY, RATE_LIMIT, RETRIES,
 							   THREADS, TIMEOUT, URL, USER_AGENT)
@@ -38,7 +38,7 @@ CARIDDI_RENAME_LIST = {
 class cariddi(HttpCrawler):
 	"""Crawl endpoints, secrets, api keys, extensions, tokens..."""
 	cmd = 'cariddi'
-	input_types = [URL]
+	input_types = [URL, HOST, HOST_PORT]
 	output_types = [Url, Tag]
 	tags = ['url', 'crawl']
 	input_flag = OPT_PIPE_INPUT

--- a/secator/tasks/dirsearch.py
+++ b/secator/tasks/dirsearch.py
@@ -9,7 +9,7 @@ from secator.definitions import (CONTENT_LENGTH, CONTENT_TYPE, DATA, DELAY, DEPT
 							   MATCH_CODES, MATCH_REGEX, MATCH_SIZE,
 							   MATCH_WORDS, METHOD, OPT_NOT_SUPPORTED, OUTPUT_PATH, PROXY,
 							   RATE_LIMIT, RETRIES, STATUS_CODE,
-							   THREADS, TIMEOUT, USER_AGENT, WORDLIST, URL)
+							   THREADS, TIMEOUT, USER_AGENT, WORDLIST, URL, HOST, HOST_PORT, IP)
 from secator.output_types import Url, Info, Error
 from secator.tasks._categories import HttpFuzzer
 
@@ -18,7 +18,7 @@ from secator.tasks._categories import HttpFuzzer
 class dirsearch(HttpFuzzer):
 	"""Advanced web path brute-forcer."""
 	cmd = 'dirsearch'
-	input_types = [URL]
+	input_types = [URL, HOST, HOST_PORT, IP]
 	output_types = [Url]
 	tags = ['url', 'fuzz']
 	input_flag = '-u'

--- a/secator/tasks/feroxbuster.py
+++ b/secator/tasks/feroxbuster.py
@@ -6,7 +6,7 @@ from secator.definitions import (CONTENT_TYPE, DATA, DELAY, DEPTH, FILTER_CODES,
 							   MATCH_REGEX, MATCH_SIZE, MATCH_WORDS, METHOD,
 							   OPT_NOT_SUPPORTED, OPT_PIPE_INPUT, PROXY,
 							   RATE_LIMIT, RETRIES, STATUS_CODE,
-							   THREADS, TIMEOUT, USER_AGENT, WORDLIST, WORDS, URL, REPLAY_PROXY)
+							   THREADS, TIMEOUT, USER_AGENT, WORDLIST, WORDS, URL, REPLAY_PROXY, HOST, HOST_PORT, IP)
 from secator.output_types import Url, Info
 from secator.serializers import JSONSerializer
 from secator.tasks._categories import HttpFuzzer
@@ -16,7 +16,7 @@ from secator.tasks._categories import HttpFuzzer
 class feroxbuster(HttpFuzzer):
 	"""Simple, fast, recursive content discovery tool written in Rust"""
 	cmd = 'feroxbuster --no-state'
-	input_types = [URL]
+	input_types = [URL, HOST, HOST_PORT, IP]
 	output_types = [Url]
 	tags = ['url', 'fuzz']
 	input_flag = '--url'

--- a/secator/tasks/katana.py
+++ b/secator/tasks/katana.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse, urlunparse
 
 from secator.decorators import task
 from secator.definitions import (DELAY, DEPTH, FILTER_CODES, FILTER_REGEX, FILTER_SIZE, FILTER_WORDS,
-								 FOLLOW_REDIRECT, HEADER, MATCH_CODES, MATCH_REGEX, MATCH_SIZE, MATCH_WORDS,
+								 FOLLOW_REDIRECT, HEADER, HOST, HOST_PORT, IP, MATCH_CODES, MATCH_REGEX, MATCH_SIZE, MATCH_WORDS,
 								 METHOD, OPT_NOT_SUPPORTED, PROXY, RATE_LIMIT, RETRIES, THREADS, TIMEOUT, URL, USER_AGENT)
 from secator.config import CONFIG
 from secator.output_types import Url, Tag
@@ -19,7 +19,7 @@ EXCLUDED_PARAMS = ['v']
 class katana(HttpCrawler):
 	"""Next-generation crawling and spidering framework."""
 	cmd = 'katana'
-	input_types = [URL]
+	input_types = [URL, HOST, HOST_PORT, IP]
 	output_types = [Url, Tag]
 	tags = ['url', 'crawl']
 	file_flag = '-list'

--- a/secator/tasks/nuclei.py
+++ b/secator/tasks/nuclei.py
@@ -4,7 +4,7 @@ from secator.definitions import (CONFIDENCE, CVSS_SCORE, DELAY, DESCRIPTION,
 								 MATCHED_AT, NAME, OPT_NOT_SUPPORTED, PERCENT,
 								 PROVIDER, PROXY, RATE_LIMIT, REFERENCES,
 								 RETRIES, SEVERITY, TAGS, THREADS, TIMEOUT,
-								 USER_AGENT, HOST, URL)
+								 USER_AGENT, HOST, URL, HOST_PORT)
 from secator.output_types import Progress, Tag, Vulnerability
 from secator.serializers import JSONSerializer
 from secator.tasks._categories import VulnMulti
@@ -24,7 +24,7 @@ def output_discriminator(self, item):
 class nuclei(VulnMulti):
 	"""Fast and customisable vulnerability scanner based on simple YAML based DSL."""
 	cmd = 'nuclei'
-	input_types = [HOST, IP, URL]
+	input_types = [HOST, HOST_PORT, IP, URL]
 	output_types = [Vulnerability, Tag, Progress]
 	tags = ['vuln', 'scan']
 	file_flag = '-l'

--- a/secator/tasks/testssl.py
+++ b/secator/tasks/testssl.py
@@ -10,7 +10,7 @@ from secator.decorators import task
 from secator.output_types import Vulnerability, Certificate, Error, Info, Ip, Tag, Warning
 from secator.definitions import (PROXY, HOST, USER_AGENT, HEADER, OUTPUT_PATH,
 								CERTIFICATE_STATUS_UNKNOWN, CERTIFICATE_STATUS_TRUSTED, CERTIFICATE_STATUS_REVOKED,
-								TIMEOUT)
+								TIMEOUT, HOST_PORT, URL, IP)
 from secator.tasks._categories import Command, OPTS
 
 
@@ -18,7 +18,7 @@ from secator.tasks._categories import Command, OPTS
 class testssl(Command):
 	"""SSL/TLS security scanner, including ciphers, protocols and cryptographic flaws."""
 	cmd = 'testssl.sh'
-	input_types = [HOST]
+	input_types = [HOST, HOST_PORT, URL, IP]
 	output_types = [Certificate, Vulnerability, Ip, Tag]
 	tags = ['dns', 'recon', 'tls']
 	input_flag = None

--- a/secator/tasks/wafw00f.py
+++ b/secator/tasks/wafw00f.py
@@ -5,7 +5,7 @@ import yaml
 
 from secator.decorators import task
 from secator.runners import Command
-from secator.definitions import (OUTPUT_PATH, HEADER, PROXY, URL, TIMEOUT)
+from secator.definitions import (OUTPUT_PATH, HEADER, PROXY, URL, TIMEOUT, HOST, HOST_PORT, IP)
 from secator.output_types import Tag, Info, Error
 from secator.tasks._categories import OPTS
 
@@ -14,7 +14,7 @@ from secator.tasks._categories import OPTS
 class wafw00f(Command):
 	"""Web Application Firewall Fingerprinting tool."""
 	cmd = 'wafw00f'
-	input_types = [URL]
+	input_types = [URL, HOST, HOST_PORT, IP]
 	output_types = [Tag]
 	tags = ['waf', 'scan']
 	input_flag = None

--- a/secator/tasks/wpscan.py
+++ b/secator/tasks/wpscan.py
@@ -9,7 +9,7 @@ from secator.definitions import (CONFIDENCE, CVSS_SCORE, DELAY, DESCRIPTION,
 							   MATCHED_AT, NAME, OPT_NOT_SUPPORTED, OUTPUT_PATH, PROVIDER,
 							   PROXY, RATE_LIMIT, REFERENCES, RETRIES,
 							   SEVERITY, TAGS, THREADS, TIMEOUT,
-							   URL, USER_AGENT)
+							   URL, USER_AGENT, HOST, IP)
 from secator.output_types import Tag, Vulnerability, Info, Error
 from secator.tasks._categories import VulnHttp
 from secator.installer import parse_version
@@ -19,7 +19,7 @@ from secator.installer import parse_version
 class wpscan(VulnHttp):
 	"""Wordpress security scanner."""
 	cmd = 'wpscan --force --verbose'
-	input_types = [URL]
+	input_types = [URL, HOST, IP]
 	output_types = [Vulnerability, Tag]
 	tags = ['vuln', 'scan', 'wordpress']
 	input_flag = '--url'


### PR DESCRIPTION
Add support for HOST, HOST_PORT, and IP input types to the following tasks:
- cariddi: added HOST, HOST_PORT
- dirsearch: added HOST, HOST_PORT, IP
- feroxbuster: added HOST, HOST_PORT, IP
- katana: added HOST, HOST_PORT, IP
- nuclei: added HOST_PORT (already had HOST, IP)
- testssl: added HOST_PORT, URL, IP (already had HOST)
- wafw00f: added HOST, HOST_PORT, IP
- wpscan: added HOST, IP (already had URL)

This allows users to pass different input formats without needing to convert them to URLs first, improving task versatility and usability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiple security scanning tools have been enhanced to accept broader input types including hosts, host:port combinations, and IP addresses, providing more flexible targeting capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->