### PR TITLE
fix: trufflehog profile set to medium

### DIFF
--- a/secator/tasks/trufflehog.py
+++ b/secator/tasks/trufflehog.py
@@ -91,6 +91,7 @@ class trufflehog(Command):
         f'mv {CONFIG.dirs.share}/trufflehog_[install_version]/trufflehog {CONFIG.dirs.bin}'
     )
     github_handle = 'trufflesecurity/trufflehog'
+    profile = 'medium'
 
     @staticmethod
     def before_init(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * TruffleHog integration now supports configurable profiling levels. Default profile is set to 'medium', allowing users to adjust runtime behavior and scanning intensity according to their needs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->