### PR TITLE
fix(mongodb): max items default to -1

### DIFF
--- a/secator/config.py
+++ b/secator/config.py
@@ -184,7 +184,7 @@ class MongodbAddon(StrictModel):
 	update_frequency: int = 60
 	max_pool_size: int = 10
 	server_selection_timeout_ms: int = 5000
-	max_items: int | None = None
+	max_items: int = -1
 	duplicate_main_copy_fields: List[str] = [
 		'screenshot_path',
 		'stored_response_path',

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -180,7 +180,8 @@ def tag_duplicates(ws_id: str = None, full_scan: bool = False, exclude_types=[],
 		del untagged_query['_tagged']
 	workspace_findings = load_findings(list(db.findings.find(workspace_query).sort('_timestamp', -1)), exclude_types)
 	untagged_query_cursor = db.findings.find(untagged_query).sort('_timestamp', -1)
-	if max_items is not None:
+	if max_items != -1:
+		debug(f'Limiting untagged query to {max_items} items', sub='hooks.mongodb', log_hook=log_hook)
 		untagged_query_cursor = untagged_query_cursor.limit(max_items)
 	untagged_findings = load_findings(list(untagged_query_cursor), exclude_types)
 	debug(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated MongoDB addon item limit handling to use -1 as the indicator for unlimited results instead of null values, improving internal consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->