### PR TITLE
fix(query): support multi-type queries and type-prefixed format strings

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -931,16 +931,75 @@ def report():
 	pass
 
 
+def process_query(query, fields=None):
+	"""Parse format fields and optional query string into a list of extractor dicts."""
+	if fields is None:
+		fields = []
+	otypes = [o.__name__.lower() for o in FINDING_TYPES]
+	extractors = []
+
+	fields_filter = {}
+	if fields:
+		for field in fields:
+			if '{' in field:
+				m = re.search(r'\{(\w+)[.\}]', field)
+				if not m:
+					console.print(Error(message='Could not determine output type from format string: ' + field))
+					sys.exit(1)
+				_type = m.group(1)
+				_field = field
+			else:
+				parts = field.split('.')
+				if len(parts) >= 2:
+					_type = parts[0]
+					_field = '.'.join(parts[1:])
+				else:
+					_type = parts[0]
+					_field = None
+			if _type not in otypes:
+				console.print(Error(message='Invalid output type: ' + _type))
+				sys.exit(1)
+			fields_filter[_type] = _field
+
+	if not query:
+		if fields:
+			extractors = [{'type': t, 'field': f, 'condition': 'True', 'op': 'or'} for t, f in fields_filter.items()]
+		return extractors
+
+	operator = '||'
+	if '&&' in query and '||' in query:
+		console.print(Error(message='Cannot mix && and || in the same query'))
+		sys.exit(1)
+	elif '&&' in query:
+		operator = '&&'
+
+	for part in query.split(operator):
+		part = part.strip()
+		_type = part.split('.')[0]
+		if _type not in otypes:
+			console.print(Error(message='Invalid output type: ' + _type))
+			sys.exit(1)
+		if fields and _type not in fields_filter:
+			console.print(Warning(message=f'Type {_type} not in --format types ({", ".join(fields_filter)}). Ignoring.'))
+			continue
+		extractor = {'type': _type, 'condition': part or 'True', 'op': 'and' if operator == '&&' else 'or'}
+		if fields_filter.get(_type):
+			extractor['field'] = fields_filter[_type]
+		extractors.append(extractor)
+	return extractors
+
+
 @report.command('show')
 @click.argument('report_query', required=False)
 @click.option('-o', '--output', type=str, default='console', help='Exporters')
 @click.option('-d', '--time-delta', type=str, default=None, help='Keep results newer than time delta. E.g: 26m, 1d, 1y')  # noqa: E501
 @click.option('-q', '--query', type=str, default=None, help='Filter results (Python-like or MongoDB JSON)')
+@click.option('-f', '--format', '_format', type=str, default='', help=f'Format output. E.g: port.host or {{{{port.host}}}}:{{{{port.port}}}}. Allowed types: {", ".join(FINDING_TYPES_LOWER)}')  # noqa: E501
 @click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.pass_context
-def report_show(ctx, report_query, output, time_delta, query, workspace, driver, dedupe):
+def report_show(ctx, report_query, output, time_delta, query, _format, workspace, driver, dedupe):
 	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""
 	from secator.query.utils import parse_report_paths, python_expr_to_mongo
 
