### PR TITLE
fix(cli): deduplicate short CLI parameters to prevent Click UserWarnings

### DIFF
--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -80,6 +80,15 @@ def decorate_command_options(opts):
 	"""
 	def decorator(f):
 		reversed_opts = OrderedDict(list(opts.items())[::-1])
+		# Pre-pass in original order to assign each short opt to its first claimant.
+		# This ensures global options (defined first) take priority over task/workflow options.
+		short_opt_owner = {}
+		for opt_name, opt_conf in opts.items():
+			short_opt = opt_conf.get('short')
+			short = f'-{short_opt}' if short_opt else f'-{opt_name}'
+			primary_short = short.split('/')[0]
+			if primary_short not in short_opt_owner:
+				short_opt_owner[primary_short] = opt_name
 		for opt_name, opt_conf in reversed_opts.items():
 			conf = opt_conf.copy()
 			short_opt = conf.pop('short', None)
@@ -119,7 +128,13 @@ def decorate_command_options(opts):
 			if choices:
 				choices_str = ', '.join([f'[dim yellow3]{c}[/]' for c in choices])
 				conf['help'] += rf' \[[dim]choices: {choices_str}[/]]'
-			args = [long, short]
+			# Deduplicate short opts: only include short form if this option is the first claimant.
+			# Earlier-defined options (exec/output globals) take priority over task/workflow options.
+			primary_short = short.split('/')[0]
+			if short_opt_owner.get(primary_short) == opt_name:
+				args = [long, short]
+			else:
+				args = [long]
 			if internal_name:
 				args.append(internal_name)
 			f = click.option(*args, **conf)(f)


### PR DESCRIPTION
Add a pre-pass in `decorate_command_options` that assigns each short option to its first claimant (in original option definition order). Global options (exec/output opts) are defined first and take priority. Any subsequent option with the same short form falls back to long-form only, eliminating the Click UserWarning about duplicate parameters.

This fixes all duplicate short opt warnings in scans/workflows that compose multiple sub-components sharing the same short flags (e.g. -ps for 'passive' across domain_recon/host_recon/subdomain_recon/url_vuln, -fd/-etags/-tlsg for httpx/nuclei options appearing in multiple workflows within the domain scan).

Fixes #964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command-line option parsing by resolving duplicate short flag conflicts. When multiple options shared the same short flag, it created ambiguity and parsing errors. Global execution and output options now correctly take precedence, preventing conflicts and ensuring consistent, reliable, and predictable command-line behavior across all operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->