### PR TITLE
fix(mapcidr): prevent unsupported delay flag from being passed

### DIFF
--- a/secator/tasks/mapcidr.py
+++ b/secator/tasks/mapcidr.py
@@ -1,7 +1,10 @@
 import validators
 
 from secator.decorators import task
-from secator.definitions import CIDR_RANGE, DELAY, IP, OPT_NOT_SUPPORTED, PROXY, RATE_LIMIT, RETRIES, SLUG, THREADS, TIMEOUT
+
+from secator.definitions import (
+    CIDR_RANGE, DELAY, IP, OPT_NOT_SUPPORTED, PROXY, RATE_LIMIT, RETRIES, SLUG, THREADS, TIMEOUT
+)  # fmt: off
 from secator.output_types import Ip
 from secator.tasks._categories import ReconIp
 

--- a/secator/tasks/mapcidr.py
+++ b/secator/tasks/mapcidr.py
@@ -1,7 +1,7 @@
 import validators
 
 from secator.decorators import task
-from secator.definitions import CIDR_RANGE, IP, OPT_NOT_SUPPORTED, PROXY, RATE_LIMIT, RETRIES, SLUG, THREADS, TIMEOUT
+from secator.definitions import CIDR_RANGE, DELAY, IP, OPT_NOT_SUPPORTED, PROXY, RATE_LIMIT, RETRIES, SLUG, THREADS, TIMEOUT
 from secator.output_types import Ip
 from secator.tasks._categories import ReconIp
 
@@ -24,6 +24,7 @@ class mapcidr(ReconIp):
 		'hide_ips': {'is_flag': True, 'short': 'hi', 'default': False, 'help': 'Hide IP addresses from output (too verbose)', 'internal': True, 'display': True},  # noqa: E501
 	}
 	opt_key_map = {
+		DELAY: OPT_NOT_SUPPORTED,
 		THREADS: OPT_NOT_SUPPORTED,
 		PROXY: OPT_NOT_SUPPORTED,
 		RATE_LIMIT: OPT_NOT_SUPPORTED,


### PR DESCRIPTION
Fixes #1049 

## Summary

This PR fixes an issue where the `delay` option is incorrectly passed to the `mapcidr` task, causing it to fail.

## Problem

`mapcidr` does not support the `-delay` flag, but `secator` forwards it anyway because it is not declared in `opt_key_map` as unsupported.

This results in:
```
flag provided but not defined: -delay
```

## Fix

- Import `DELAY` from `secator.definitions`
- Add `DELAY: OPT_NOT_SUPPORTED` to `opt_key_map`

## Patch

```diff
-from secator.definitions import (CIDR_RANGE, IP, OPT_NOT_SUPPORTED, PROXY,
-                 RATE_LIMIT, RETRIES, THREADS, TIMEOUT, SLUG)
+from secator.definitions import (CIDR_RANGE, DELAY, IP, OPT_NOT_SUPPORTED, PROXY,
+           RATE_LIMIT, RETRIES, THREADS, TIMEOUT, SLUG)

 opt_key_map = {
+    DELAY: OPT_NOT_SUPPORTED,
     THREADS: OPT_NOT_SUPPORTED,
     PROXY: OPT_NOT_SUPPORTED,
     RATE_LIMIT: OPT_NOT_SUPPORTED,
```

## Impact

- Prevents runtime errors when using global options like `delay`
- Aligns `mapcidr` behavior with other tools that properly declare unsupported options

## Testing 

- Run `secator` with `delay` option before fix → error
- Run after fix → no error, option is ignored as expected

## Notes 

This follows the existing pattern used for other unsupported options in `opt_key_map`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration handling for option mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->