### PR TITLE
ci(security): only allow read permissions for publish.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*.*.*
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 


### PR DESCRIPTION
Potential fix for [https://github.com/freelabz/secator/security/code-scanning/22](https://github.com/freelabz/secator/security/code-scanning/22)

In general, fix this by adding an explicit `permissions:` block that grants only the minimal scopes the workflow actually needs. Because this workflow only needs to read repository contents (for `actions/checkout` and to access tags) and uses external credentials for PyPI and Docker Hub, we can safely set `contents: read`. Defining `permissions` at the workflow root (top level, alongside `name`, `on`, `env`, `jobs`) will apply to both `publish-pypi` and `publish-docker` jobs without altering functionality.

Concretely, edit `.github/workflows/publish.yml` after the `on:` block (after line 7) and insert:

```yaml
permissions:
  contents: read
```

No other changes are necessary: no steps/jobs need different permissions, and the workflow does not appear to require any additional scopes (like `packages` or `pull-requests`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enforce restricted repository access permissions on the publish pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->