### PR TITLE
fix(cli): stream cmd and description to client in remote worker mode

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -474,8 +474,9 @@ class Command(Runner):
 				cmd_str = _s(self.cmd)
 				if self.chunk and self.chunk_count:
 					cmd_str += f' ({self.chunk}/{self.chunk_count})'
+				desc_part = f'{self.description} ' if self.description else ''
 				yield Info(
-					message=f'Started task {self.description} ([bold gold3]{self.unique_name}[/]) (cmd=[dim white]{cmd_str}[/])',
+					message=f'Started task {desc_part}([bold gold3]{self.unique_name}[/]) (cmd=[dim white]{cmd_str}[/])',
 					_source=self.unique_name
 				)
 

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -16,7 +16,7 @@ from time import time
 import psutil
 from fp.fp import FreeProxy
 
-from secator.definitions import OPT_NOT_SUPPORTED, OPT_PIPE_INPUT, OPT_SPACE_SEPARATED
+from secator.definitions import IN_WORKER, OPT_NOT_SUPPORTED, OPT_PIPE_INPUT, OPT_SPACE_SEPARATED
 from secator.config import CONFIG
 from secator.output_types import Info, Warning, Error, Stat
 from secator.runners import Runner
@@ -468,6 +468,16 @@ class Command(Runner):
 			# Print command
 			self.print_description()
 			self.print_command()
+
+			# In remote worker mode, stream description and cmd back to the client
+			if IN_WORKER:
+				if not self.has_children and self.caller and self.description and self.print_cmd:
+					yield Info(message=f':wrench: {self.description} ({self.config.name}) ...', _source=self.unique_name)
+				if self.print_cmd:
+					cmd_str = f':zap: {_s(self.cmd)}'
+					if self.chunk and self.chunk_count:
+						cmd_str += f' ({self.chunk}/{self.chunk_count})'
+					yield Info(message=cmd_str, _source=self.unique_name)
 
 			# Check for sudo requirements and prepare the password if needed
 			sudo_required = re.search(r'\bsudo\b', self.cmd)

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -474,9 +474,12 @@ class Command(Runner):
 				cmd_str = _s(self.cmd)
 				if self.chunk and self.chunk_count:
 					cmd_str += f' ({self.chunk}/{self.chunk_count})'
-				desc_part = f'{self.description} ' if self.description else ''
+				if self.description:
+					task_part = f'{self.description} ([bold gold3]{self.unique_name}[/])'
+				else:
+					task_part = f'[bold gold3]{self.unique_name}[/]'
 				yield Info(
-					message=f'Started task {desc_part}([bold gold3]{self.unique_name}[/]) (cmd=[dim white]{cmd_str}[/])',
+					message=f'Started task {task_part} (cmd=[dim white]{cmd_str}[/])',
 					_source=self.unique_name
 				)
 

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -470,14 +470,14 @@ class Command(Runner):
 			self.print_command()
 
 			# In remote worker mode, stream description and cmd back to the client
-			if IN_WORKER:
-				if not self.has_children and self.caller and self.description and self.print_cmd:
-					yield Info(message=f':wrench: {self.description} ({self.config.name}) ...', _source=self.unique_name)
-				if self.print_cmd:
-					cmd_str = f':zap: {_s(self.cmd)}'
-					if self.chunk and self.chunk_count:
-						cmd_str += f' ({self.chunk}/{self.chunk_count})'
-					yield Info(message=cmd_str, _source=self.unique_name)
+			if IN_WORKER and self.print_cmd:
+				cmd_str = _s(self.cmd)
+				if self.chunk and self.chunk_count:
+					cmd_str += f' ({self.chunk}/{self.chunk_count})'
+				yield Info(
+					message=f'Started task {self.description} ([bold gold3]{self.unique_name}[/]) (cmd=[dim white]{cmd_str}[/])',
+					_source=self.unique_name
+				)
 
 			# Check for sudo requirements and prepare the password if needed
 			sudo_required = re.search(r'\bsudo\b', self.cmd)


### PR DESCRIPTION
When sync=False, yield Info objects with the description and full cmd back to the client so they are visible, matching the sync=True behavior where print_description() and print_command() output to the console.

Fixes #1030

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced task metadata streaming in worker mode to provide improved visibility of task execution, including task descriptions and command information with progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->