### PR TITLE
fix(cli): dot-path --format broken when field name collides with type name

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -970,10 +970,14 @@ def _apply_format(results, fmt):
 
 		if _template:
 			formatted = []
+			is_brace_style = '{' in spec and '}' in spec
 			for item in items:
 				d = item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
 				try:
-					value = _template.format(**{**d, _type: DotMap(d)})
+					# Brace-style ({type.field}) needs DotMap for attribute access.
+					# Dot-path style (type.field) uses direct field values to avoid clobbering.
+					kwargs = {**d, _type: DotMap(d)} if is_brace_style else d
+					value = _template.format(**kwargs)
 					# DotMap returns an empty DotMap() for missing nested paths; skip such items.
 					if 'DotMap()' in str(value):
 						continue

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -986,7 +986,20 @@ def _apply_format(results, fmt):
 					pass
 			new_results[_type] = formatted
 		else:
-			new_results[_type] = [str(item) for item in items]
+			# No field specified — use each OutputType's __str__ for a clean primary-field repr.
+			# Items from report.data['results'] may be raw dicts; reconstruct via OutputType.load().
+			_otype_map = {cls.get_name(): cls for cls in FINDING_TYPES}
+			otype_cls = _otype_map.get(_type)
+			formatted = []
+			for item in items:
+				if isinstance(item, dict) and otype_cls:
+					try:
+						formatted.append(str(otype_cls.load(item)))
+					except Exception:
+						formatted.append(json.dumps(item))
+				else:
+					formatted.append(str(item))
+			new_results[_type] = formatted
 
 	return new_results
 

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 import sys
 
-from datetime import datetime
 from pathlib import Path
 from stat import S_ISFIFO
 
@@ -993,21 +992,23 @@ def _apply_format(results, fmt):
 			continue
 
 		if _type not in results:
-			# The spec may be a field name rather than a type name.
-			# If there is exactly one non-empty type, fall back to field lookup.
-			nonempty_types = [k for k, v in results.items() if v]
-			if len(nonempty_types) == 1:
-				_actual_type = nonempty_types[0]
-				items = results[_actual_type]
-				formatted = []
-				for item in items:
-					d = item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
-					val = d.get(_type)
-					if val is not None:
-						formatted.append(str(val))
-				new_results[_actual_type] = formatted
-			else:
-				console.print(f'[yellow]Warning: --format type {_type!r} not found in results[/yellow]')
+			if _template is None:
+				# The spec is a plain field name (no type prefix). If there is exactly one
+				# non-empty type, fall back to field lookup on that type.
+				nonempty_types = [k for k, v in results.items() if v]
+				if len(nonempty_types) == 1:
+					_actual_type = nonempty_types[0]
+					items = results[_actual_type]
+					formatted = []
+					for item in items:
+						d = item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
+						val = d.get(_type)
+						if val is not None:
+							formatted.append(str(val))
+					new_results[_actual_type] = formatted
+				else:
+					console.print(f'[yellow]Warning: --format type {_type!r} not found in results[/yellow]')
+			# When _template is set the user gave an explicit type prefix — skip silently.
 			continue
 
 		items = results[_type]

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -969,13 +969,14 @@ def _apply_format(results, fmt):
 			_template = '{' + _field + '}' if _field else None
 
 		if _field_only:
-			if len(results) != 1:
+			nonempty_types = [k for k, v in results.items() if v]
+			if len(nonempty_types) != 1:
 				console.print(
 					f'[yellow]Warning: --format "{spec}" requires a single type in results, '
-					f'got: {list(results.keys())}[/yellow]'
+					f'got: {nonempty_types}[/yellow]'
 				)
 				continue
-			_type = list(results.keys())[0]
+			_type = nonempty_types[0]
 			items = results[_type]
 			if not items:
 				new_results[_type] = []

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -993,7 +993,21 @@ def _apply_format(results, fmt):
 			continue
 
 		if _type not in results:
