### PR TITLE
perf(query): yield findings lazily in JSON backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ dependencies = [
   'tldextract < 6',
   'typing_extensions < 5',
   'validators < 1',
-  'xmltodict < 1'
+  'xmltodict < 1',
+  'json-stream < 2'
 ]
 
 [project.optional-dependencies]

--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -131,7 +131,7 @@ class JsonBackend(QueryBackend):
 								results = data['results']
 								for type_name, items in results.items():
 									for item in items:
-										item_dict = item.collect()
+										item_dict = json_stream.to_standard_types(item)
 										if f'{runner_type_singular}_id' not in item_dict['_context']:
 											item_dict['_context'][f'{runner_type_singular}_id'] = runner_id
 										yield item_dict

--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -3,7 +3,7 @@
 import json
 import re
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Generator, List, Dict, Any, Optional
 
 from secator.query._base import QueryBackend
 from secator.config import CONFIG
@@ -78,7 +78,6 @@ class JsonBackend(QueryBackend):
 				 context: Optional[dict] = None, results: Optional[list] = None):
 		super().__init__(workspace_id, config, context=context)
 		self._results = results
-		self._findings_cache = None
 		reports_dir = config.get('reports_dir', CONFIG.dirs.reports) if config else CONFIG.dirs.reports
 		self.reports_dir = Path(reports_dir).expanduser()
 
@@ -94,26 +93,23 @@ class JsonBackend(QueryBackend):
 		workspace_folder = sanitize_folder_name(self.workspace_id)
 		return self.reports_dir / workspace_folder
 
-	def _load_all_findings(self) -> List[Dict[str, Any]]:
-		"""Load all findings from workspace JSON files, or return pre-loaded/cached results."""
+	def _load_all_findings(self) -> Generator[Dict[str, Any], None, None]:
+		"""Yield findings from workspace JSON files, or iterate pre-loaded results."""
 		if self._results is not None:
-			return self._results
-		if self._findings_cache is not None:
-			return self._findings_cache
-		findings = []
+			yield from self._results
+			return
+
 		workspace_path = self._get_workspace_path()
 		debug(f'Looking for reports in: {workspace_path}', sub='query.json')
 		debug(f'Workspace ID/name: {self.workspace_id}', sub='query.json')
 
 		if not workspace_path.exists():
 			debug(f'Workspace path does not exist: {workspace_path}', sub='query.json')
-			# Show what workspaces are available
 			if self.reports_dir.exists():
 				available = [d.name for d in self.reports_dir.iterdir() if d.is_dir()]
 				debug(f'Available workspaces in {self.reports_dir}: {available}', sub='query.json')
-			return findings
+			return
 
-		# Search for report.json files in tasks/, workflows/, scans/
 		for runner_type in ['tasks', 'workflows', 'scans']:
 			runner_path = workspace_path / runner_type
 			if not runner_path.exists():
@@ -136,35 +132,25 @@ class JsonBackend(QueryBackend):
 						for type_name, items in results.items():
 							if isinstance(items, list):
 								for item in items:
-									# Inject runner context from directory path if not already present
 									if f'{runner_type_singular}_id' not in item['_context']:
 										item['_context'][f'{runner_type_singular}_id'] = runner_id
-								findings.extend(items)
+									yield item
 					except (json.JSONDecodeError, IOError) as e:
 						debug(f'Error loading {report_file}: {e}', sub='query.json')
 						continue
 
-		debug(f'Loaded {len(findings)} findings from workspace', sub='query.json')
-		self._findings_cache = findings
-		return findings
-
 	def _execute_search(self, query: dict, limit: int = 100, exclude_fields: list = None) -> List[Dict[str, Any]]:
 		"""Search findings matching query."""
-		findings = self._load_all_findings()
-
 		matched = []
-		for finding in findings:
+		for finding in self._load_all_findings():
 			if match_query(finding, query):
-				# Remove excluded fields
 				if exclude_fields and isinstance(finding, dict):
 					finding = {k: v for k, v in finding.items() if k not in exclude_fields}
 				matched.append(finding)
 				if limit and len(matched) >= limit:
 					break
-
 		return matched
 
 	def _execute_count(self, query: dict) -> int:
 		"""Count findings matching query."""
-		findings = self._load_all_findings()
-		return sum(1 for f in findings if match_query(f, query))
+		return sum(1 for f in self._load_all_findings() if match_query(f, query))

--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -1,6 +1,7 @@
 # secator/query/json.py
 
 import json
+import json_stream
 import re
 from pathlib import Path
 from typing import Generator, List, Dict, Any, Optional
@@ -122,19 +123,20 @@ class JsonBackend(QueryBackend):
 				report_file = report_dir / 'report.json'
 				if report_file.exists():
 					try:
-						with open(report_file, 'r') as f:
-							data = json.load(f)
-
-						results = data.get('results', {})
 						runner_type_singular = runner_type.rstrip('s')  # "tasks" -> "task", "scans" -> "scan"
 						runner_id = report_dir.name
