### PR TITLE
fix(exporters): create report.json with runner info at init when JSON exporter is configured

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -1042,7 +1042,7 @@ class Runner:
 		from secator.exporters.json import JsonExporter
 		if JsonExporter not in self.exporters:
 			return
-		if self.dry_run or self.no_process:
+		if not self.enable_reports:
 			return
 		json_path = Path(self.reports_folder) / 'report.json'
 		if not json_path.exists():

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -250,6 +250,9 @@ class Runner:
 		# Run hooks
 		self.run_hooks('on_init', sub='init')
 
+		# Create initial JSON report with runner info
+		self._init_json_report()
+
 	def _process_config(self, config):
 		"""Process the configuration in different formats (dict, TemplateLoader, DotMap).
 
@@ -1033,6 +1036,18 @@ class Runner:
 		)
 		# fmt: on
 		self._print(info, rich=True)
+
+	def _init_json_report(self):
+		"""Create initial report.json with runner info when JSON exporter is configured."""
+		from secator.exporters.json import JsonExporter
+		if JsonExporter not in self.exporters:
+			return
+		if self.dry_run or self.no_process:
+			return
+		json_path = Path(self.reports_folder) / 'report.json'
+		if not json_path.exists():
+			with open(json_path, 'w') as f:
+				json.dump({'info': self.toDict(), 'results': {}}, f, indent=2, default=str)
 
 	def export_reports(self):
 		"""Export reports."""


### PR DESCRIPTION
Fixes #1042

When JsonExporter is in the runner's exporters list, create reports_dir and write report.json pre-filled with runner.toDict() in 'info' key on runner init. The file is later overwritten with full results by export_reports() at completion.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * JSON report file (report.json) is now automatically created and seeded with initial metadata at execution start when the JSON exporter is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->