### PR TITLE
fix(core): autodetect_type should not check file path if target is too long

### DIFF
--- a/secator/utils.py
+++ b/secator/utils.py
@@ -1040,7 +1040,7 @@ def autodetect_type(target):
 		return IBAN
 	elif validators.uuid(target):
 		return UUID
-	elif Path(target).exists():
+	elif len(target) < 255 and Path(target).exists():
 		return PATH
 	elif validators.slug(target):
 		return SLUG

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -74,7 +74,7 @@ class TestExtractRootDomain(unittest.TestCase):
 			("https://github.com/example/example.git", URL),
 			("github.com/example/example.git", STRING),
 			("gs://example/example.txt", GCS_URL),
-			("a" * 255, STRING),
+			("a" * 255, SLUG),
 		]
 		for target, expected in targets:
 			with self.subTest(target=target):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -74,6 +74,7 @@ class TestExtractRootDomain(unittest.TestCase):
 			("https://github.com/example/example.git", URL),
 			("github.com/example/example.git", STRING),
 			("gs://example/example.txt", GCS_URL),
+			("a" * 255, STRING),
 		]
 		for target, expected in targets:
 			with self.subTest(target=target):


### PR DESCRIPTION
When a target string is >= 255 characters, `Path(target).exists()` raises `OSError: File name too long` on Linux.

This fix limits the file path existence check to targets shorter than 255 characters.

Closes #1012

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input type detection to properly distinguish between long strings and file paths. The system now correctly classifies inputs exceeding 255 characters as text strings rather than file paths, enhancing type detection accuracy and preventing misclassification of lengthy text data for more reliable input processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->