### PR TITLE
feat(configs): add conditional options support in workflow YAML

### DIFF
--- a/secator/configs/workflows/host_recon.yaml
+++ b/secator/configs/workflows/host_recon.yaml
@@ -51,6 +51,8 @@ tasks:
     version_detection: true
     tcp_syn_stealth: false
     fragment: false
+    skip_host_discovery_:
+      condition: "'naabu' in opts.scanners or 'masscan' in opts.scanners"
     targets_:
     - type: target
       field: name

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -25,7 +25,7 @@ def resolve_conditional_opts(opts, context):
 	for key, val in opts.items():
 		if not key.endswith('_'):
 			continue
-		if not isinstance(val, dict) or 'condition' not in val:
+		if not isinstance(val, dict) or 'condition' not in val or 'type' in val:
 			continue
 		base_key = key.rstrip('_')
 		condition = val['condition']
@@ -33,8 +33,11 @@ def resolve_conditional_opts(opts, context):
 		try:
 			if eval(condition, safe_globals, context):
 				resolved[base_key] = opt_value
-		except Exception:
-			pass
+		except Exception as e:
+			debug(
+				f'ignored conditional option [bold]{key}[/] because condition failed: {condition!r} ({e})',
+				sub='conditional_opts',
+			)
 		to_remove.append(key)
 	for key in to_remove:
 		del opts[key]

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -6,6 +6,42 @@ from secator.output_types import Error
 from secator.utils import deduplicate, debug
 
 
