### PR TITLE
feat: add group_by_collect extractor to group nmap hosts by open port set

### DIFF
--- a/secator/configs/workflows/host_recon.yaml
+++ b/secator/configs/workflows/host_recon.yaml
@@ -58,10 +58,7 @@ tasks:
     - type: port
       field: host
       condition: opts.scanners
-    ports_:
-    - type: port
-      field: port
-      condition: port.host in targets and opts.scanners
+      group_by_collect: port
     if: not opts.passive
 
   sshaudit:

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -78,13 +78,15 @@ def fmt_extractor(extractor):
 	parsed_extractor = parse_extractor(extractor)
 	if not parsed_extractor:
 		return '<DYNAMIC[INVALID_EXTRACTOR]>'
-	_type, _field, _condition, _group_by = parsed_extractor
+	_type, _field, _condition, _group_by, _group_by_collect = parsed_extractor
 	s = f'{_type}.{_field}'
 	if _condition:
 		_condition = _condition.replace("'", '').replace('"', '')
 		s = f'{s} if {_condition}'
 	if _group_by:
 		s = f'{s} group_by {_group_by}'
+	if _group_by_collect:
+		s = f'{s} group_by_collect {_group_by_collect}'
 	return f'<DYNAMIC({s})>'
 
 
@@ -130,7 +132,7 @@ def parse_extractor(extractor):
 		extractor (dict / str): extractor definition.
 
 	Returns:
