### PR TITLE
fix(query): add --format to report show and improve query expression support

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -959,6 +959,7 @@ def _apply_format(results, fmt):
 			_template = '{' + _field + '}' if _field else None
 
 		if _type not in results:
+			console.print(f'[yellow]Warning: --format type {_type!r} not found in results[/yellow]')
 			continue
 
 		items = results[_type]
@@ -972,6 +973,9 @@ def _apply_format(results, fmt):
 				d = item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
 				try:
 					value = _template.format(**{_type: DotMap(d), **d})
+					# DotMap returns an empty DotMap() for missing nested paths; skip such items.
+					if 'DotMap()' in str(value):
+						continue
 					formatted.append(value)
 				except (KeyError, AttributeError):
 					pass
@@ -979,7 +983,7 @@ def _apply_format(results, fmt):
 		else:
 			new_results[_type] = [str(item) for item in items]
 
-	return new_results if new_results else results
+	return new_results
 
 
 @report.command('show')
@@ -1052,6 +1056,13 @@ def report_show(ctx, report_query, output, time_delta, query, fmt, workspace, dr
 	}
 
 	exporters = Runner.resolve_exporters(output)
+
+	if fmt:
+		non_console = [e.strip() for e in output.split(',') if e.strip() and e.strip() != 'console']
+		if non_console:
+			raise click.UsageError(
+				f"--format (-f) is only supported with the console exporter; incompatible with: {', '.join(non_console)}"
+			)
 
 	# 6. Build and send report via QueryEngine
 	dedupe_effective = CONFIG.runners.remove_duplicates if dedupe is None else dedupe

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -931,16 +931,68 @@ def report():
 	pass
 
 
+def _apply_format(results, fmt):
+	"""Apply a --format string to report results, returning formatted strings grouped by type.
+
+	Args:
+		results (dict): Report results keyed by type name.
+		fmt (str): Format spec(s), optionally pipe-separated per type.
+			E.g. '{tag.match}-{tag.name}' or '{port.host}:{port.port} || vulnerability.matched_at'
+
+	Returns:
+		dict: Results dict with items replaced by formatted strings (only matching types kept).
+	"""
+	specs = [s.strip() for s in re.split(r'\s*\|\|\s*', fmt) if s.strip()]
+	new_results = {}
+
+	for spec in specs:
+		if '{' in spec and '}' in spec:
+			m = re.search(r'\{(\w+)[.\}]', spec)
+			if not m:
+				continue
+			_type = m.group(1)
+			_template = spec
+		else:
+			parts = spec.split('.', 1)
+			_type = parts[0]
+			_field = parts[1] if len(parts) > 1 else None
+			_template = '{' + _field + '}' if _field else None
+
+		if _type not in results:
+			continue
+
+		items = results[_type]
+		if not items:
+			new_results[_type] = []
+			continue
+
+		if _template:
+			formatted = []
+			for item in items:
+				d = item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
+				try:
+					value = _template.format(**{_type: DotMap(d), **d})
+					formatted.append(value)
+				except (KeyError, AttributeError):
+					pass
+			new_results[_type] = formatted
+		else:
+			new_results[_type] = [str(item) for item in items]
+
+	return new_results if new_results else results
+
+
 @report.command('show')
 @click.argument('report_query', required=False)
 @click.option('-o', '--output', type=str, default='console', help='Exporters')
 @click.option('-d', '--time-delta', type=str, default=None, help='Keep results newer than time delta. E.g: 26m, 1d, 1y')  # noqa: E501
 @click.option('-q', '--query', type=str, default=None, help='Filter results (Python-like or MongoDB JSON)')
+@click.option('--format', '-f', 'fmt', type=str, default=None, help='Format string for results, e.g. \'{tag.match}-{tag.name}\' or \'{port.host}:{port.port} || vulnerability.matched_at\'')  # noqa: E501
 @click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.pass_context
-def report_show(ctx, report_query, output, time_delta, query, workspace, driver, dedupe):
+def report_show(ctx, report_query, output, time_delta, query, fmt, workspace, driver, dedupe):
 	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""
 	from secator.query.utils import parse_report_paths, python_expr_to_mongo
 