+def resolve_conditional_opts(opts, context):
+	"""Resolve conditional options (keys ending with '_' whose value is a dict with a 'condition' key).
+
+	If the condition evaluates to True, the base key (without '_') is set to the specified value
+	(defaulting to True). The conditional key is always removed from opts.
+
+	Args:
+		opts (dict): Options dict (modified in place).
+		context (dict): Evaluation context (should contain 'opts' as DotMap).
+
+	Returns:
+		dict: Options with conditional opts resolved.
+	"""
+	safe_globals = {'__builtins__': {'len': len}}
+	to_remove = []
+	resolved = {}
+	for key, val in opts.items():
+		if not key.endswith('_'):
+			continue
+		if not isinstance(val, dict) or 'condition' not in val:
+			continue
+		base_key = key.rstrip('_')
+		condition = val['condition']
+		opt_value = val.get('value', True)
+		try:
+			if eval(condition, safe_globals, context):
+				resolved[base_key] = opt_value
+		except Exception:
+			pass
+		to_remove.append(key)
+	for key in to_remove:
+		del opts[key]
+	opts.update(resolved)
+	return opts
+
+
 def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 	"""Run extractors and merge extracted values with option dict.
 
@@ -23,6 +59,7 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		inputs = []
 	if ctx is None:
 		ctx = {}
+	resolve_conditional_opts(opts, ctx)
 	extractors = {k: v for k, v in opts.items() if k.endswith('_')}
 	if dry_run:
 		input_extractors = {k: v for k, v in extractors.items() if k.rstrip('_') == 'targets'}

--- a/secator/runners/workflow.py
+++ b/secator/runners/workflow.py
@@ -3,6 +3,7 @@ from dotmap import DotMap
 from secator.config import CONFIG
 from secator.output_types import Info
 from secator.runners._base import Runner
+from secator.runners._helpers import resolve_conditional_opts
 from secator.runners.task import Task
 from secator.tree import build_runner_tree, walk_runner_tree
 from secator.utils import merge_opts
@@ -92,6 +93,9 @@ class Workflow(Runner):
 
 				# Get task class
 				task = Task.get_task_class(node.name)
+
+				# Resolve conditional options in node opts
+				resolve_conditional_opts(node.opts, local_ns)
 
 				# Merge task options (order of priority with overrides)
 				task_opts = merge_opts(self.config.default_options.toDict(), node.opts, opts)

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from secator.runners._helpers import (
     run_extractors,
+    resolve_conditional_opts,
     fmt_extractor,
     extract_from_results,
     parse_extractor,
@@ -365,6 +366,77 @@ class TestExtractorFunctions(unittest.TestCase):
         ]
         result = get_task_folder_id('/dummy/path')
         self.assertEqual(result, 4)  # Max numeric dir (3) + 1
+
+
+class TestResolveConditionalOpts(unittest.TestCase):
+
+    def test_condition_true_sets_base_key(self):
+        """When condition is True, set base key (without '_') to True by default."""
+        from dotmap import DotMap
+        opts = {'skip_host_discovery_': {'condition': "'masscan' in opts.scanners"}}
+        ctx = {'opts': DotMap({'scanners': ['masscan', 'nmap']})}
+        result = resolve_conditional_opts(opts, ctx)
+        self.assertNotIn('skip_host_discovery_', result)
+        self.assertTrue(result.get('skip_host_discovery'))
+
+    def test_condition_false_does_not_set_base_key(self):
+        """When condition is False, base key is not set."""
+        from dotmap import DotMap
+        opts = {'skip_host_discovery_': {'condition': "'masscan' in opts.scanners"}}
+        ctx = {'opts': DotMap({'scanners': ['nmap']})}
+        result = resolve_conditional_opts(opts, ctx)
+        self.assertNotIn('skip_host_discovery_', result)
+        self.assertNotIn('skip_host_discovery', result)
+
+    def test_condition_with_custom_value(self):
+        """When condition is True and a 'value' key is specified, use that value."""
+        from dotmap import DotMap
+        opts = {'rate_limit_': {'condition': 'opts.passive', 'value': 10}}
+        ctx = {'opts': DotMap({'passive': True})}
+        result = resolve_conditional_opts(opts, ctx)
+        self.assertEqual(result.get('rate_limit'), 10)
+
+    def test_invalid_condition_does_not_crash(self):
+        """An invalid condition expression is silently ignored."""
+        opts = {'some_opt_': {'condition': 'this is not valid python !!!'}}
+        result = resolve_conditional_opts(opts, {})
+        self.assertNotIn('some_opt_', result)
+        self.assertNotIn('some_opt', result)
+
+    def test_non_dict_value_not_treated_as_conditional(self):
+        """Keys ending with '_' but with list/string values are left alone (extractors)."""
+        opts = {'targets_': [{'type': 'url', 'field': 'url'}]}
+        result = resolve_conditional_opts(opts, {})
+        self.assertIn('targets_', result)
+
+    def test_run_extractors_resolves_conditional_opts_first(self):
+        """run_extractors resolves conditional opts before processing extractors."""
+        from dotmap import DotMap
+        opts = {
+            'skip_host_discovery_': {'condition': "'masscan' in opts.scanners"},
+        }
+        ctx = {'opts': DotMap({'scanners': ['masscan']})}
+        _inputs, updated_opts, errors = run_extractors([], opts, ctx=ctx)
+        self.assertEqual(errors, [])
+        self.assertTrue(updated_opts.get('skip_host_discovery'))
+        self.assertNotIn('skip_host_discovery_', updated_opts)
+
+    def test_run_extractors_conditional_and_extractor_together(self):
+        """run_extractors handles conditional opts alongside standard extractors."""
+        from dotmap import DotMap
+        url1 = Url(url='http://example.com')
+        url2 = Url(url='http://example.org')
+        results = [url1, url2]
+        opts = {
+            'other_': ['url.url'],
+            'skip_host_discovery_': {'condition': 'True'},
+        }
+        ctx = {'opts': DotMap({})}
+        _inputs, updated_opts, errors = run_extractors(results, opts, ctx=ctx)
+        self.assertEqual(errors, [])
+        self.assertIn('other', updated_opts)
+        self.assertTrue(updated_opts.get('skip_host_discovery'))
+        self.assertNotIn('skip_host_discovery_', updated_opts)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -409,6 +409,18 @@ class TestResolveConditionalOpts(unittest.TestCase):
         result = resolve_conditional_opts(opts, {})
         self.assertIn('targets_', result)
 
+    def test_dict_extractor_with_type_key_not_treated_as_conditional(self):
+        """Dict extractors with 'type' key must NOT be treated as conditional opts."""
+        # Reproduces the url_fuzz.yaml httpx.targets_ case:
+        # targets_:
+        #   type: url
+        #   field: url
+        #   condition: not url.verified
+        opts = {'targets_': {'type': 'url', 'field': 'url', 'condition': 'not url.verified'}}
+        result = resolve_conditional_opts(opts, {})
+        self.assertIn('targets_', result)
+        self.assertNotIn('targets', result)
+
     def test_run_extractors_resolves_conditional_opts_first(self):
         """run_extractors resolves conditional opts before processing extractors."""
         from dotmap import DotMap


### PR DESCRIPTION
Implements #988

Adds support for setting options conditionally in workflow YAML files using a `key_: {condition: ...}` syntax.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conditional options support to workflows, enabling dynamic task configuration based on runtime conditions. Options now activate automatically when specified criteria are met (e.g., when particular scanners are selected).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->