### PR TITLE
fix(exporters): Table exporter broken because of dict change

### DIFF
--- a/secator/exporters/table.py
+++ b/secator/exporters/table.py
@@ -33,7 +33,8 @@ class TableExporter(Exporter):
 							try:
 								item = cls.load(item)
 							except TypeError as e:
-								console.print(f'[bold orange1]Warning:[/] TableExporter could not cast item of type {item.get("_type")!r}: {e}. Skipping.')
+								_type = item.get('_type')
+								console.print(f'[bold orange1]Warning:[/] TableExporter could not cast item of type {_type!r}: {e}. Skipping.')
 								continue
 					cast_items.append(item)
 				if not cast_items:

--- a/secator/exporters/table.py
+++ b/secator/exporters/table.py
@@ -32,11 +32,14 @@ class TableExporter(Exporter):
 						if cls:
 							try:
 								item = cls.load(item)
-							except TypeError:
-								pass
+							except TypeError as e:
+								console.print(f'[bold orange1]Warning:[/] TableExporter could not cast item of type {item.get("_type")!r}: {e}. Skipping.')
+								continue
 					cast_items.append(item)
+				if not cast_items:
+					continue
 				items = cast_items
-				is_output_type = isinstance(items[0], OutputType)
+				is_output_type = all(isinstance(item, OutputType) for item in items)
 				output_fields = items[0]._table_fields if is_output_type else None
 				sort_by = items[0]._sort_by if is_output_type else []
 				_table = build_table(

--- a/secator/exporters/table.py
+++ b/secator/exporters/table.py
@@ -1,12 +1,14 @@
 from rich.markdown import Markdown
 
 from secator.exporters._base import Exporter
-from secator.output_types import OutputType
+from secator.output_types import OUTPUT_TYPES, OutputType
 from secator.rich import build_table, console
 from secator.utils import pluralize
 
 
 class TableExporter(Exporter):
+	_type_map = {cls.get_name(): cls for cls in OUTPUT_TYPES}
+
 	def send(self):
 		results = self.report.data['results']
 		if not results:
@@ -23,6 +25,17 @@ class TableExporter(Exporter):
 			if output_type == 'progress':
 				continue
 			if items:
+				cast_items = []
+				for item in items:
+					if isinstance(item, dict):
+						cls = self._type_map.get(item.get('_type'))
+						if cls:
+							try:
+								item = cls.load(item)
+							except TypeError:
+								pass
+					cast_items.append(item)
+				items = cast_items
 				is_output_type = isinstance(items[0], OutputType)
 				output_fields = items[0]._table_fields if is_output_type else None
 				sort_by = items[0]._sort_by if is_output_type else []


### PR DESCRIPTION
Fix TableExporter to cast dict items to their respective OutputType instances before rendering, matching the fix applied to TXT and CSV exporters in #994.

Closes #1003

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table export functionality to automatically convert dictionary data to appropriate output types, with graceful error handling that preserves original data if type conversion fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->