-
-						for type_name, items in results.items():
-							if isinstance(items, list):
-								for item in items:
-									if f'{runner_type_singular}_id' not in item['_context']:
-										item['_context'][f'{runner_type_singular}_id'] = runner_id
-									yield item
+						with open(report_file, 'r') as f:
+							data = json_stream.load(f)
+							try:
+								results = data['results']
+								for type_name, items in results.items():
+									for item in items:
+										item_dict = item.collect()
+										if f'{runner_type_singular}_id' not in item_dict['_context']:
+											item_dict['_context'][f'{runner_type_singular}_id'] = runner_id
+										yield item_dict
+							except KeyError:
+								pass
 					except (json.JSONDecodeError, IOError) as e:
 						debug(f'Error loading {report_file}: {e}', sub='query.json')
 						continue

--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -12,6 +12,15 @@ from secator.utils import sanitize_folder_name
 from secator.utils import debug
 
 
+def _collect(obj):
+    """Recursively convert a json_stream transient object to a standard Python type."""
+    if hasattr(obj, 'items'):
+        return {k: _collect(v) for k, v in obj.items()}
+    elif hasattr(obj, '__iter__') and not isinstance(obj, str):
+        return [_collect(v) for v in obj]
+    return obj
+
+
 OPERATORS = {
 	"$regex": lambda field, pattern: re.search(pattern, str(field)) is not None if field else False,
 	"$contains": lambda field, value: value in str(field) if field else False,
@@ -131,7 +140,7 @@ class JsonBackend(QueryBackend):
 								results = data['results']
 								for type_name, items in results.items():
 									for item in items:
-										item_dict = json_stream.to_standard_types(item)
+										item_dict = _collect(item)
 										if f'{runner_type_singular}_id' not in item_dict['_context']:
 											item_dict['_context'][f'{runner_type_singular}_id'] = runner_id
 										yield item_dict

--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -1,6 +1,5 @@
 # secator/query/json.py
 
-import json
 import json_stream
 import re
 from pathlib import Path
@@ -13,12 +12,12 @@ from secator.utils import debug
 
 
 def _collect(obj):
-    """Recursively convert a json_stream transient object to a standard Python type."""
-    if hasattr(obj, 'items'):
-        return {k: _collect(v) for k, v in obj.items()}
-    elif hasattr(obj, '__iter__') and not isinstance(obj, str):
-        return [_collect(v) for v in obj]
-    return obj
+	"""Recursively convert a json_stream transient object to a standard Python type."""
+	if hasattr(obj, 'items'):
+		return {k: _collect(v) for k, v in obj.items()}
+	elif hasattr(obj, '__iter__') and not isinstance(obj, str):
+		return [_collect(v) for v in obj]
+	return obj
 
 
 OPERATORS = {
@@ -146,7 +145,11 @@ class JsonBackend(QueryBackend):
 										yield item_dict
 							except KeyError:
 								pass
-					except (json.JSONDecodeError, IOError) as e:
+					# json_stream parses lazily, so malformed JSON surfaces as a
+					# ValueError raised *during* iteration above (json.JSONDecodeError
+					# is itself a ValueError subclass). Catch ValueError to keep the
+					# query fail-open: a corrupt report.json is skipped, not fatal.
+					except (ValueError, IOError) as e:
 						debug(f'Error loading {report_file}: {e}', sub='query.json')
 						continue
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -175,6 +175,32 @@ class TestJsonBackend(unittest.TestCase):
 		count = backend.count({'_type': 'vulnerability'})
 		self.assertEqual(count, 2)
 
+	def test_json_backend_skips_corrupt_report(self):
+		"""A corrupt report.json must be skipped (fail-open), not crash search/count.
+
+		json_stream parses lazily, so malformed JSON raises a ValueError *during*
+		iteration. This regression test ensures that error is caught and the valid
+		report is still returned.
+		"""
+		from pathlib import Path
+		from secator.query.json import JsonBackend
+
+		# Write a second task with an invalid (truncated) report.json
+		bad_dir = Path(self.temp_dir) / self.workspace_id / 'tasks' / '1'
+		bad_dir.mkdir(parents=True)
+		with open(bad_dir / 'report.json', 'w') as f:
+			# Malformed JSON: json_stream raises a bare ValueError (NOT a
+			# json.JSONDecodeError) lazily during iteration of this report.
+			f.write('{"results": {"vulnerability": [ }}}')
+
+		backend = JsonBackend(workspace_id=self.workspace_id, config={'reports_dir': self.temp_dir})
+
+		# Search and count must not raise and must still return the valid findings
+		results = backend.search({'_type': 'vulnerability'})
+		self.assertEqual(len(results), 2)
+		count = backend.count({'_type': 'vulnerability'})
+		self.assertEqual(count, 2)
+
 	def test_json_backend_injects_context_from_path(self):
 		"""Findings from tasks/{id}/report.json should have _context.task_id injected."""
 		results = self.backend.search({'_context.task_id': self.task_id})


### PR DESCRIPTION
Convert `_load_all_findings` from a list-accumulating function to a generator so results are passed directly to the filter without holding the entire result set in memory. `_execute_search` can now short-circuit as soon as the limit is reached, avoiding unnecessary file reads. Removes the now-redundant `_findings_cache`.

Fixes #1022

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Findings are now processed incrementally, improving performance and reducing memory use for large result sets; loader silently skips malformed or unexpected result payloads.
* **Chores**
  * Added a JSON streaming dependency to support incremental parsing and conversion to standard data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->