### PR TITLE
fix(cli): remove secator report export command

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -27,10 +27,9 @@ from secator.output_types import FINDING_TYPES, Info, Warning, Error
 from secator.report import Report
 from secator.rich import console
 from secator.runners import Command, Runner
-from secator.serializers.dataclass import loads_dataclass
 from secator.loader import get_configs_by_type, discover_tasks
 from secator.utils import (
-	debug, detect_host, flatten, print_version,
+	debug, detect_host, print_version,
 	get_file_timestamp, list_reports, get_info_from_report_path, human_to_timedelta,
 	humanize_date,
 	vhs_tap_to_tape, trim_gif, reduce_gif_frames, get_gif_info
@@ -1229,31 +1228,6 @@ def report_info(runner_id, workspace, show_all):
 		console.print('[dim]No errors.[/]')
 
 
-@report.command('export')
-@click.argument('json_path', type=str)
-@click.option('--output-folder', '-of', type=str)
-@click.option('--output', '-o', type=str, required=True)
-def report_export(json_path, output_folder, output):
-	with open(json_path, 'r') as f:
-		data = loads_dataclass(f.read())
-
-	split = json_path.split('/')
-	workspace_name = '/'.join(split[:-4]) if len(split) > 4 else '_default'
-	runner_instance = DotMap({
-		"config": {
-			"name": data['info']['name']
-		},
-		"workspace_name": workspace_name,
-		"reports_folder": output_folder or Path.cwd(),
-		"data": data,
-		"results": flatten(list(data['results'].values()))
-	})
-	exporters = Runner.resolve_exporters(output)
-	report = Report(runner_instance, title=data['info']['title'], exporters=exporters)
-	report.data = data
-	report.send()
-
-
 #--------#
 # DEPLOY #
 #--------#
@@ -1547,7 +1521,7 @@ c set celery.broker_url redis://<remote_ip>:6379/0              [dim]# set redis
 		title=f":zap: [{title_style}]Too slow ? Use a worker[/]", **kwargs)
 
 	panel5 = Panel(r"""
-[dim bold]:left_arrow_curving_right: Reports are stored in the [bold cyan]~/.secator/reports[/] directory. You can list, show, filter and export reports using the following commands.[/]
+[dim bold]:left_arrow_curving_right: Reports are stored in the [bold cyan]~/.secator/reports[/] directory. You can list, show, and filter reports using the following commands.[/]
 
 [dim]# List and filter reports...[/]
 r list                    [dim]# list all reports[/]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -246,14 +246,6 @@ class TestCli(unittest.TestCase):
 		assert result.exit_code == 0
 		assert 'No reports found' in result.output
 
-	def test_report_export_command(self):
-		# Since this would need an actual JSON file, we'll mock the file opening
-		with mock.patch('builtins.open', mock.mock_open(read_data='{"info":{"name":"test", "title": "test"}, "results":{}}')), \
-			 mock.patch('secator.cli.loads_dataclass', return_value={"info": {"name": "test", "title": "test"}, "results": {}}):
-				result = self.runner.invoke(cli, ['report', 'export', 'test.json', '--output', 'console'])
-				assert not result.exception
-				assert result.exit_code == 0
-
 	@mock.patch('secator.loader.get_configs_by_type')
 	def test_install_tools_command(self, mock_get_configs_by_type):
 		mock_get_configs_by_type.return_value = []


### PR DESCRIPTION
Removes the `secator r export` subcommand which is now useless.

Changes:
- Remove `report_export` CLI command
- Remove unused `loads_dataclass` import
- Remove `flatten` from utils imports
- Update cheatsheet text
- Remove `test_report_export_command` unit test

Closes #1039

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Removed the `report export` CLI command.

* **Documentation**
  * Updated CLI help documentation to reflect available report commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->