@@ -1005,6 +1064,25 @@ def report_show(ctx, report_query, output, time_delta, query, workspace, driver,
 	dedupe_effective = CONFIG.runners.remove_duplicates if dedupe is None else dedupe
 	report = Report(runner, title=f'Consolidated report - {current}', exporters=exporters)
 	report.build(query=full_query, dedupe=dedupe_effective)
+
+	# 7. Apply --format extractors if provided (post-processing: format and print to stdout)
+	if _format:
+		from secator.serializers.dataclass import dataclass_decoder
+		from secator.runners._helpers import extract_from_results
+		format_fields = [f.strip() for f in re.split(r'\s*\|\|\s*|,', _format) if f.strip()]
+		extractors = process_query(None, fields=format_fields)
+		all_items = []
+		for items in report.data['results'].values():
+			for item in items:
+				if isinstance(item, dict):
+					item = dataclass_decoder(item)
+				all_items.append(item)
+		for extractor in extractors:
+			results, _ = extract_from_results(all_items, extractor)
+			for r in results:
+				print(r)
+		return
+
 	report.send()
 
 

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -935,16 +935,26 @@ def process_query(query, fields=None):
 	fields_filter = {}
 	if fields:
 		for field in fields:
-			parts = field.split('.')
-			if len(parts) == 2:
-				_type, field = parts
+			if '{' in field:
+				# Format string like '{port.host}:{port.port}' - extract type via regex
+				m = re.search(r'\{(\w+)[.\}]', field)
+				if not m:
+					console.print(Error(message='Could not determine output type from format string: ' + field))
+					sys.exit(1)
+				_type = m.group(1)
+				_field = field
 			else:
-				_type = parts[0]
-				field = None
+				parts = field.split('.')
+				if len(parts) >= 2:
+					_type = parts[0]
+					_field = '.'.join(parts[1:])
+				else:
+					_type = parts[0]
+					_field = None
 			if _type not in otypes:
 				console.print(Error(message='Invalid output type: ' + _type))
 				sys.exit(1)
-			fields_filter[_type] = field
+			fields_filter[_type] = _field
 
 	# No query
 	if not query:
@@ -1005,7 +1015,8 @@ def report_show(ctx, report_query, output, runner_type, time_delta, _format, que
 		unified = True
 
 	# Get extractors
-	extractors = process_query(query, fields=_format.split(',') if _format else [])
+	format_fields = [f.strip() for f in re.split(r'\s*\|\|\s*|,', _format) if f.strip()] if _format else []
+	extractors = process_query(query, fields=format_fields)
 	if extractors:
 		console.print(':wrench: [bold gold3]Showing query summary[/]')
 		op = extractors[0]['op']

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -30,7 +30,7 @@ from secator.serializers.dataclass import loads_dataclass
 from secator.loader import get_configs_by_type, discover_tasks
 from secator.utils import (
 	debug, detect_host, flatten, print_version, get_file_date,
-	sort_files_by_date, get_file_timestamp, list_reports, get_info_from_report_path, human_to_timedelta,
+	get_file_timestamp, list_reports, get_info_from_report_path, human_to_timedelta,
 	vhs_tap_to_tape, trim_gif, reduce_gif_frames, get_gif_info
 )
 from contextlib import nullcontext
@@ -931,182 +931,81 @@ def report():
 	pass
 
 
-def process_query(query, fields=None):
-	if fields is None:
-		fields = []
-	otypes = [o.__name__.lower() for o in FINDING_TYPES]
-	extractors = []
-
-	# Process fields
-	fields_filter = {}
-	if fields:
-		for field in fields:
-			if '{' in field:
-				# Format string like '{port.host}:{port.port}' - extract type via regex
-				m = re.search(r'\{(\w+)[.\}]', field)
-				if not m:
-					console.print(Error(message='Could not determine output type from format string: ' + field))
-					sys.exit(1)
-				_type = m.group(1)
-				_field = field
-			else:
-				parts = field.split('.')
-				if len(parts) >= 2:
-					_type = parts[0]
-					_field = '.'.join(parts[1:])
-				else:
-					_type = parts[0]
-					_field = None
-			if _type not in otypes:
-				console.print(Error(message='Invalid output type: ' + _type))
-				sys.exit(1)
-			fields_filter[_type] = _field
-
-	# No query
-	if not query:
-		if fields:
-			extractors = [{'type': field_type, 'field': field, 'condition': 'True', 'op': 'or'} for field_type, field in fields_filter.items()]  # noqa: E501
-		return extractors
-
-	# Get operator
-	operator = '||'
-	if '&&' in query and '||' in query:
-		console.print(Error(message='Cannot mix && and || in the same query'))
-		sys.exit(1)
-	elif '&&' in query:
-		operator = '&&'
-	elif '||' in query:
-		operator = '||'
-
-	# Process query
-	query = query.split(operator)
-	for part in query:
-		part = part.strip()
-		split_part = part.split('.')
-		_type = split_part[0]
-		if _type not in otypes:
-			console.print(Error(message='Invalid output type: ' + _type))
-			sys.exit(1)
-		if fields and _type not in fields_filter:
-			console.print(Warning(message='Type not allowed by --filter field: ' + _type + ' (allowed: ' + ', '.join(fields_filter.keys()) + '). Ignoring extractor.'))  # noqa: E501
-			continue
-		extractor = {
-			'type': _type,
-			'condition': part or 'True',
-			'op': 'and' if operator == '&&' else 'or'
-		}
-		field = fields_filter.get(_type)
-		if field:
-			extractor['field'] = field
-		extractors.append(extractor)
-	return extractors
-
-
 @report.command('show')
 @click.argument('report_query', required=False)
 @click.option('-o', '--output', type=str, default='console', help='Exporters')
-@click.option('-r', '--runner-type', type=str, default=None, help='Filter by runner type. Choices: task, workflow, scan')  # noqa: E501
 @click.option('-d', '--time-delta', type=str, default=None, help='Keep results newer than time delta. E.g: 26m, 1d, 1y')  # noqa: E501
-@click.option('-f', '--format', "_format", type=str, default='', help=f'Format output, comma-separated of: <output_type> or <output_type>.<field>. [bold]Allowed output types[/]: {", ".join(FINDING_TYPES_LOWER)}')  # noqa: E501
-@click.option('-q', '--query', type=str, default=None, help='Query results using a Python expression')
+@click.option('-q', '--query', type=str, default=None, help='Filter results (Python-like or MongoDB JSON)')
 @click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
-@click.option('-u', '--unified', is_flag=True, default=False, help='Show unified results (merge reports and de-duplicates results)')  # noqa: E501
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.pass_context
-def report_show(ctx, report_query, output, runner_type, time_delta, _format, query, workspace, unified):
-	"""Show report results and filter on them."""
+def report_show(ctx, report_query, output, time_delta, query, workspace, driver, dedupe):
+	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""
+	from secator.query.utils import parse_report_paths, python_expr_to_mongo
 
-	# Get report query from piped input
-	if ctx.obj['piped_input']:
-		report_query = ','.join(sys.stdin.read().splitlines())
-		unified = True
-
-	# Get extractors
-	format_fields = [f.strip() for f in re.split(r'\s*\|\|\s*|,', _format) if f.strip()] if _format else []
-	extractors = process_query(query, fields=format_fields)
-	if extractors:
-		console.print(':wrench: [bold gold3]Showing query summary[/]')
-		op = extractors[0]['op']
-		console.print(f':carousel_horse: [bold blue]Op[/] [bold orange3]->[/] [bold green]{op.upper()}[/]')
-		for extractor in extractors:
-			console.print(f':zap: [bold blue]{extractor["type"].title()}[/] [bold orange3]->[/] [bold green]{extractor["condition"]}[/]', highlight=False)  # noqa: E501
-
-	# Build runner instance
 	current = get_file_timestamp()
+	workspace_name = workspace or CONFIG.workspace.default or 'default'
+
+	# 1. Parse path-based runner filter
+	runner_filter = parse_report_paths(report_query)
+	debug('runner paths filter', sub='query', obj=runner_filter)
+
+	# 2. Translate -q expression to MongoDB style
+	debug('original query expr', sub='query', obj={'raw': query or ''})
+	mongo_query = python_expr_to_mongo(query) if query else {}
+	debug('converted mongo query', sub='query', obj=mongo_query)
+
+	# 3. Merge filters
+	overlap = set(runner_filter) & set(mongo_query)
+	if overlap:
+		# Preserve both constraints rather than letting one silently override
+		full_query = {'$and': [runner_filter, mongo_query]}
+	else:
+		full_query = {**runner_filter, **mongo_query}
+	debug('full query', sub='query', obj=full_query)
+
+	# 4. Add time delta filter if provided
+	if time_delta:
+		delta = human_to_timedelta(time_delta)
+		if delta:
+			import datetime
+			cutoff = datetime.datetime.now(datetime.timezone.utc) - delta
+			full_query['_timestamp'] = {'$gte': cutoff.timestamp()}
+
+	# 5. Build runner context for QueryEngine backend selection
+	drivers = [driver] if driver and driver != 'local' else []
 	runner = DotMap({
-		"config": {
-			"name": f"consolidated_report_{current}"
+		'config': DotMap({'name': f'consolidated_report_{current}', 'type': 'consolidated'}),
+		'name': 'runner',
+		'workspace_name': workspace_name,
+		'errors': [],
+		'context': {
+			'workspace_id': workspace_name,
+			'workspace_name': workspace_name,
+			'drivers': drivers,
 		},
-		"name": "runner",
-		"workspace_name": "_consolidated",
-		"reports_folder": Path.cwd(),
+		'reports_folder': Path.cwd(),
 	})
+	runner.toDict = lambda: {
+		'name': runner.name,
+		'status': 'completed',
+		'targets': [],
+		'start_time': None,
+		'end_time': None,
+		'elapsed': None,
+		'elapsed_human': None,
+		'run_opts': {},
+		'results_count': 0,
+	}
+
 	exporters = Runner.resolve_exporters(output)
 
-	# Build report queries from fuzzy input
-	paths = []
-	report_query = report_query.split(',') if report_query else []
-	load_all_reports = not report_query or any([not Path(p).exists() for p in report_query])  # fuzzy query, need to load all reports  # noqa: E501
-	all_reports = []
-	if load_all_reports or workspace:
-		all_reports = list_reports(workspace=workspace, type=runner_type, timedelta=human_to_timedelta(time_delta))
-	if not report_query:
-		report_query = all_reports
-	for query in report_query:
-		query = str(query)
-		if not query.endswith('/'):
-			query += '/'
-		path = Path(query)
-		if not path.exists():
-			matches = []
-			for path in all_reports:
-				if query in str(path):
-					matches.append(path)
-			if not matches:
-				console.print(
-					f'[bold orange3]Query {query} did not return any matches. [/][bold green]Ignoring.[/]')
-			paths.extend(matches)
-		else:
-			paths.append(path)
-	paths = sort_files_by_date(paths)
-
-	# Load reports, extract results
-	all_results = []
-	for ix, path in enumerate(paths):
-		if unified:
-			if ix == 0:
-				console.print(f'\n:wrench: [bold gold3]Loading {len(paths)} reports ...[/]')
-			console.print(rf':file_cabinet: Loading {path} \[[bold yellow4]{ix + 1}[/]/[bold yellow4]{len(paths)}[/]] \[results={len(all_results)}]...')  # noqa: E501
-		with open(path, 'r') as f:
-			try:
-				data = loads_dataclass(f.read())
-				info = get_info_from_report_path(path)
-				runner_type = info.get('type', 'unknowns')[:-1]
-				runner.results = flatten(list(data['results'].values()))
-				if unified:
-					all_results.extend(runner.results)
-					continue
-				report = Report(runner, title=f"Consolidated report - {current}", exporters=exporters)
-				report.build(extractors=extractors if not unified else [], dedupe=unified)
-				file_date = get_file_date(path)
-				runner_name = data['info']['name']
-				if not report.is_empty():
-					console.print(
-						f'\n{path} ([bold blue]{runner_name}[/] [dim]{runner_type}[/]) ([dim]{file_date}[/]):')
-				if report.is_empty():
-					if len(paths) == 1:
-						console.print(Warning(message='No results in report.'))
-					continue
-				report.send()
-			except json.decoder.JSONDecodeError as e:
-				console.print(Error(message=f'Could not load {path}: {str(e)}'))
-
-	if unified:
-		console.print(f'\n:wrench: [bold gold3]Building report by crunching {len(all_results)} results ...[/]', end='')
-		console.print(' (:coffee: [dim]this can take a while ...[/])')
-		runner.results = all_results
-		report = Report(runner, title=f"Consolidated report - {current}", exporters=exporters)
-		report.build(extractors=extractors, dedupe=True)
-		report.send()
+	# 6. Build and send report via QueryEngine
+	dedupe_effective = CONFIG.runners.remove_duplicates if dedupe is None else dedupe
+	report = Report(runner, title=f'Consolidated report - {current}', exporters=exporters)
+	report.build(query=full_query, dedupe=dedupe_effective)
+	report.send()
 
 
 @report.command('list')
@@ -1497,8 +1396,8 @@ r list [blue]-ws[/] [bright_magenta]prod[/]           [dim]# list reports from t
 r list [blue]-d[/] [bright_magenta]1h[/]              [dim]# list reports from the last hour[/]
 
 [dim]# Show and filter results...[/]
-r show [blue]-q[/] [bright_magenta]"url.status_code not in ['401', '403']"[/] [blue]-o[/] [bright_magenta]txt[/]                                 [dim]# show urls with status 401 or 403, save to txt file[/]
-r show tasks/10,tasks/11 [blue]-q[/] [bright_magenta]"tag.match and 'signup.php' in tag.match"[/] [blue]--unified[/] [blue]-o[/] [bright_magenta]json[/]  [dim]# show tags with targets matching 'signup.php' from tasks 10 and 11[/]
+r show [blue]-q[/] [bright_magenta]"vulnerability.severity_score >= 7"[/] [blue]-o[/] [bright_magenta]txt[/]                                      [dim]# show high-severity vulnerabilities, save to txt file[/]
+r show tasks/10,tasks/11 [blue]-q[/] [bright_magenta]"port.state == 'open'"[/] [blue]-o[/] [bright_magenta]json[/]           [dim]# show open ports from tasks 10 and 11[/]
 """,  # noqa: E501
 		title=f":file_cabinet: [{title_style}]Digging into reports[/]", **kwargs)
 

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -78,11 +78,13 @@ def fmt_extractor(extractor):
 	parsed_extractor = parse_extractor(extractor)
 	if not parsed_extractor:
 		return '<DYNAMIC[INVALID_EXTRACTOR]>'
-	_type, _field, _condition = parsed_extractor
+	_type, _field, _condition, _group_by = parsed_extractor
 	s = f'{_type}.{_field}'
 	if _condition:
 		_condition = _condition.replace("'", '').replace('"', '')
 		s = f'{s} if {_condition}'
+	if _group_by:
+		s = f'{s} group_by {_group_by}'
 	return f'<DYNAMIC({s})>'
 
 
@@ -128,22 +130,24 @@ def parse_extractor(extractor):
 		extractor (dict / str): extractor definition.
 
 	Returns:
-		tuple|None: type, field, condition or None if invalid.
+		tuple|None: type, field, condition, group_by or None if invalid.
 	"""
 	# Parse extractor, it can be a dict or a string (shortcut)
 	if isinstance(extractor, dict):
 		_type = extractor['type']
 		_field = extractor.get('field')
 		_condition = extractor.get('condition')
+		_group_by = extractor.get('group_by')
 	else:
 		parts = tuple(extractor.split('.'))
 		if len(parts) == 2:
 			_type = parts[0]
 			_field = parts[1]
 			_condition = None
+			_group_by = None
 		else:
 			return None
-	return _type, _field, _condition
+	return _type, _field, _condition, _group_by
 
 
 def process_extractor(results, extractor, ctx=None):
@@ -166,7 +170,7 @@ def process_extractor(results, extractor, ctx=None):
 	parsed_extractor = parse_extractor(extractor)
 	if not parsed_extractor:
 		return results
-	_type, _field, _condition = parsed_extractor
+	_type, _field, _condition, _group_by = parsed_extractor
 
 	# Evaluate condition for each result
 	if _condition:
@@ -202,7 +206,21 @@ def process_extractor(results, extractor, ctx=None):
 	if _field:
 		already_formatted = '{' in _field and '}' in _field
 		_field = '{' + _field + '}' if not already_formatted else _field
-		results = [_field.format(**{**item.toDict(), _type: item}) for item in results]
+
+		if _group_by:
+			already_formatted_gb = '{' in _group_by and '}' in _group_by
+			_group_by = '{' + _group_by + '}' if not already_formatted_gb else _group_by
+			groups = {}
+			for item in results:
+				group_key = _group_by.format(**{**item.toDict(), _type: item})
+				value = _field.format(**{**item.toDict(), _type: item})
+				prefix = value.split('~')[0] if '~' in value else value
+				bucket = groups.setdefault(group_key, [])
+				if prefix not in bucket:
+					bucket.append(prefix)
+			results = [','.join(hosts) + '~' + group_key for group_key, hosts in groups.items()]
+		else:
+			results = [_field.format(**{**item.toDict(), _type: item}) for item in results]
 	# debug('after extract', obj={'results_count': len(results), 'key': ctx.get('key')}, sub='extractor')
 	return results
 

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -201,7 +201,7 @@ def process_extractor(results, extractor, ctx=None):
 	if _field:
 		already_formatted = '{' in _field and '}' in _field
 		_field = '{' + _field + '}' if not already_formatted else _field
-		results = [_field.format(**{_type: item, **item.toDict()}) for item in results]
+		results = [_field.format(**{**item.toDict(), _type: item}) for item in results]
 	# debug('after extract', obj={'results_count': len(results), 'key': ctx.get('key')}, sub='extractor')
 	return results
 

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -201,7 +201,7 @@ def process_extractor(results, extractor, ctx=None):
 	if _field:
 		already_formatted = '{' in _field and '}' in _field
 		_field = '{' + _field + '}' if not already_formatted else _field
-		results = [_field.format(**item.toDict()) for item in results]
+		results = [_field.format(**{_type: item, **item.toDict()}) for item in results]
 	# debug('after extract', obj={'results_count': len(results), 'key': ctx.get('key')}, sub='extractor')
 	return results
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -339,50 +339,5 @@ class TestCli(unittest.TestCase):
 				assert result.exit_code == 0
 				assert 'already installed' in result.output
 
-class TestProcessQuery(unittest.TestCase):
-	"""Tests for process_query function."""
-
-	def test_simple_format_field(self):
-		"""Test simple type.field format string."""
-		from secator.cli import process_query
-		extractors = process_query(None, fields=['vulnerability.matched_at'])
-		self.assertEqual(len(extractors), 1)
-		self.assertEqual(extractors[0]['type'], 'vulnerability')
-		self.assertEqual(extractors[0]['field'], 'matched_at')
-
-	def test_format_string_with_braces(self):
-		"""Test format string with {type.field} syntax."""
-		from secator.cli import process_query
-		extractors = process_query(None, fields=['{tag.match}-{tag.name}'])
-		self.assertEqual(len(extractors), 1)
-		self.assertEqual(extractors[0]['type'], 'tag')
-		self.assertEqual(extractors[0]['field'], '{tag.match}-{tag.name}')
-
-	def test_multi_type_format_fields(self):
-		"""Test multiple format fields for different types."""
-		from secator.cli import process_query
-		extractors = process_query(None, fields=['{port.host}:{port.port}', 'vulnerability.matched_at'])
-		self.assertEqual(len(extractors), 2)
-		types = {e['type'] for e in extractors}
-		self.assertIn('port', types)
-		self.assertIn('vulnerability', types)
-		port_extractor = next(e for e in extractors if e['type'] == 'port')
-		self.assertEqual(port_extractor['field'], '{port.host}:{port.port}')
-
-	def test_multi_type_query_with_and(self):
-		"""Test query with && across different types creates separate extractors."""
-		from secator.cli import process_query
-		query = "port.ip == '192.168.1.189' && vulnerability.severity == 'critical'"
-		format_fields = ['{port.host}:{port.port}', 'vulnerability.matched_at']
-		extractors = process_query(query, fields=format_fields)
-		self.assertEqual(len(extractors), 2)
-		port_extractor = next(e for e in extractors if e['type'] == 'port')
-		vuln_extractor = next(e for e in extractors if e['type'] == 'vulnerability')
-		self.assertEqual(port_extractor['op'], 'and')
-		self.assertEqual(vuln_extractor['op'], 'and')
-		self.assertIn('port.ip', port_extractor['condition'])
-		self.assertIn('vulnerability.severity', vuln_extractor['condition'])
-
-
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -339,5 +339,50 @@ class TestCli(unittest.TestCase):
 				assert result.exit_code == 0
 				assert 'already installed' in result.output
 
+class TestProcessQuery(unittest.TestCase):
+	"""Tests for process_query function."""
+
+	def test_simple_format_field(self):
+		"""Test simple type.field format string."""
+		from secator.cli import process_query
+		extractors = process_query(None, fields=['vulnerability.matched_at'])
+		self.assertEqual(len(extractors), 1)
+		self.assertEqual(extractors[0]['type'], 'vulnerability')
+		self.assertEqual(extractors[0]['field'], 'matched_at')
+
+	def test_format_string_with_braces(self):
+		"""Test format string with {type.field} syntax."""
+		from secator.cli import process_query
+		extractors = process_query(None, fields=['{tag.match}-{tag.name}'])
+		self.assertEqual(len(extractors), 1)
+		self.assertEqual(extractors[0]['type'], 'tag')
+		self.assertEqual(extractors[0]['field'], '{tag.match}-{tag.name}')
+
+	def test_multi_type_format_fields(self):
+		"""Test multiple format fields for different types."""
+		from secator.cli import process_query
+		extractors = process_query(None, fields=['{port.host}:{port.port}', 'vulnerability.matched_at'])
+		self.assertEqual(len(extractors), 2)
+		types = {e['type'] for e in extractors}
+		self.assertIn('port', types)
+		self.assertIn('vulnerability', types)
+		port_extractor = next(e for e in extractors if e['type'] == 'port')
+		self.assertEqual(port_extractor['field'], '{port.host}:{port.port}')
+
+	def test_multi_type_query_with_and(self):
+		"""Test query with && across different types creates separate extractors."""
+		from secator.cli import process_query
+		query = "port.ip == '192.168.1.189' && vulnerability.severity == 'critical'"
+		format_fields = ['{port.host}:{port.port}', 'vulnerability.matched_at']
+		extractors = process_query(query, fields=format_fields)
+		self.assertEqual(len(extractors), 2)
+		port_extractor = next(e for e in extractors if e['type'] == 'port')
+		vuln_extractor = next(e for e in extractors if e['type'] == 'vulnerability')
+		self.assertEqual(port_extractor['op'], 'and')
+		self.assertEqual(vuln_extractor['op'], 'and')
+		self.assertIn('port.ip', port_extractor['condition'])
+		self.assertIn('vulnerability.severity', vuln_extractor['condition'])
+
+
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -9,7 +9,7 @@ from secator.runners._helpers import (
     process_extractor,
     get_task_folder_id
 )
-from secator.output_types import OutputType, Url, Vulnerability, Target, Port
+from secator.output_types import OutputType, Url, Vulnerability, Target, Technology, Port
 from dataclasses import dataclass, field
 
 
@@ -24,7 +24,7 @@ class MockOutputType(OutputType):
 
 
 class TestExtractorFunctions(unittest.TestCase):
-    
+
     def setUp(self):
         # Create some mock objects for testing
         self.mock1 = MockOutputType(field1='test1', field2=1)
@@ -37,10 +37,15 @@ class TestExtractorFunctions(unittest.TestCase):
         self.target1 = Target(name='localhost')
 
         self.vuln1 = Vulnerability(
-            name='Test Vuln', 
+            name='Test Vuln',
             description='Test Description',
             severity='high'
         )
+
+        self.tech1 = Technology(match='10.0.0.1:80', product='apache httpd', version='2.4.50')
+        self.tech2 = Technology(match='10.0.0.2:80', product='apache httpd', version='2.4.50')
+        self.tech3 = Technology(match='10.0.0.3:80', product='nginx', version='1.21.0')
+        self.tech_results = [self.tech1, self.tech2, self.tech3]
 
         # Test results for extractors
         self.results = [
@@ -54,7 +59,7 @@ class TestExtractorFunctions(unittest.TestCase):
         """Test parsing extractor from string format."""
         # Test valid string format
         result = parse_extractor('mock.field1')
-        self.assertEqual(result, ('mock', 'field1', None))
+        self.assertEqual(result, ('mock', 'field1', None, None))
 
         # Test invalid string format
         result = parse_extractor('invalid_format')
@@ -73,14 +78,31 @@ class TestExtractorFunctions(unittest.TestCase):
             'condition': 'item.field2 > 1'
         }
         result = parse_extractor(extractor)
-        self.assertEqual(result, ('mock', 'field1', 'item.field2 > 1'))
+        self.assertEqual(result, ('mock', 'field1', 'item.field2 > 1', None))
 
         # Test with minimal fields
         extractor = {
             'type': 'mock'
         }
         result = parse_extractor(extractor)
-        self.assertEqual(result, ('mock', None, None))
+        self.assertEqual(result, ('mock', None, None, None))
+
+    def test_parse_extractor_dict_with_group_by(self):
+        """Test parsing extractor dict with group_by field."""
+        extractor = {
+            'type': 'mock',
+            'field': '{field1}~{field2}',
+            'condition': 'item.field2 > 1',
+            'group_by': '{field2}',
+        }
+        result = parse_extractor(extractor)
+        self.assertEqual(result, ('mock', '{field1}~{field2}', 'item.field2 > 1', '{field2}'))
+
+    def test_parse_extractor_dict_without_group_by(self):
+        """Test that group_by defaults to None when absent."""
+        extractor = {'type': 'mock', 'field': 'field1'}
+        result = parse_extractor(extractor)
+        self.assertEqual(result, ('mock', 'field1', None, None))
 
     def test_fmt_extractor(self):
         """Test formatting extractors for display."""
@@ -183,6 +205,14 @@ class TestExtractorFunctions(unittest.TestCase):
         result = process_extractor(self.results, extractor)
         self.assertEqual(result, ['test1', 'test2', 'test3'])
 
+        # TODO: Test nested field access
+        # extractor = {
+        #     'type': 'mock',
+        #     'field': '{nested.subfield}'
+        # }
+        # result = process_extractor(self.results, extractor)
+        # self.assertEqual(result, ['nested_value', 'nested_value', 'nested_value'])
+
         # Test type-prefixed format string like '{mock.field1}_{mock.field2}'
         extractor = {
             'type': 'mock',
@@ -192,8 +222,8 @@ class TestExtractorFunctions(unittest.TestCase):
         self.assertEqual(result, ['test1_1', 'test2_2', 'test3_3'])
 
         # Test type-prefixed format string where type name conflicts with a field name of the same name.
-        # Port has a 'port' field (int), so {_type: item, **item.toDict()} would override the item
-        # with the int value, causing '{port.host}'.format() to fail with AttributeError.
+        # Port has a 'port' field (int), so without the fix {**item.toDict(), _type: item} would have
+        # toDict()'s 'port: 80' override the 'port' item reference, causing '{port.host}'.format() to fail.
         port = Port(port=80, ip='127.0.0.1', host='localhost')
         extractor = {
             'type': 'port',
@@ -202,13 +232,53 @@ class TestExtractorFunctions(unittest.TestCase):
         result = process_extractor([port], extractor)
         self.assertEqual(result, ['localhost'])
 
-        # TODO: Test nested field access
-        # extractor = {
-        #     'type': 'mock',
-        #     'field': '{nested.subfield}'
-        # }
-        # result = process_extractor(self.results, extractor)
-        # self.assertEqual(result, ['nested_value', 'nested_value', 'nested_value'])
+    def test_process_extractor_group_by_combines_hosts(self):
+        """group_by groups items by key and joins matched_at values with comma."""
+        extractor = {
+            'type': 'technology',
+            'field': '{match}~{product} {version}',
+            'condition': 'item.version',
+            'group_by': '{product} {version}',
+        }
+        result = process_extractor(self.tech_results, extractor)
+        self.assertEqual(len(result), 2)
+        self.assertIn('10.0.0.1:80,10.0.0.2:80~apache httpd 2.4.50', result)
+        self.assertIn('10.0.0.3:80~nginx 1.21.0', result)
+
+    def test_process_extractor_group_by_single_item(self):
+        """group_by with one item per group produces normal ~ format."""
+        extractor = {
+            'type': 'technology',
+            'field': '{match}~{product} {version}',
+            'condition': 'item.version',
+            'group_by': '{product} {version}',
+        }
+        result = process_extractor([self.tech3], extractor)
+        self.assertEqual(result, ['10.0.0.3:80~nginx 1.21.0'])
+
+    def test_process_extractor_without_group_by_unchanged(self):
+        """Without group_by, process_extractor behaves exactly as before."""
+        extractor = {
+            'type': 'technology',
+            'field': '{match}~{product} {version}',
+            'condition': 'item.version',
+        }
+        result = process_extractor(self.tech_results, extractor)
+        self.assertEqual(len(result), 3)
+        self.assertIn('10.0.0.1:80~apache httpd 2.4.50', result)
+        self.assertIn('10.0.0.2:80~apache httpd 2.4.50', result)
+        self.assertIn('10.0.0.3:80~nginx 1.21.0', result)
+
+    def test_fmt_extractor_with_group_by(self):
+        """fmt_extractor includes group_by in display string."""
+        extractor = {
+            'type': 'mock',
+            'field': '{field1}~{field2}',
+            'condition': 'item.field2 > 1',
+            'group_by': '{field2}',
+        }
+        result = fmt_extractor(extractor)
+        self.assertEqual(result, '<DYNAMIC(mock.{field1}~{field2} if item.field2 > 1 group_by {field2})>')
 
     def test_extract_from_results(self):
         """Test extract_from_results function."""
@@ -252,6 +322,34 @@ class TestExtractorFunctions(unittest.TestCase):
         self.assertEqual(updated_opts['other'], ['<DYNAMIC(url.url)>'])
         self.assertEqual(errors, [])
 
+    def test_run_extractors_with_group_by(self):
+        """Full pipeline: Technology items → grouped search_vulns inputs via group_by extractor."""
+        tech1 = Technology(match='10.0.0.1:80', product='apache httpd', version='2.4.50')
+        tech2 = Technology(match='10.0.0.2:80', product='apache httpd', version='2.4.50')
+        tech3 = Technology(match='10.0.0.3:80', product='nginx', version='1.21.0')
+        results = [tech1, tech2, tech3]
+
+        opts = {
+            'targets_': [
+                {
+                    'type': 'technology',
+                    'field': '{match}~{product} {version}',
+                    'condition': 'item.version',
+                    'group_by': '{product} {version}',
+                }
+            ]
+        }
+
+        inputs, _updated_opts, errors = run_extractors(results, opts)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(inputs), 2)  # 2 unique services
+        apache_input = next(i for i in inputs if 'apache' in i)
+        self.assertIn('10.0.0.1:80', apache_input.split('~')[0])
+        self.assertIn('10.0.0.2:80', apache_input.split('~')[0])
+        self.assertEqual(apache_input.split('~')[1], 'apache httpd 2.4.50')
+        nginx_input = next(i for i in inputs if 'nginx' in i)
+        self.assertEqual(nginx_input, '10.0.0.3:80~nginx 1.21.0')
+
     @patch('os.scandir')
     @patch('os.path.exists')
     def test_get_task_folder_id(self, mock_exists, mock_scandir):
@@ -289,4 +387,4 @@ class TestExtractorFunctions(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -9,7 +9,7 @@ from secator.runners._helpers import (
     process_extractor,
     get_task_folder_id
 )
-from secator.output_types import OutputType, Url, Vulnerability, Target
+from secator.output_types import OutputType, Url, Vulnerability, Target, Port
 from dataclasses import dataclass, field
 
 
@@ -159,6 +159,17 @@ class TestExtractorFunctions(unittest.TestCase):
         }
         result = process_extractor(self.results, extractor)
         self.assertEqual(result, ['test1_1', 'test2_2', 'test3_3'])
+
+        # Test type-prefixed format string where type name conflicts with a field name of the same name.
+        # Port has a 'port' field (int), so {_type: item, **item.toDict()} would override the item
+        # with the int value, causing '{port.host}'.format() to fail with AttributeError.
+        port = Port(port=80, ip='127.0.0.1', host='localhost')
+        extractor = {
+            'type': 'port',
+            'field': '{port.host}'
+        }
+        result = process_extractor([port], extractor)
+        self.assertEqual(result, ['localhost'])
 
         # TODO: Test nested field access
         # extractor = {

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -152,6 +152,14 @@ class TestExtractorFunctions(unittest.TestCase):
         result = process_extractor(self.results, extractor)
         self.assertEqual(result, ['test1', 'test2', 'test3'])
 
+        # Test type-prefixed format string like '{mock.field1}_{mock.field2}'
+        extractor = {
+            'type': 'mock',
+            'field': '{mock.field1}_{mock.field2}'
+        }
+        result = process_extractor(self.results, extractor)
+        self.assertEqual(result, ['test1_1', 'test2_2', 'test3_3'])
+
         # TODO: Test nested field access
         # extractor = {
         #     'type': 'mock',


### PR DESCRIPTION
- Split --format by || or , to support per-type format specs e.g. '{port.host}:{port.port} || vulnerability.matched_at'
- Parse format fields containing { via regex to extract output type (fixes 'Invalid output type: {tag}' error)
- Pass item under its type name when formatting, so {type.field} attribute-access syntax resolves correctly in format strings
- Handles multi-type queries with && across different output types
- Add unit tests for process_query and process_extractor

Closes #963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field parsing to properly handle complex format strings with type-qualified field references (e.g., `{type.field}`).
  * Enhanced query processing to correctly handle compound conditions across multiple field types.
  * Fixed format string interpolation to support type-prefixed field placeholders in extraction contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->