### PR TITLE
fix(query): support mixing && and || with && taking precedence

### DIFF
--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -19,7 +19,7 @@ OPERATORS = {
 	"$gte": lambda field, value: field >= value if field is not None else False,
 	"$lt": lambda field, value: field < value if field is not None else False,
 	"$lte": lambda field, value: field <= value if field is not None else False,
-	"$ne": lambda field, value: field != value,
+	"$ne": lambda field, value: field is not None and field != value,
 }
 
 

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -166,6 +166,17 @@ def _normalize_logical_ops(query):
     return ''.join(result)
 
 
+def _merge_clause_dicts(base, update):
+    """Merge two clause dicts, combining operator sub-dicts for the same field key."""
+    result = dict(base)
+    for key, value in update.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = {**result[key], **value}
+        else:
+            result[key] = value
+    return result
+
+
 def python_expr_to_mongo(query):
     """Translate a Python-like CLI query expression to a MongoDB-style query dict.
 
@@ -204,7 +215,7 @@ def python_expr_to_mongo(query):
             if len(and_parts) > 1:
                 merged = {}
                 for ap in and_parts:
-                    merged.update(_parse_single_expr(ap))
+                    merged = _merge_clause_dicts(merged, _parse_single_expr(ap))
                 mongo_clauses.append(merged)
             else:
                 mongo_clauses.append(_parse_single_expr(or_part))
@@ -214,7 +225,7 @@ def python_expr_to_mongo(query):
         if len(and_parts) > 1:
             result = {}
             for part in and_parts:
-                result.update(_parse_single_expr(part))
+                result = _merge_clause_dicts(result, _parse_single_expr(part))
         else:
             result = _parse_single_expr(query)
 

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -146,6 +146,7 @@ def python_expr_to_mongo(query):
         - 'type.field > value' → {'_type': 'type', 'field': {'$gt': value}}
         - 'expr1 && expr2' → merged dict (AND)
         - 'expr1 || expr2' → {'$or': [...]}
+        - 'e1 || e2 && e3 || e4' → {'$or': [e1, {e2 merged e3}, e4]}  (&&  binds tighter than ||)
     """
     if not query:
         return {}
@@ -160,19 +161,27 @@ def python_expr_to_mongo(query):
             pass
 
     or_parts = _split_logical_op(query, '||')
-    and_parts = _split_logical_op(query, '&&')
-
-    if len(or_parts) > 1 and len(and_parts) > 1:
-        raise ValueError("Cannot mix && and || in the same query expression")
 
     if len(or_parts) > 1:
-        result = {'$or': [_parse_single_expr(p) for p in or_parts]}
-    elif len(and_parts) > 1:
-        result = {}
-        for part in and_parts:
-            result.update(_parse_single_expr(part))
+        mongo_clauses = []
+        for or_part in or_parts:
+            and_parts = _split_logical_op(or_part, '&&')
+            if len(and_parts) > 1:
+                merged = {}
+                for ap in and_parts:
+                    merged.update(_parse_single_expr(ap))
+                mongo_clauses.append(merged)
+            else:
+                mongo_clauses.append(_parse_single_expr(or_part))
+        result = {'$or': mongo_clauses}
     else:
-        result = _parse_single_expr(query)
+        and_parts = _split_logical_op(query, '&&')
+        if len(and_parts) > 1:
+            result = {}
+            for part in and_parts:
+                result.update(_parse_single_expr(part))
+        else:
+            result = _parse_single_expr(query)
 
     debug('python_expr_to_mongo', sub='query', obj={'input': query, 'output': result})
     return result

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -266,6 +266,13 @@ class TestQueryOperators(unittest.TestCase):
 		self.assertTrue(match_query(item, {'url': {'$regex': r'example\.com'}}))
 		self.assertFalse(match_query(item, {'url': {'$regex': r'other\.com'}}))
 
+		# $ne: missing field (None) should NOT match
+		self.assertFalse(match_query(item, {'nonexistent_field': {'$ne': 'anything'}}))
+		# $ne: present field with different value should match
+		self.assertTrue(match_query(item, {'severity': {'$ne': 'low'}}))
+		# $ne: present field with same value should not match
+		self.assertFalse(match_query(item, {'severity': {'$ne': 'critical'}}))
+
 
 class TestMongoDBBackend(unittest.TestCase):
 	def test_mongodb_backend_instantiation(self):

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -126,6 +126,19 @@ class TestPythonExprToMongo:
             ]
         }
 
+    def test_and_range_query_same_field(self):
+        result = python_expr_to_mongo('port.port > 80 && port.port < 1024')
+        assert result == {'_type': 'port', 'port': {'$gt': 80, '$lt': 1024}}
+
+    def test_mixed_and_or_preserves_same_field_range(self):
+        result = python_expr_to_mongo('domain || port.port > 80 && port.port < 1024')
+        assert result == {
+            '$or': [
+                {'_type': 'domain'},
+                {'_type': 'port', 'port': {'$gt': 80, '$lt': 1024}},
+            ]
+        }
+
     def test_passthrough_mongo_dict(self):
         query = {'_type': 'vulnerability', 'severity_score': {'$gte': 7}}
         assert python_expr_to_mongo(query) == query

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -98,6 +98,34 @@ class TestPythonExprToMongo:
         result = python_expr_to_mongo("technology.product ~= 'xrdp'")
         assert result == {'_type': 'technology', 'product': {'$regex': 'xrdp'}}
 
+    def test_mixed_and_or_precedence(self):
+        # && binds tighter than ||
+        # "ip || port.extra_data.confidence == 'high' || url ||
+        #  vulnerability.severity_nb < 2 && vulnerability.confidence == 'high' || exploit"
+        query = (
+            "ip || port.extra_data.confidence == 'high' || url || "
+            "vulnerability.severity_nb < 2 && vulnerability.confidence == 'high' || exploit"
+        )
+        result = python_expr_to_mongo(query)
+        assert result == {
+            '$or': [
+                {'_type': 'ip'},
+                {'_type': 'port', 'extra_data.confidence': 'high'},
+                {'_type': 'url'},
+                {'_type': 'vulnerability', 'severity_nb': {'$lt': 2}, 'confidence': 'high'},
+                {'_type': 'exploit'},
+            ]
+        }
+
+    def test_mixed_and_within_or_simple(self):
+        result = python_expr_to_mongo("domain || port.state == 'open' && port.port < 1024")
+        assert result == {
+            '$or': [
+                {'_type': 'domain'},
+                {'_type': 'port', 'state': 'open', 'port': {'$lt': 1024}},
+            ]
+        }
+
     def test_passthrough_mongo_dict(self):
         query = {'_type': 'vulnerability', 'severity_score': {'$gte': 7}}
         assert python_expr_to_mongo(query) == query


### PR DESCRIPTION
Fixes #1004

Splits on `||` first (lower precedence), then for each OR segment splits on `&&` (higher precedence) and dict-merges the AND parts. Removes the ValueError that previously blocked mixed expressions.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query expressions now support mixing OR and AND operators with proper precedence (AND binds tighter than OR), enabling more complex and flexible filtering.

* **Tests**
  * Added unit tests validating OR and AND operator precedence in query parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->