### PR TITLE
fix(cli): humanize dates in secator r list

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -32,6 +32,7 @@ from secator.loader import get_configs_by_type, discover_tasks
 from secator.utils import (
 	debug, detect_host, flatten, print_version,
 	get_file_timestamp, list_reports, get_info_from_report_path, human_to_timedelta,
+	humanize_date,
 	vhs_tap_to_tape, trim_gif, reduce_gif_frames, get_gif_info
 )
 from contextlib import nullcontext
@@ -1085,15 +1086,6 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 	paths = list_reports(workspace=workspace, type=runner_type, timedelta=human_to_timedelta(time_delta))
 	paths = sorted(paths, key=lambda x: x.stat().st_mtime, reverse=False)
 
-	def _fmt_date(iso_str):
-		if not iso_str:
-			return ''
-		try:
-			dt = datetime.fromisoformat(iso_str)
-			return dt.strftime('%Y-%m-%d %H:%M:%S')
-		except (ValueError, TypeError):
-			return str(iso_str)
-
 	# Build table
 	table = Table()
 	table.add_column("Workspace", style="bold gold3")
@@ -1131,8 +1123,8 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 				'status': content['info'].get('status', ''),
 				'id': f'[link={Path(path).as_uri()}]{runner_id}[/link]',
 				'target': first_target,
-				'start_date': _fmt_date(content['info'].get('start_time')),
-				'end_date': _fmt_date(content['info'].get('end_time')),
+				'start_date': humanize_date(content['info'].get('start_time')),
+				'end_date': humanize_date(content['info'].get('end_time')),
 				'elapsed': content['info'].get('elapsed_human', ''),
 			}
 			status_color = STATE_COLORS[data['status']] if data['status'] in STATE_COLORS else 'white'

--- a/secator/utils.py
+++ b/secator/utils.py
@@ -664,6 +664,30 @@ def get_file_date(file_path):
 		return f'{mod_date.strftime("%B %d @ %H:%m")}'
 
 
+def humanize_date(dt):
+	"""Returns a human-readable format for a datetime object or ISO format string.
+
+	Args:
+		dt (datetime | str): Datetime object or ISO format string.
+
+	Returns:
+		str: Human-readable time format.
+	"""
+	if dt is None:
+		return ''
+	if isinstance(dt, str):
+		try:
+			dt = datetime.fromisoformat(dt)
+		except (ValueError, TypeError):
+			return str(dt)
+	dt_utc = dt.replace(tzinfo=None) if dt.tzinfo else dt
+	now = datetime.utcnow()
+	if (now - dt_utc).days < 7:
+		return humanize.naturaltime(now - dt_utc) + dt_utc.strftime(' @ %H:%M')
+	else:
+		return f'{dt_utc.strftime("%B %d @ %H:%M")}'
+
+
 def trim_string(s, max_length=30, mode='middle'):
 	"""Trims a long string with an ellipsis indicator.
 


### PR DESCRIPTION
Humanize the Start Date and End Date columns in `secator r list` using a new `humanize_date()` utility function.

For recent dates (within 7 days), the format is: "2 hours ago @ 14:30". For older dates: "April 21 @ 14:30".

Closes #1031

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced date and time display in report listings. Dates now show in a more human-readable format, displaying relative time (e.g., "2 days ago") for entries from the past week, and absolute date/time format for older entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->