-			console.print(f'[yellow]Warning: --format type {_type!r} not found in results[/yellow]')
+			# The spec may be a field name rather than a type name.
+			# If there is exactly one non-empty type, fall back to field lookup.
+			nonempty_types = [k for k, v in results.items() if v]
+			if len(nonempty_types) == 1:
+				_actual_type = nonempty_types[0]
+				items = results[_actual_type]
+				formatted = []
+				for item in items:
+					d = item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
+					val = d.get(_type)
+					if val is not None:
+						formatted.append(str(val))
+				new_results[_actual_type] = formatted
+			else:
+				console.print(f'[yellow]Warning: --format type {_type!r} not found in results[/yellow]')
 			continue
 
 		items = results[_type]

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -947,17 +947,49 @@ def _apply_format(results, fmt):
 	new_results = {}
 
 	for spec in specs:
+		_field_only = False
 		if '{' in spec and '}' in spec:
-			m = re.search(r'\{(\w+)[.\}]', spec)
-			if not m:
-				continue
-			_type = m.group(1)
-			_template = spec
+			if re.search(r'\{\w+\.\w+', spec):
+				# Brace-style with type.field dot notation: {url.host} {port.port}
+				m = re.search(r'\{(\w+)\.', spec)
+				if not m:
+					continue
+				_type = m.group(1)
+				_template = spec
+			else:
+				# Brace-style with direct field names: {url} {host} {status_code}
+				# Only works when exactly one type is present in results.
+				_field_only = True
+				_type = None
+				_template = spec
 		else:
 			parts = spec.split('.', 1)
 			_type = parts[0]
 			_field = parts[1] if len(parts) > 1 else None
 			_template = '{' + _field + '}' if _field else None
+
+		if _field_only:
+			if len(results) != 1:
+				console.print(
+					f'[yellow]Warning: --format "{spec}" requires a single type in results, '
+					f'got: {list(results.keys())}[/yellow]'
+				)
+				continue
+			_type = list(results.keys())[0]
+			items = results[_type]
+			if not items:
+				new_results[_type] = []
+				continue
+			formatted = []
+			for item in items:
+				d = item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
+				try:
+					value = _template.format(**d)
+					formatted.append(value)
+				except (KeyError, AttributeError):
+					pass
+			new_results[_type] = formatted
+			continue
 
 		if _type not in results:
 			console.print(f'[yellow]Warning: --format type {_type!r} not found in results[/yellow]')

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -38,6 +38,18 @@ class TestApplyFormat(unittest.TestCase):
 		out = _apply_format(results, 'port.ip')
 		self.assertEqual(out, {'port': ['10.0.0.1']})
 
+	def test_dotpath_style_field_name_collides_with_type(self):
+		"""Dot-path style url.url must return the url string, not a DotMap repr."""
+		results = {'url': [{'url': 'https://example.com', 'status_code': 200, 'webserver': 'nginx'}]}
+		out = _apply_format(results, 'url.url')
+		self.assertEqual(out, {'url': ['https://example.com']})
+
+	def test_dotpath_style_non_colliding_field(self):
+		"""Dot-path style url.webserver must return the webserver field value."""
+		results = {'url': [{'url': 'https://example.com', 'status_code': 200, 'webserver': 'nginx'}]}
+		out = _apply_format(results, 'url.webserver')
+		self.assertEqual(out, {'url': ['nginx']})
+
 	def test_unknown_type_returns_empty(self):
 		results = {'port': [self._make_port()]}
 		out = _apply_format(results, '{vulnerability.matched_at}')

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -78,6 +78,17 @@ class TestApplyFormat(unittest.TestCase):
 		out = _apply_format(results, '{url} {host} {status_code}')
 		self.assertEqual(out, {})
 
+	def test_brace_style_field_only_single_nonempty_type(self):
+		"""Brace-style with direct field names works when only one type has non-empty results (simulates -q filter)."""
+		results = {
+			'url': [{'url': 'https://example.com', 'host': 'example.com', 'port': 443}],
+			'port': [],
+			'subdomain': [],
+			'ip': [],
+		}
+		out = _apply_format(results, '{url}:{port}')
+		self.assertEqual(out, {'url': ['https://example.com:443']})
+
 	def test_unknown_type_returns_empty(self):
 		results = {'port': [self._make_port()]}
 		out = _apply_format(results, '{vulnerability.matched_at}')

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -50,6 +50,19 @@ class TestApplyFormat(unittest.TestCase):
 		out = _apply_format(results, 'url.webserver')
 		self.assertEqual(out, {'url': ['nginx']})
 
