### PR TITLE
fix(exporters): stream items in TxtExporter, cast dicts to OutputType

### DIFF
--- a/secator/exporters/txt.py
+++ b/secator/exporters/txt.py
@@ -1,9 +1,11 @@
 from secator.exporters._base import Exporter
-from secator.output_types import Info
+from secator.output_types import OUTPUT_TYPES, Info
 from secator.rich import console
 
 
 class TxtExporter(Exporter):
+	_type_map = {cls.get_name(): cls for cls in OUTPUT_TYPES}
+
 	def send(self):
 		results = self.report.data['results']
 		if not results:
@@ -11,12 +13,23 @@ class TxtExporter(Exporter):
 		txt_paths = []
 
 		for output_type, items in results.items():
-			items = list(set(str(i) for i in items))
 			if not items:
 				continue
 			txt_path = f'{self.report.output_folder}/report_{output_type}.txt'
 			with open(txt_path, 'w') as f:
-				f.write('\n'.join(items))
+				first = True
+				for item in items:
+					if isinstance(item, dict):
+						cls = self._type_map.get(item.get('_type'))
+						if cls:
+							try:
+								item = cls.load(item)
+							except (TypeError, Exception):
+								pass
+					if not first:
+						f.write('\n')
+					f.write(str(item))
+					first = False
 			txt_paths.append(txt_path)
 
 		if not txt_paths:

--- a/secator/exporters/txt.py
+++ b/secator/exporters/txt.py
@@ -19,13 +19,13 @@ class TxtExporter(Exporter):
 			with open(txt_path, 'w') as f:
 				first = True
 				for item in items:
-					if isinstance(item, dict):
-						cls = self._type_map.get(item.get('_type'))
-						if cls:
-							try:
-								item = cls.load(item)
-							except (TypeError, Exception):
-								pass
+				if isinstance(item, dict):
+					cls = self._type_map.get(item.get('_type'))
+					if cls:
+						try:
+							item = cls.load(item)
+						except TypeError:
+							pass
 					if not first:
 						f.write('\n')
 					f.write(str(item))

--- a/secator/exporters/txt.py
+++ b/secator/exporters/txt.py
@@ -19,17 +19,17 @@ class TxtExporter(Exporter):
 			with open(txt_path, 'w') as f:
 				first = True
 				for item in items:
-				if isinstance(item, dict):
-					cls = self._type_map.get(item.get('_type'))
-					if cls:
-						try:
-							item = cls.load(item)
-						except TypeError:
-							pass
-					if not first:
-						f.write('\n')
-					f.write(str(item))
-					first = False
+					if isinstance(item, dict):
+						cls = self._type_map.get(item.get('_type'))
+						if cls:
+							try:
+								item = cls.load(item)
+							except TypeError:
+								pass
+						if not first:
+							f.write('\n')
+						f.write(str(item))
+						first = False
 			txt_paths.append(txt_path)
 
 		if not txt_paths:


### PR DESCRIPTION
Stream items directly to file instead of buffering with list(set(...)). The set() deduplication is unnecessary since QueryEngine handles duplicates, and buffering all items in memory can be problematic for large result sets.

Cast dict items to their OutputType class (matching ConsoleExporter pattern) before calling str() so txt output shows proper str representation, not JSON.

Fixes #991

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Updated TXT exporter to preserve item order and original format instead of automatically deduplicating and converting to strings.
  * Improved handling of complex data types during export with intelligent type reconstruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->