-		tuple|None: type, field, condition, group_by or None if invalid.
+		tuple|None: type, field, condition, group_by, group_by_collect or None if invalid.
 	"""
 	# Parse extractor, it can be a dict or a string (shortcut)
 	if isinstance(extractor, dict):
@@ -138,6 +140,7 @@ def parse_extractor(extractor):
 		_field = extractor.get('field')
 		_condition = extractor.get('condition')
 		_group_by = extractor.get('group_by')
+		_group_by_collect = extractor.get('group_by_collect')
 	else:
 		parts = tuple(extractor.split('.'))
 		if len(parts) == 2:
@@ -145,9 +148,10 @@ def parse_extractor(extractor):
 			_field = parts[1]
 			_condition = None
 			_group_by = None
+			_group_by_collect = None
 		else:
 			return None
-	return _type, _field, _condition, _group_by
+	return _type, _field, _condition, _group_by, _group_by_collect
 
 
 def process_extractor(results, extractor, ctx=None):
@@ -170,7 +174,7 @@ def process_extractor(results, extractor, ctx=None):
 	parsed_extractor = parse_extractor(extractor)
 	if not parsed_extractor:
 		return results
-	_type, _field, _condition, _group_by = parsed_extractor
+	_type, _field, _condition, _group_by, _group_by_collect = parsed_extractor
 
 	# Evaluate condition for each result
 	if _condition:
@@ -207,7 +211,33 @@ def process_extractor(results, extractor, ctx=None):
 		already_formatted = '{' in _field and '}' in _field
 		_field = '{' + _field + '}' if not already_formatted else _field
 
-		if _group_by:
+		if _group_by_collect:
+			already_formatted_gbc = '{' in _group_by_collect and '}' in _group_by_collect
+			_group_by_collect_fmt = '{' + _group_by_collect + '}' if not already_formatted_gbc else _group_by_collect
+
+			# Phase 1: for each item, collect group_by_collect values per field value
+			field_to_collected = {}
+			for item in results:
+				field_val = _field.format(**item.toDict())
+				collect_val = _group_by_collect_fmt.format(**item.toDict())
+				bucket = field_to_collected.setdefault(field_val, [])
+				if collect_val not in bucket:
+					bucket.append(collect_val)
+
+			# Phase 2: group field values by their sorted fingerprint of collected values
+			def _sort_key(v):
+				try:
+					return (0, int(v))
+				except (ValueError, TypeError):
+					return (1, str(v))
+
+			fingerprint_to_fields = {}
+			for field_val, collected in field_to_collected.items():
+				fingerprint = ','.join(sorted(collected, key=_sort_key))
+				fingerprint_to_fields.setdefault(fingerprint, []).append(field_val)
+
+			results = [','.join(fields) + '~' + fp for fp, fields in fingerprint_to_fields.items()]
+		elif _group_by:
 			already_formatted_gb = '{' in _group_by and '}' in _group_by
 			_group_by = '{' + _group_by + '}' if not already_formatted_gb else _group_by
 			groups = {}

--- a/secator/tasks/nmap.py
+++ b/secator/tasks/nmap.py
@@ -140,6 +140,35 @@ class nmap(ReconPort):
 	disable_preexec = True
 
 	@staticmethod
+	def before_init(self):
+		encoded_inputs = [i for i in self.inputs if '~' in i]
+		if not encoded_inputs or len(encoded_inputs) != len(self.inputs):
+			return
+
+		if len(encoded_inputs) == 1:
+			# Single group (e.g. distributed mode): expand field values and set collected values as ports
+			fields_str, collect_str = encoded_inputs[0].split('~', 1)
+			self.inputs = fields_str.split(',')
+			self.run_opts[PORTS] = collect_str
+		else:
+			# Multiple groups (e.g. sync mode): collect all field values + union of collected values
+			all_fields = []
+			all_collect = set()
+			for enc in encoded_inputs:
+				fields_str, collect_str = enc.split('~', 1)
+				all_fields.extend(fields_str.split(','))
+				all_collect.update(collect_str.split(','))
+
+			def _sort_key(v):
+				try:
+					return (0, int(v))
+				except (ValueError, TypeError):
+					return (1, str(v))
+
+			self.inputs = all_fields
+			self.run_opts[PORTS] = ','.join(sorted(all_collect, key=_sort_key))
+
+	@staticmethod
 	def on_cmd(self):
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -9,7 +9,7 @@ from secator.runners._helpers import (
     process_extractor,
     get_task_folder_id
 )
-from secator.output_types import OutputType, Url, Vulnerability, Target, Technology
+from secator.output_types import OutputType, Port, Url, Vulnerability, Target, Technology
 from dataclasses import dataclass, field
 
 
@@ -59,7 +59,7 @@ class TestExtractorFunctions(unittest.TestCase):
         """Test parsing extractor from string format."""
         # Test valid string format
         result = parse_extractor('mock.field1')
-        self.assertEqual(result, ('mock', 'field1', None, None))
+        self.assertEqual(result, ('mock', 'field1', None, None, None))
 
         # Test invalid string format
         result = parse_extractor('invalid_format')
@@ -78,14 +78,14 @@ class TestExtractorFunctions(unittest.TestCase):
             'condition': 'item.field2 > 1'
         }
         result = parse_extractor(extractor)
-        self.assertEqual(result, ('mock', 'field1', 'item.field2 > 1', None))
+        self.assertEqual(result, ('mock', 'field1', 'item.field2 > 1', None, None))
 
         # Test with minimal fields
         extractor = {
             'type': 'mock'
         }
         result = parse_extractor(extractor)
-        self.assertEqual(result, ('mock', None, None, None))
+        self.assertEqual(result, ('mock', None, None, None, None))
 
     def test_parse_extractor_dict_with_group_by(self):
         """Test parsing extractor dict with group_by field."""
@@ -96,13 +96,24 @@ class TestExtractorFunctions(unittest.TestCase):
             'group_by': '{field2}',
         }
         result = parse_extractor(extractor)
-        self.assertEqual(result, ('mock', '{field1}~{field2}', 'item.field2 > 1', '{field2}'))
+        self.assertEqual(result, ('mock', '{field1}~{field2}', 'item.field2 > 1', '{field2}', None))
 
     def test_parse_extractor_dict_without_group_by(self):
         """Test that group_by defaults to None when absent."""
         extractor = {'type': 'mock', 'field': 'field1'}
         result = parse_extractor(extractor)
-        self.assertEqual(result, ('mock', 'field1', None, None))
+        self.assertEqual(result, ('mock', 'field1', None, None, None))
+
+    def test_parse_extractor_dict_with_group_by_collect(self):
+        """Test parsing extractor dict with group_by_collect field."""
+        extractor = {
+            'type': 'port',
+            'field': 'host',
+            'condition': 'opts.scanners',
+            'group_by_collect': 'port',
+        }
+        result = parse_extractor(extractor)
+        self.assertEqual(result, ('port', 'host', 'opts.scanners', None, 'port'))
 
     def test_fmt_extractor(self):
         """Test formatting extractors for display."""
@@ -260,6 +271,107 @@ class TestExtractorFunctions(unittest.TestCase):
         }
         result = fmt_extractor(extractor)
         self.assertEqual(result, '<DYNAMIC(mock.{field1}~{field2} if item.field2 > 1 group_by {field2})>')
+
+    def test_fmt_extractor_with_group_by_collect(self):
+        """fmt_extractor includes group_by_collect in display string."""
+        extractor = {
+            'type': 'port',
+            'field': 'host',
+            'condition': 'opts.scanners',
+            'group_by_collect': 'port',
+        }
+        result = fmt_extractor(extractor)
+        self.assertEqual(result, '<DYNAMIC(port.host if opts.scanners group_by_collect port)>')
+
+    def test_process_extractor_group_by_collect_groups_fields_by_collected_set(self):
+        """group_by_collect groups field values by their collected value set fingerprint."""
+        port1 = Port(port=80, ip='10.0.0.1', host='host1')
+        port2 = Port(port=443, ip='10.0.0.1', host='host1')
+        port3 = Port(port=80, ip='10.0.0.2', host='host2')
+        port4 = Port(port=443, ip='10.0.0.2', host='host2')
+        port5 = Port(port=22, ip='10.0.0.3', host='host3')
+        port6 = Port(port=80, ip='10.0.0.3', host='host3')
+        port_results = [port1, port2, port3, port4, port5, port6]
+
+        extractor = {
+            'type': 'port',
+            'field': 'host',
+            'group_by_collect': 'port',
+        }
+        result = process_extractor(port_results, extractor)
+
+        # host1 and host2 both have ports 80,443 → grouped together
+        # host3 has ports 22,80 → separate group
+        self.assertEqual(len(result), 2)
+        group_80_443 = next((r for r in result if '80,443' in r), None)
+        group_22_80 = next((r for r in result if '22,80' in r), None)
+        self.assertIsNotNone(group_80_443)
+        self.assertIsNotNone(group_22_80)
+        self.assertIn('host1', group_80_443.split('~')[0])
+        self.assertIn('host2', group_80_443.split('~')[0])
+        self.assertEqual(group_22_80.split('~')[0], 'host3')
+
+    def test_process_extractor_group_by_collect_single_group(self):
+        """group_by_collect with a single unique fingerprint produces one result."""
+        port1 = Port(port=80, ip='10.0.0.1', host='host1')
+        port2 = Port(port=443, ip='10.0.0.1', host='host1')
+        port3 = Port(port=80, ip='10.0.0.2', host='host2')
+        port4 = Port(port=443, ip='10.0.0.2', host='host2')
+        port_results = [port1, port2, port3, port4]
+
+        extractor = {
+            'type': 'port',
+            'field': 'host',
+            'group_by_collect': 'port',
+        }
+        result = process_extractor(port_results, extractor)
+        self.assertEqual(len(result), 1)
+        self.assertIn('host1', result[0].split('~')[0])
+        self.assertIn('host2', result[0].split('~')[0])
+        self.assertEqual(result[0].split('~')[1], '80,443')
+
+    def test_process_extractor_group_by_collect_port_sorted_numerically(self):
+        """group_by_collect sorts port numbers numerically, not lexicographically."""
+        port1 = Port(port=9000, ip='10.0.0.1', host='host1')
+        port2 = Port(port=80, ip='10.0.0.1', host='host1')
+        port3 = Port(port=443, ip='10.0.0.1', host='host1')
+        port_results = [port1, port2, port3]
+
+        extractor = {'type': 'port', 'field': 'host', 'group_by_collect': 'port'}
+        result = process_extractor(port_results, extractor)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].split('~')[1], '80,443,9000')
+
+    def test_run_extractors_with_group_by_collect(self):
+        """Full pipeline: Port items → grouped nmap inputs via group_by_collect extractor."""
+        port1 = Port(port=80, ip='10.0.0.1', host='host1')
+        port2 = Port(port=443, ip='10.0.0.1', host='host1')
+        port3 = Port(port=80, ip='10.0.0.2', host='host2')
+        port4 = Port(port=443, ip='10.0.0.2', host='host2')
+        port5 = Port(port=22, ip='10.0.0.3', host='host3')
+        port6 = Port(port=80, ip='10.0.0.3', host='host3')
+        results = [port1, port2, port3, port4, port5, port6]
+
+        opts = {
+            'targets_': [
+                {
+                    'type': 'port',
+                    'field': 'host',
+                    'group_by_collect': 'port',
+                }
+            ]
+        }
+
+        inputs, _updated_opts, errors = run_extractors(results, opts)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(inputs), 2)  # 2 unique port fingerprints
+        group_80_443 = next((i for i in inputs if '80,443' in i), None)
+        group_22_80 = next((i for i in inputs if '22,80' in i), None)
+        self.assertIsNotNone(group_80_443)
+        self.assertIsNotNone(group_22_80)
+        self.assertIn('host1', group_80_443.split('~')[0])
+        self.assertIn('host2', group_80_443.split('~')[0])
+        self.assertEqual(group_22_80.split('~')[0], 'host3')
 
     def test_extract_from_results(self):
         """Test extract_from_results function."""


### PR DESCRIPTION
Closes #993

## Summary

- Adds new `group_by_collect` extractor option to `_helpers.py` that groups field values by their collected value fingerprint
- Adds `before_init` hook to `nmap` task to parse `~`-encoded grouped inputs, expanding hosts and setting per-group ports
- Updates `host_recon` workflow to use `group_by_collect: port`, reducing N per-host nmap calls to K per-port-fingerprint calls

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced fingerprint-based grouping and deduplication for batch input processing, enabling more efficient aggregation of collected data.

* **Refactor**
  * Simplified port collection logic in host reconnaissance workflows with streamlined configuration directives.

* **Tests**
  * Expanded test coverage to validate grouping behavior, including numeric sorting and fingerprint matching across batch inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->