### PR TITLE
fix(exporters): TXT exporter produces empty files in runner context

### DIFF
--- a/secator/exporters/txt.py
+++ b/secator/exporters/txt.py
@@ -26,10 +26,10 @@ class TxtExporter(Exporter):
 								item = cls.load(item)
 							except TypeError:
 								pass
-						if not first:
-							f.write('\n')
-						f.write(str(item))
-						first = False
+					if not first:
+						f.write('\n')
+					f.write(str(item))
+					first = False
 			txt_paths.append(txt_path)
 
 		if not txt_paths:


### PR DESCRIPTION
Move write operations outside isinstance(item, dict) block so they execute for both dict items and OutputType objects. In runner context items are OutputType instances, so they were being silently skipped.

Fixes #1015

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text file export formatting to ensure all items are properly displayed with consistent newline separation, regardless of their data type. Mixed data exports now render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->