+	def test_type_only_spec_uses_str_repr(self):
+		"""--format url (no dot) should use Url.__str__ (returns the url field), not dict repr."""
+		results = {'url': [{'url': 'https://example.com', 'status_code': 200, 'host': 'example.com'}]}
+		out = _apply_format(results, 'url')
+		self.assertEqual(out, {'url': ['https://example.com']})
+
+	def test_type_only_spec_port_uses_str_repr(self):
+		"""--format port (no dot) should use Port.__str__ (returns host:port), not dict repr."""
+		results = {'port': [self._make_port(ip='1.2.3.4', port=8080)]}
+		out = _apply_format(results, 'port')
+		# Port.__str__ returns 'host:port'
+		self.assertEqual(out, {'port': ['example.com:8080']})
+
 	def test_unknown_type_returns_empty(self):
 		results = {'port': [self._make_port()]}
 		out = _apply_format(results, '{vulnerability.matched_at}')

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -63,6 +63,21 @@ class TestApplyFormat(unittest.TestCase):
 		# Port.__str__ returns 'host:port'
 		self.assertEqual(out, {'port': ['example.com:8080']})
 
+	def test_brace_style_field_only_single_type(self):
+		"""Brace-style with direct field names works when only one type is present."""
+		results = {'url': [{'url': 'https://example.com', 'host': 'example.com', 'status_code': 200}]}
+		out = _apply_format(results, '{url} {host} {status_code}')
+		self.assertEqual(out, {'url': ['https://example.com example.com 200']})
+
+	def test_brace_style_field_only_multi_type_warns(self):
+		"""Brace-style with direct field names produces no output when multiple types present."""
+		results = {
+			'url': [{'url': 'https://example.com', 'host': 'example.com', 'status_code': 200}],
+			'port': [self._make_port()],
+		}
+		out = _apply_format(results, '{url} {host} {status_code}')
+		self.assertEqual(out, {})
+
 	def test_unknown_type_returns_empty(self):
 		results = {'port': [self._make_port()]}
 		out = _apply_format(results, '{vulnerability.matched_at}')

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -89,6 +89,25 @@ class TestApplyFormat(unittest.TestCase):
 		out = _apply_format(results, '{url}:{port}')
 		self.assertEqual(out, {'url': ['https://example.com:443']})
 
+	def test_plain_field_spec_single_nonempty_type(self):
+		"""--format status_code (no dot, no braces) should look up the field on the single non-empty type."""
+		results = {
+			'url': [{'url': 'https://example.com', 'status_code': 200, 'host': 'example.com'}],
+			'port': [],
+			'subdomain': [],
+		}
+		out = _apply_format(results, 'status_code')
+		self.assertEqual(out, {'url': ['200']})
+
+	def test_plain_field_spec_multi_nonempty_types_warns(self):
+		"""--format status_code warns when multiple non-empty types present (ambiguous)."""
+		results = {
+			'url': [{'url': 'https://example.com', 'status_code': 200}],
+			'port': [{'port': 80, 'status_code': None}],
+		}
+		out = _apply_format(results, 'status_code')
+		self.assertEqual(out, {})
+
 	def test_unknown_type_returns_empty(self):
 		results = {'port': [self._make_port()]}
 		out = _apply_format(results, '{vulnerability.matched_at}')


### PR DESCRIPTION
Fix `_apply_format` in `secator/cli.py`: for simple dot-path format specs like `url.url`, the format kwargs were always `{**d, _type: DotMap(d)}` which overwrote the actual field string value with a DotMap object. Now brace-style specs (`{url.url}`) keep the DotMap override for attribute access, while dot-path specs (`url.url`) use `d` directly for plain field lookup.

Closes #1024

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved `--format` flag to properly handle both brace-style placeholders (`{field}`) and dot-path notation (`type.field`), ensuring correct field access regardless of formatting style.

* **Tests**
  * Added unit tests for format handling with nested field access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->