### PR TITLE
fix(cli): display runner tree to client in remote worker mode

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -466,9 +466,11 @@ class Runner:
 			OutputType: runner result.
 		"""
 		try:
-			# If sync mode, set started
+			# If sync mode, set started; otherwise log start info to client console
 			if self.sync:
 				self.mark_started()
+			else:
+				self.log_start()
 
 			# Yield results buffer
 			yield from self.results_buffer


### PR DESCRIPTION
Fixes #1026

When sync=False, the runner tree was only printed in the Celery worker process and never visible to the client. Fix by calling log_start() in the client's __iter__() when sync=False.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved execution flow handling for asynchronous operations in the runner module to better distinguish between synchronous and asynchronous execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->