@@ -1005,6 +1057,8 @@ def report_show(ctx, report_query, output, time_delta, query, workspace, driver,
 	dedupe_effective = CONFIG.runners.remove_duplicates if dedupe is None else dedupe
 	report = Report(runner, title=f'Consolidated report - {current}', exporters=exporters)
 	report.build(query=full_query, dedupe=dedupe_effective)
+	if fmt:
+		report.data['results'] = _apply_format(report.data['results'], fmt)
 	report.send()
 
 

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -101,8 +101,9 @@ def _normalize_field_path(field):
     """Convert Python-style method calls to dot notation for MongoDB.
 
     E.g. 'extra_data.get(\'product\')' → 'extra_data.product'
+    E.g. 'extra_data.get(\'http-title\')' → 'extra_data.http-title'
     """
-    return re.sub(r"\.get\(['\"](\w+)['\"]\)", r'.\1', field)
+    return re.sub(r"\.get\(\s*(['\"])([^'\"]+)\1\s*\)", r'.\2', field)
 
 
 def _parse_single_expr(expr):

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -97,6 +97,14 @@ _OP_MAP = {
 }
 
 
+def _normalize_field_path(field):
+    """Convert Python-style method calls to dot notation for MongoDB.
+
+    E.g. 'extra_data.get(\'product\')' → 'extra_data.product'
+    """
+    return re.sub(r"\.get\(['\"](\w+)['\"]\)", r'.\1', field)
+
+
 def _parse_single_expr(expr):
     """Parse one expression like 'vulnerability.severity_score > 7' into a query dict."""
     expr = expr.strip()
@@ -122,7 +130,7 @@ def _parse_single_expr(expr):
         mongo_op = _OP_MAP.get(op_str)
         parts = left.split('.', 1)
         _type = parts[0].strip()
-        field = parts[1].strip() if len(parts) > 1 else None
+        field = _normalize_field_path(parts[1].strip()) if len(parts) > 1 else None
         value = _parse_value(right)
         result = {'_type': _type}
         if field:
@@ -134,6 +142,37 @@ def _parse_single_expr(expr):
     return {'_type': parts[0].strip()}
 
 
+def _normalize_logical_ops(query):
+    """Replace Python-style 'and'/'or' with '&&'/'||', skipping quoted substrings."""
+    result = []
+    i = 0
+    in_quote = None
+    while i < len(query):
+        ch = query[i]
+        if in_quote is None and ch in ('"', "'"):
+            in_quote = ch
+            result.append(ch)
+            i += 1
+        elif ch == in_quote:
+            in_quote = None
+            result.append(ch)
+            i += 1
+        elif in_quote is None:
+            if query[i:i + 5] == ' and ':
+                result.append(' && ')
+                i += 5
+            elif query[i:i + 4] == ' or ':
+                result.append(' || ')
+                i += 4
+            else:
+                result.append(ch)
+                i += 1
+        else:
+            result.append(ch)
+            i += 1
+    return ''.join(result)
+
+
 def python_expr_to_mongo(query):
     """Translate a Python-like CLI query expression to a MongoDB-style query dict.
 
@@ -143,8 +182,8 @@ def python_expr_to_mongo(query):
         - JSON string (starts with '{') → parsed as dict
         - 'type' → {'_type': 'type'}
         - 'type.field > value' → {'_type': 'type', 'field': {'$gt': value}}
-        - 'expr1 && expr2' → merged dict (AND)
-        - 'expr1 || expr2' → {'$or': [...]}
+        - 'expr1 && expr2' or 'expr1 and expr2' → merged dict (AND)
+        - 'expr1 || expr2' or 'expr1 or expr2' → {'$or': [...]}
     """
     if not query:
         return {}
@@ -157,6 +196,8 @@ def python_expr_to_mongo(query):
             return json.loads(query)
         except json.JSONDecodeError:
             pass
+
+    query = _normalize_logical_ops(query)
 
     or_parts = _split_logical_op(query, '||')
     and_parts = _split_logical_op(query, '&&')

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -97,15 +97,6 @@ _OP_MAP = {
 }
 
 
-def _normalize_field_path(field):
-    """Convert Python-style method calls to dot notation for MongoDB.
-
-    E.g. 'extra_data.get(\'product\')' → 'extra_data.product'
-    E.g. 'extra_data.get(\'http-title\')' → 'extra_data.http-title'
-    """
-    return re.sub(r"\.get\(\s*(['\"])([^'\"]+)\1\s*\)", r'.\2', field)
-
-
 def _parse_single_expr(expr):
     """Parse one expression like 'vulnerability.severity_score > 7' into a query dict."""
     expr = expr.strip()
@@ -131,7 +122,7 @@ def _parse_single_expr(expr):
         mongo_op = _OP_MAP.get(op_str)
         parts = left.split('.', 1)
         _type = parts[0].strip()
-        field = _normalize_field_path(parts[1].strip()) if len(parts) > 1 else None
+        field = parts[1].strip() if len(parts) > 1 else None
         value = _parse_value(right)
         result = {'_type': _type}
         if field:

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,4 +1,4 @@
-from secator.query.utils import parse_report_paths, python_expr_to_mongo, _normalize_field_path
+from secator.query.utils import parse_report_paths, python_expr_to_mongo
 
 
 class TestParseReportPaths:
@@ -120,37 +120,3 @@ class TestPythonExprToMongo:
         result = python_expr_to_mongo("tag.name == 'this and that' and tag.match == 'x'")
         assert result == {'_type': 'tag', 'name': 'this and that', 'match': 'x'}
 
-    def test_get_method_normalization(self):
-        result = python_expr_to_mongo("tag.extra_data.get('product') == 'Apache'")
-        assert result == {'_type': 'tag', 'extra_data.product': 'Apache'}
-
-    def test_get_method_double_quotes(self):
-        result = python_expr_to_mongo('tag.extra_data.get("product") == "Apache"')
-        assert result == {'_type': 'tag', 'extra_data.product': 'Apache'}
-
-    def test_full_issue_query(self):
-        result = python_expr_to_mongo(
-            "tag.name == 'technology' and tag.extra_data.get('product') == 'Apache HTTP Server'"
-        )
-        assert result == {'_type': 'tag', 'name': 'technology', 'extra_data.product': 'Apache HTTP Server'}
-
-
-class TestNormalizeFieldPath:
-
-    def test_get_single_quotes(self):
-        assert _normalize_field_path("extra_data.get('product')") == 'extra_data.product'
-
-    def test_get_double_quotes(self):
-        assert _normalize_field_path('extra_data.get("product")') == 'extra_data.product'
-
-    def test_nested_get(self):
-        assert _normalize_field_path("a.b.get('c')") == 'a.b.c'
-
-    def test_no_get(self):
-        assert _normalize_field_path('extra_data.product') == 'extra_data.product'
-
-    def test_get_non_identifier_key(self):
-        assert _normalize_field_path("extra_data.get('http-title')") == 'extra_data.http-title'
-
-    def test_get_with_spaces(self):
-        assert _normalize_field_path("extra_data.get( 'product' )") == 'extra_data.product'

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -148,3 +148,9 @@ class TestNormalizeFieldPath:
 
     def test_no_get(self):
         assert _normalize_field_path('extra_data.product') == 'extra_data.product'
+
+    def test_get_non_identifier_key(self):
+        assert _normalize_field_path("extra_data.get('http-title')") == 'extra_data.http-title'
+
+    def test_get_with_spaces(self):
+        assert _normalize_field_path("extra_data.get( 'product' )") == 'extra_data.product'

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,4 +1,4 @@
-from secator.query.utils import parse_report_paths, python_expr_to_mongo
+from secator.query.utils import parse_report_paths, python_expr_to_mongo, _normalize_field_path
 
 
 class TestParseReportPaths:
@@ -102,3 +102,49 @@ class TestPythonExprToMongo:
         import json
         query = {'_type': 'vulnerability', 'severity_score': {'$gte': 7}}
         assert python_expr_to_mongo(json.dumps(query)) == query
+
+    def test_python_and_keyword(self):
+        result = python_expr_to_mongo("port.state == 'open' and port.port < 1024")
+        assert result == {'_type': 'port', 'state': 'open', 'port': {'$lt': 1024}}
+
+    def test_python_or_keyword(self):
+        result = python_expr_to_mongo('vulnerability.severity_score > 7 or domain')
+        assert result == {
+            '$or': [
+                {'_type': 'vulnerability', 'severity_score': {'$gt': 7}},
+                {'_type': 'domain'},
+            ]
+        }
+
+    def test_and_with_quoted_value_containing_and(self):
+        result = python_expr_to_mongo("tag.name == 'this and that' and tag.match == 'x'")
+        assert result == {'_type': 'tag', 'name': 'this and that', 'match': 'x'}
+
+    def test_get_method_normalization(self):
+        result = python_expr_to_mongo("tag.extra_data.get('product') == 'Apache'")
+        assert result == {'_type': 'tag', 'extra_data.product': 'Apache'}
+
+    def test_get_method_double_quotes(self):
+        result = python_expr_to_mongo('tag.extra_data.get("product") == "Apache"')
+        assert result == {'_type': 'tag', 'extra_data.product': 'Apache'}
+
+    def test_full_issue_query(self):
+        result = python_expr_to_mongo(
+            "tag.name == 'technology' and tag.extra_data.get('product') == 'Apache HTTP Server'"
+        )
+        assert result == {'_type': 'tag', 'name': 'technology', 'extra_data.product': 'Apache HTTP Server'}
+
+
+class TestNormalizeFieldPath:
+
+    def test_get_single_quotes(self):
+        assert _normalize_field_path("extra_data.get('product')") == 'extra_data.product'
+
+    def test_get_double_quotes(self):
+        assert _normalize_field_path('extra_data.get("product")') == 'extra_data.product'
+
+    def test_nested_get(self):
+        assert _normalize_field_path("a.b.get('c')") == 'a.b.c'
+
+    def test_no_get(self):
+        assert _normalize_field_path('extra_data.product') == 'extra_data.product'


### PR DESCRIPTION
Fix 'Invalid output type' error and add -- format option to `secator report show` adapted to the new MongoDB-style query architecture.

Closes #963

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--format` option to the `report show` command to format results using custom templates.
  * Query expressions now support Python-style logical operators (`and`/`or`) alongside symbolic operators.
  * Query expressions support Python-style field access patterns for improved readability.

* **Tests**
  * Added comprehensive test coverage for new query and reporting features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->