### PR TITLE
fix(cli): add Profiles column and multi-target display to report list

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1100,6 +1100,7 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 	table.add_column("Name")
 	table.add_column("Id")
 	table.add_column("Target")
+	table.add_column("Profiles")
 	table.add_column("Start Date")
 	table.add_column("End Date")
 	table.add_column("Elapsed")
@@ -1125,12 +1126,17 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 			runner_id = info['type'] + '/' + info['id']
 			targets = content['info'].get('targets', [])
 			first_target = str(targets[0]) if targets else ''
+			if len(targets) > 1:
+				first_target += f' (+{len(targets) - 1})'
+			profiles = content['info'].get('profiles', [])
+			profiles_str = ', '.join(profiles) if profiles else ''
 			data = {
 				'workspace': info['workspace'],
 				'name': f"[bold blue]{content['info']['name']}[/]",
 				'status': content['info'].get('status', ''),
 				'id': f'[link={Path(path).as_uri()}]{runner_id}[/link]',
 				'target': first_target,
+				'profiles': profiles_str,
 				'start_date': _fmt_date(content['info'].get('start_time')),
 				'end_date': _fmt_date(content['info'].get('end_time')),
 				'elapsed': content['info'].get('elapsed_human', ''),
@@ -1143,6 +1149,7 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 				data['name'],
 				data['id'],
 				data['target'],
+				data['profiles'],
 				data['start_date'],
 				data['end_date'],
 				data['elapsed'],

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1120,7 +1120,9 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 			first_target = str(targets[0]) if targets else ''
 			if len(targets) > 1:
 				first_target += f' (+{len(targets) - 1})'
-			profiles = content['info'].get('profiles', [])
+			profiles = content['info'].get('run_opts', {}).get('profiles', [])
+			if isinstance(profiles, str):
+				profiles = [p.strip() for p in profiles.split(',') if p.strip()]
 			profiles_str = ', '.join(profiles) if profiles else ''
 			data = {
 				'workspace': info['workspace'],

--- a/secator/report.py
+++ b/secator/report.py
@@ -46,6 +46,7 @@ class Report:
 			'name',
 			'status',
 			'targets',
+			'profiles',
 			'start_time',
 			'end_time',
 			'elapsed',

--- a/secator/report.py
+++ b/secator/report.py
@@ -46,7 +46,6 @@ class Report:
 			'name',
 			'status',
 			'targets',
-			'profiles',
 			'start_time',
 			'end_time',
 			'elapsed',

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -26,7 +26,7 @@ class TestReportBuild:
             'end_time': None,
             'elapsed': None,
             'elapsed_human': None,
-            'run_opts': {},
+            'run_opts': {'profiles': ['aggressive']},
             'results_count': 0,
         }
         return runner
@@ -66,6 +66,12 @@ class TestReportBuild:
         report = Report(runner)
         report.build(query={})
         assert len(report.data['results'].get('vulnerability', [])) == 150
+
+    def test_build_persists_profiles_in_run_opts(self):
+        runner = self._make_runner([])
+        report = Report(runner)
+        report.build(query={})
+        assert report.data['info']['run_opts']['profiles'] == ['aggressive']
 
     def test_build_no_preloaded_results_does_not_short_circuit_backend(self):
         """When runner has no pre-loaded results, Report.build() must not pass empty list to context.


### PR DESCRIPTION
When multiple targets exist in a report, show the first target followed by (+N). Add a Profiles column showing comma-separated profile names used for the scan in `secator r list`.

Fixes #1029

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports table now includes a new "Profiles" column to display profile information for each report.
  * The target field now shows an indicator displaying the count of additional targets when multiple targets are configured.
  * Runner profiling information is now captured and exported as part of report metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->