### PR TITLE
fix(workflow): gracefully skip invalid tasks in workflows instead of crashing

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -102,7 +102,10 @@ def workflow(ctx):
 
 
 for config in WORKFLOWS:
-	register_runner(workflow, config)
+	try:
+		register_runner(workflow, config)
+	except Exception as e:
+		console.print(Warning(message=f'Skipping workflow {config.name!r}: {e}'))
 
 
 #------#
@@ -118,7 +121,10 @@ def scan(ctx):
 
 
 for config in SCANS:
-	register_runner(scan, config)
+	try:
+		register_runner(scan, config)
+	except Exception as e:
+		console.print(Warning(message=f'Skipping scan {config.name!r}: {e}'))
 
 
 #--------#

--- a/secator/template.py
+++ b/secator/template.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from dotmap import DotMap
 from pathlib import Path
 
-from secator.output_types import Error
+from secator.output_types import Error, Warning
 from secator.rich import console
 
 
@@ -145,7 +145,10 @@ def get_config_options(config, exec_opts=None, output_opts=None, type_mapping=No
 				continue
 			node_task = None
 			if check_class_opts:
-				node_task = Task.get_task_class(_.name)
+				try:
+					node_task = Task.get_task_class(_.name)
+				except ValueError:
+					continue
 				if opt_name not in node_task.opts:
 					continue
 				opts_value = node_task.opts[opt_name]
@@ -188,7 +191,11 @@ def get_config_options(config, exec_opts=None, output_opts=None, type_mapping=No
 
 		# Process task options
 		# a.k.a task options defined in their respective task classes
-		cls = Task.get_task_class(node.name)
+		try:
+			cls = Task.get_task_class(node.name)
+		except ValueError:
+			console.print(Warning(message=f'Task {node.name!r} not found - skipping it in {config.name!r}. Please update your config.'))
+			return
 		task_opts = cls.opts.copy()
 		task_opts_meta = getattr(cls, 'meta_opts', {}).copy()
 		task_opts_all = {**task_opts, **task_opts_meta}

--- a/secator/template.py
+++ b/secator/template.py
@@ -194,7 +194,7 @@ def get_config_options(config, exec_opts=None, output_opts=None, type_mapping=No
 		try:
 			cls = Task.get_task_class(node.name)
 		except ValueError:
-			console.print(Warning(message=f'Task {node.name!r} not found - skipping it in {config.name!r}. Please update your config.'))
+			console.print(Warning(message=f'Task {node.name!r} not found - skipping it in {config.name!r}. Please update your config.'))  # noqa: E501
 			return
 		task_opts = cls.opts.copy()
 		task_opts_meta = getattr(cls, 'meta_opts', {}).copy()


### PR DESCRIPTION
When a workflow references a task that is no longer registered in secator (e.g. retired tasks like x8 or dirsearch), the CLI would crash on import with a ValueError stack trace, making secator completely unusable.

- In template.py: catch ValueError in find_same_opts (skip unknown tasks) and process_node (warn and skip the node) instead of propagating the error
- In cli.py: wrap workflow and scan registration in try/except as a safety net, printing a warning and skipping the invalid config

Fixes #935

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application stability with graceful error handling for CLI configurations and task discovery. Instead of crashing when configurations fail to load, the application now displays warning messages and continues operating normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->