### PR TITLE
fix(targets): use regex-based hostname validation to detect internal hosts

### DIFF
--- a/secator/utils.py
+++ b/secator/utils.py
@@ -990,6 +990,34 @@ def format_object(obj, color='magenta', skip_keys=[], predicate=lambda x: True):
 	return ''
 
 
+_HOSTNAME_LABEL_RE = re.compile(r'^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?$')
+
+
+def is_valid_hostname(target):
+	"""Check if target is a valid hostname per the hostname(7) manpage definition.
+
+	Accepts multi-label hostnames with any TLD (including non-standard ones like .internal,
+	.corp, .local) and single-label hostnames containing a hyphen (e.g. db-server, web-01).
+	Single-label names without a hyphen (e.g. redis, test123) return False so they can fall
+	through to slug detection and avoid ambiguity with Docker image names and usernames.
+	"""
+	if not target or len(target) > 253:
+		return False
+	try:
+		ascii_target = target.encode('idna').decode('ascii')
+	except (UnicodeError, ValueError):
+		ascii_target = target
+	labels = ascii_target.split('.')
+	if len(labels) < 2 and '-' not in ascii_target:
+		return False
+	for label in labels:
+		if not label or len(label) > 63:
+			return False
+		if not _HOSTNAME_LABEL_RE.match(label):
+			return False
+	return True
+
+
 def is_host_port(target):
 	"""Check if a target is a host:port.
 
@@ -1000,7 +1028,7 @@ def is_host_port(target):
 		bool: True if the target is a host:port, False otherwise.
 	"""
 	split = target.split(':')
-	if not (validators.domain(split[0]) or validators.ipv4(split[0]) or validators.ipv6(split[0]) or split[0] == 'localhost'):  # noqa: E501
+	if not (is_valid_hostname(split[0]) or validators.ipv4(split[0]) or validators.ipv6(split[0]) or split[0] == 'localhost'):  # noqa: E501
 		return False
 	try:
 		port = int(split[1])
@@ -1028,7 +1056,7 @@ def autodetect_type(target):
 		return CIDR_RANGE
 	elif validators.ipv4(target) or validators.ipv6(target) or target == 'localhost':
 		return IP
-	elif validators.domain(target):
+	elif is_valid_hostname(target):
 		return HOST
 	elif is_host_port(target):
 		return HOST_PORT

--- a/secator/utils.py
+++ b/secator/utils.py
@@ -1001,12 +1001,14 @@ def is_valid_hostname(target):
 	Single-label names without a hyphen (e.g. redis, test123) return False so they can fall
 	through to slug detection and avoid ambiguity with Docker image names and usernames.
 	"""
-	if not target or len(target) > 253:
+	if not target:
 		return False
 	try:
 		ascii_target = target.encode('idna').decode('ascii')
 	except (UnicodeError, ValueError):
-		ascii_target = target
+		return False
+	if len(ascii_target) > 253:
+		return False
 	labels = ascii_target.split('.')
 	if len(labels) < 2 and '-' not in ascii_target:
 		return False
@@ -1028,10 +1030,13 @@ def is_host_port(target):
 		bool: True if the target is a host:port, False otherwise.
 	"""
 	split = target.split(':')
-	if not (is_valid_hostname(split[0]) or validators.ipv4(split[0]) or validators.ipv6(split[0]) or split[0] == 'localhost'):  # noqa: E501
+	if len(split) != 2:
+		return False
+	host, port_str = split
+	if not (is_valid_hostname(host) or validators.ipv4(host) or validators.ipv6(host) or host == 'localhost'):
 		return False
 	try:
-		port = int(split[1])
+		port = int(port_str)
 		if port < 1 or port > 65535:
 			return False
 	except ValueError:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -52,6 +52,16 @@ class TestExtractRootDomain(unittest.TestCase):
 			("example.com", HOST),
 			("example.co.uk", HOST),
 			("example.tata", HOST),
+			# Internal/non-standard TLD hostnames
+			("server.internal", HOST),
+			("db.corp", HOST),
+			("web.local", HOST),
+			("app.lan", HOST),
+			("host01.office.corp", HOST),
+			# Single-label hostnames with hyphen
+			("db-server", HOST),
+			("web-01", HOST),
+			("my-host", HOST),
 			("localhost", IP),
 			("127.0.0.1", IP),
 			("192.168.1.1", IP),
@@ -60,6 +70,10 @@ class TestExtractRootDomain(unittest.TestCase):
 			("example.com:8080", HOST_PORT),
 			("example.co.uk:80", HOST_PORT),
 			("example.tata:443", HOST_PORT),
+			# Internal host:port
+			("server.internal:8080", HOST_PORT),
+			("db.corp:5432", HOST_PORT),
+			("db-server:22", HOST_PORT),
 			("http://localhost", URL),
 			("https://localhost", URL),
 			("http://localhost:8080", URL),


### PR DESCRIPTION
Replace `validators.domain()` with a regex-based `is_valid_hostname()` that follows the hostname(7) manpage definition.

Fixes detection of multi-label hostnames with non-standard TLDs (`server.internal`, `db.corp`, `web.local`) and single-label hostnames containing a hyphen (`db-server`, `web-01`).

Closes #992

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced hostname validation to recognize internal domain extensions (e.g., `.internal`, `.corp`, `.local`) and hyphenated single-label hostnames.

* **Tests**
  * Expanded test coverage for hostname validation scenarios, including internal TLDs and single-label patterns with port specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->