### PR TITLE
feat(config): support setting task-specific config overrides

### DIFF
--- a/secator/config.py
+++ b/secator/config.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 from subprocess import call, DEVNULL
-from typing import Dict, List
+from typing import Any, Dict, List
 from typing_extensions import Annotated, Self
 
 import validators
@@ -126,6 +126,7 @@ class HTTP(StrictModel):
 
 class Tasks(StrictModel):
 	exporters: List[str] = ['json', 'csv', 'txt', 'markdown']
+	overrides: Dict[str, Dict[str, Any]] = {}
 
 
 class Workflows(StrictModel):

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -206,6 +206,11 @@ class Command(Runner):
 		self.proxy = self.run_opts.pop('proxy', False)
 		self.configure_proxy()
 
+		# Apply task-specific config overrides
+		task_name = self.__class__.__name__
+		for attr, value in CONFIG.tasks.overrides.get(task_name, {}).items():
+			setattr(self, attr, value)
+
 		# Build command input
 		self._build_cmd_input()
 

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -308,3 +308,55 @@ class TestCommandChunking(unittest.TestCase):
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=TestCmd):
 			cmd = TestCmd(targets)
 			self.assertFalse(cmd.needs_chunking(sync=False))
+
+
+class TestCommandConfigOverrides(unittest.TestCase):
+
+	def test_config_override_input_chunk_size(self):
+		"""Test that task-specific config overrides apply to instance attributes."""
+		from secator.config import CONFIG
+
+		class OverrideTestCmd(Command):
+			cmd = 'test'
+			input_chunk_size = 100
+			file_flag = None
+
+		targets = ['target1', 'target2', 'target3']
+		original_overrides = CONFIG.tasks.overrides
+		CONFIG.tasks.overrides = {'OverrideTestCmd': {'input_chunk_size': 2}}
+		try:
+			with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=OverrideTestCmd):
+				cmd = OverrideTestCmd(targets)
+				self.assertEqual(cmd.input_chunk_size, 2)
+				self.assertTrue(cmd.needs_chunking(sync=False))
+		finally:
+			CONFIG.tasks.overrides = original_overrides
+
+	def test_config_override_does_not_affect_other_tasks(self):
+		"""Test that config overrides for one task don't affect other tasks."""
+		from secator.config import CONFIG
+
+		class TaskOverrideA(Command):
+			cmd = 'test_a'
+			input_chunk_size = 100
+			file_flag = None
+
+		class TaskOverrideB(Command):
+			cmd = 'test_b'
+			input_chunk_size = 100
+			file_flag = None
+
+		targets = ['t1', 't2', 't3']
+		original_overrides = CONFIG.tasks.overrides
+		CONFIG.tasks.overrides = {'TaskOverrideA': {'input_chunk_size': 2}}
+		try:
+			with unittest.mock.patch(
+				'secator.runners.task.Task.get_task_class',
+				side_effect=lambda x: TaskOverrideA if x == 'TaskOverrideA' else TaskOverrideB
+			):
+				cmd_a = TaskOverrideA(targets)
+				cmd_b = TaskOverrideB(targets)
+				self.assertEqual(cmd_a.input_chunk_size, 2)
+				self.assertEqual(cmd_b.input_chunk_size, 100)
+		finally:
+			CONFIG.tasks.overrides = original_overrides


### PR DESCRIPTION
Add `tasks.overrides` dict to the Secator config model, allowing users to override any task attribute (e.g. `input_chunk_size`) per task name in their `config.yml`.

Fixes #1010

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks can now be configured with custom overrides that are applied during execution. This enables per-task customization of behavior and settings without modifying global configuration.

* **Tests**
  * Added comprehensive test coverage to verify that task-specific configuration overrides are properly applied and isolated to their respective tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->