### PR TITLE
fix(runner): add fix for killing worker when CTRL + C on non-process grouped tasks

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -651,12 +651,24 @@ class Command(Runner):
 		yield error
 
 	def stop_process(self, exit_ok=False, sig=signal.SIGINT):
-		"""Sends SIGINT to running process, if any."""
+		"""Sends signal to running process, if any.
+
+		Uses killpg only when the subprocess has its own process group (preexec_fn=os.setsid).
+		Otherwise (disable_preexec=True or sudo), the subprocess shares the worker's pgid and
+		killpg would also kill the worker.
+		"""
 		if not self.process:
 			return
 		self.debug(f'Sending signal {signal_to_name(sig)} to process {self.process.pid}.', sub='error')
 		if self.process and self.process.pid:
-			os.killpg(os.getpgid(self.process.pid), sig)
+			try:
+				pgid = os.getpgid(self.process.pid)
+				if pgid == self.process.pid:
+					os.killpg(pgid, sig)
+				else:
+					os.kill(self.process.pid, sig)
+			except (ProcessLookupError, PermissionError):
+				pass
 		if exit_ok:
 			self.exit_ok = True
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced process termination handling to prevent accidental interruption of the worker process in certain execution environments (such as restricted privilege modes or specific configurations). Improved signal handling now safely checks process group relationships before termination and gracefully handles edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->