### PR TITLE
fix(worker): replace deprecated eventlet with gevent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ trace = [
   'pyinstrument < 5',
 ]
 worker = [
-  'eventlet < 1',
+  'gevent',
   'flower < 3',
 ]
 redis = [

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -130,7 +130,7 @@ for config in SCANS:
 @click.option('-c', '--concurrency', type=int, default=100, help='Number of child processes processing the queue.')
 @click.option('-r', '--reload', is_flag=True, help='Autoreload Celery on code changes.')
 @click.option('-Q', '--queue', type=str, default='', help='Listen to a specific queue.')
-@click.option('-P', '--pool', type=str, default='eventlet', help='Pool implementation.')
+@click.option('-P', '--pool', type=str, default='gevent', help='Pool implementation.')
 @click.option('--quiet', is_flag=True, default=False, help='Quiet mode.')
 @click.option('--loglevel', type=str, default='INFO', help='Log level.')
 @click.option('--check', is_flag=True, help='Check if Celery worker is alive.')
@@ -181,7 +181,7 @@ def worker(hostname, concurrency, reload, queue, pool, quiet, loglevel, check, d
 		pidfile = '%n.pid'
 		queues = '-Q:1 celery -Q:2 small -Q:3 medium -Q:4 large -Q:5 extra_large'
 		concur = '-c:1 10 -c:2 100 -c:3 50 -c:4 20 -c:5 4'
-		pool = 'eventlet'
+		pool = 'gevent'
 		cmd = f'{celery} -A {app_str} multi {subcmd} 5 {queues} -P {pool} {concur} --logfile={logfile} --pidfile={pidfile}'
 	else:
 		cmd = f'{celery} -A {app_str} worker -n {hostname} -Q {queue}'

--- a/secator/definitions.py
+++ b/secator/definitions.py
@@ -176,7 +176,7 @@ def is_importable(module_to_import):
 ADDONS_ENABLED = {}
 
 for addon, module in [
-	('worker', 'eventlet'),
+	('worker', 'gevent'),
 	('gdrive', 'gspread'),
 	('gcs', 'google.cloud.storage'),
 	('api', 'requests'),

--- a/tests/performance/loadtester.py
+++ b/tests/performance/loadtester.py
@@ -1,5 +1,6 @@
-import eventlet
-eventlet.monkey_patch()
+from gevent import monkey
+monkey.patch_all()
+from gevent.pool import Pool  # noqa: E402
 from secator.runners import Workflow, Task, Scan  # noqa: E402
 from secator.template import TemplateLoader  # noqa: E402
 from secator.celery import *  # noqa: E402,F403
@@ -7,7 +8,7 @@ import click  # noqa: E402
 import json  # noqa: E402
 from time import sleep, time  # noqa: E402
 
-pool = eventlet.GreenPool(100)
+pool = Pool(100)
 
 from kombu.serialization import register  # noqa: E402
 


### PR DESCRIPTION
Eventlet is deprecated and in bugfix-only maintenance mode. Replace all usages with gevent, which is a drop-in alternative for I/O-bound Celery concurrency.

Fixes #966

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default worker pool backend for the `secator worker` CLI command, switching to an alternative implementation for enhanced system compatibility.
  * Updated project optional dependencies to align with the new worker pool backend.
  * Refreshed the performance testing suite to ensure proper operation with the updated worker pool implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->