### PR TITLE
fix(query): handle ~= regex operator in python_expr_to_mongo

### DIFF
--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -84,8 +84,8 @@ def _parse_value(raw):
 
 
 # Regex that finds the first comparison operator outside of quotes.
-# Alternatives are ordered longest-first so >= matches before >.
-_OP_RE = re.compile(r'^(.*?)\s*(>=|<=|!=|>|<|==)\s*(.+)$', re.DOTALL)
+# Alternatives are ordered longest-first so >= matches before > and ~= is included.
+_OP_RE = re.compile(r'^(.*?)\s*(>=|<=|!=|~=|>|<|==)\s*(.+)$', re.DOTALL)
 
 _OP_MAP = {
     '>=': '$gte',
@@ -94,6 +94,7 @@ _OP_MAP = {
     '<': '$lt',
     '!=': '$ne',
     '==': None,
+    '~=': '$regex',
 }
 
 

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -94,6 +94,10 @@ class TestPythonExprToMongo:
             ]
         }
 
+    def test_regex_match_operator(self):
+        result = python_expr_to_mongo("technology.product ~= 'xrdp'")
+        assert result == {'_type': 'technology', 'product': {'$regex': 'xrdp'}}
+
     def test_passthrough_mongo_dict(self):
         query = {'_type': 'vulnerability', 'severity_score': {'$gte': 7}}
         assert python_expr_to_mongo(query) == query


### PR DESCRIPTION
Fix the `~=` regex match operator in `python_expr_to_mongo` so that queries like `technology.product ~= 'xrdp'` correctly produce `{"_type": "technology", "product": {"$regex": "xrdp"}}` instead of dropping the field condition.

Fixes #986

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the regex match operator (`~=`) in query expressions, enabling pattern matching in search queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->