### PR TITLE
fix(query): support dot notation for nested dict fields in query conditions

### DIFF
--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+from dotmap import DotMap
 from secator.output_types import Error
 from secator.utils import deduplicate, debug
 
@@ -175,8 +176,8 @@ def process_extractor(results, extractor, ctx=None):
 		for item in results:
 			if item._type != _type:
 				continue
-			ctx['item'] = item
-			ctx[f'{_type}'] = item
+			ctx['item'] = DotMap(item.toDict())
+			ctx[f'{_type}'] = DotMap(item.toDict())
 			safe_globals = {
 				'__builtins__': {'len': len},
 				're_match': lambda pattern, value: bool(re.search(pattern, str(value))) if value is not None else False,

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -134,6 +134,37 @@ class TestExtractorFunctions(unittest.TestCase):
         result = process_extractor(self.results, extractor, {})
         self.assertEqual(result, ['test1'])
 
+    def test_process_extractor_with_nested_condition(self):
+        """Test process_extractor with nested dict field access in conditions (dot notation)."""
+        # Test dot notation access on nested dict field (the original bug)
+        extractor = {
+            'type': 'mock',
+            'field': 'field1',
+            'condition': "mock.nested.subfield == 'nested_value'"
+        }
+        result = process_extractor(self.results, extractor)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result, ['test1', 'test2', 'test3'])
+
+        # Test dot notation with combined condition
+        extractor = {
+            'type': 'mock',
+            'field': 'field1',
+            'condition': "mock.nested.subfield == 'nested_value' and mock.field2 == 1"
+        }
+        result = process_extractor(self.results, extractor)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result, ['test1'])
+
+        # Test that non-matching nested value returns no results
+        extractor = {
+            'type': 'mock',
+            'field': 'field1',
+            'condition': "mock.nested.subfield == 'no_such_value'"
+        }
+        result = process_extractor(self.results, extractor)
+        self.assertEqual(result, [])
+
     def test_process_extractor_with_formatted_field(self):
         """Test process_extractor with formatted fields."""
         # Test already formatted field


### PR DESCRIPTION
Wrap OutputType items in DotMap before adding to the eval context in process_extractor(). This allows queries like `tag.extra_data.product == 'Apache HTTP Server'` to work correctly instead of silently returning no results.

Closes #962

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed condition evaluation to support dot-notation for accessing nested dictionary fields in extractor operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->