### PR TITLE
feat(query): add ~= regex match operator to -q expressions

### DIFF
--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -181,7 +181,7 @@ def process_extractor(results, extractor, ctx=None):
 				'__builtins__': {'len': len},
 				're_match': lambda pattern, value: bool(re.search(pattern, str(value))) if value is not None else False,
 			}
-			_eval_condition = re.sub(r'([\w.]+)\s*~=\s*(.+)', r're_match(\2, \1)', _condition)
+			_eval_condition = re.sub(r'([\w.]+)\s*~=\s*(.+?)(?=\s+(?:and|or)\s+|$)', r're_match(\2, \1)', _condition)
 			eval_result = eval(_eval_condition, safe_globals, ctx)
 			if eval_result:
 				tmp_results.append(item)

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from secator.output_types import Error
 from secator.utils import deduplicate, debug
@@ -176,8 +177,12 @@ def process_extractor(results, extractor, ctx=None):
 				continue
 			ctx['item'] = item
 			ctx[f'{_type}'] = item
-			safe_globals = {'__builtins__': {'len': len}}
-			eval_result = eval(_condition, safe_globals, ctx)
+			safe_globals = {
+				'__builtins__': {'len': len},
+				're_match': lambda pattern, value: bool(re.search(pattern, str(value))) if value is not None else False,
+			}
+			_eval_condition = re.sub(r'([\w.]+)\s*~=\s*(.+)', r're_match(\2, \1)', _condition)
+			eval_result = eval(_eval_condition, safe_globals, ctx)
 			if eval_result:
 				tmp_results.append(item)
 			del ctx['item']


### PR DESCRIPTION
## Summary

- Adds `~=` operator support to `secator report show -q` expressions
- Transforms `field ~= 'pattern'` into `re.search(pattern, str(field))` before `eval()`
- Makes `re_match` available in the safe eval context alongside the existing `len` builtin

## Usage

```bash
secator report show scans/20 -q "vulnerability.tags ~= 'exploitable'"
secator report show -q "vulnerability.name ~= 'SQL.*[Ii]njection'"
secator report show -q "url.url ~= 'admin|login|dashboard'"
```

## Test plan

- [x] All existing `test_query` unit tests pass (25 passed)
- [x] Manual test with `secator report show -q "vulnerability.tags ~= 'exploitable'"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added regex pattern matching support for extractor conditions using the new `~=` operator. Users can now apply regular expression patterns directly within condition evaluations for more advanced and flexible text filtering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->