### PR TITLE
fix(tasks): wafw00f handle dict headers and missing JSON fields

### DIFF
--- a/secator/tasks/wafw00f.py
+++ b/secator/tasks/wafw00f.py
@@ -60,9 +60,14 @@ class wafw00f(Command):
 		if self.headers:
 			header_file = f'{self.reports_folder}/.inputs/headers.txt'
 			with open(header_file, 'w') as f:
-				for header in self.headers.split(';;'):
-					f.write(f'{header}\n')
-			self.cmd = self.cmd.replace(self.headers, header_file)
+				if isinstance(self.headers, dict):
+					for key, value in self.headers.items():
+						f.write(f'{key}:{value}\n')
+				else:
+					for header in self.headers.split(';;'):
+						f.write(f'{header}\n')
+			if isinstance(self.headers, str):
+				self.cmd = self.cmd.replace(self.headers, header_file)
 
 	@staticmethod
 	def on_cmd_done(self):
@@ -80,12 +85,12 @@ class wafw00f(Command):
 			results = yaml.safe_load(f.read())
 
 		for result in results:
-			if not result['detected']:
+			if not result.get('detected'):
 				continue
 			waf_name = result['firewall']
 			url = result['url']
-			match = result['trigger_url']
-			manufacter = result['manufacturer']
+			match = result.get('trigger_url', '')
+			manufacter = result.get('manufacturer', '')
 			yield Tag(
 				category='info',
 				name='waf',
@@ -103,6 +108,10 @@ class wafw00f(Command):
 		temp_dir = tempfile.gettempdir()
 		header_file = f'{temp_dir}/headers.txt'
 		with open(header_file, 'w') as f:
+			if isinstance(headers, dict):
+				for key, value in headers.items():
+					f.write(f'{key}:{value}\n')
+				return header_file
 			for header in headers.split(';;'):
 				f.write(f'{header}\n')
 		return header_file


### PR DESCRIPTION
Fix: #1054 

## Problem

The `wafw00f` task has three crashes:

1. **`AttributeError: 'dict' object has no attribute 'split'`**  `headers_to_file()` assumes headers is always a string, but the runner pipeline preprocesses it to a dict via `headers_to_dict`
2. **`TypeError: replace() argument 1 must be str, not dict`** `on_cmd()` calls `.split(';;')` and `.replace()` on headers, which crashes when it's a dict
3. **`KeyError: 'trigger_url'`** `on_cmd_done()` accesses `result['trigger_url']` and `result['manufacturer']` directly, but wafw00f JSON output doesn't always include these fields

## Fix

Three changes in `secator/tasks/wafw00f.py`:

- **`headers_to_file()`**: Added `isinstance(headers, dict)` branch iterates over `.items()` to write `key:value\n` pairs instead of calling `.split(';;')`
- **`on_cmd()`**: Added same dict handling for file writing. Wrapped `self.cmd.replace()` in `isinstance(self.headers, str)` check when headers is a dict, `opt_value_map` already inserted the file path in the command
- **`on_cmd_done()`**: Changed `result['trigger_url']` → `result.get('trigger_url', '')` and `result['manufacturer']` → `result.get('manufacturer', '')` to handle optional fields gracefully

## Backward Compatibility

All string paths are completely unchanged. The dict branches are purely additive. The `.get()` calls use empty string defaults matching the existing field types.

## Testing

Tested with secator v0.30.1 via CLI and Celery worker in Docker:

```bash
secator x wafw00f --header "test:value" https://example.com
```

Result: Cloudflare WAF detected correctly, no errors in both CLI and worker contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header input handling to support multiple formats
  * Enhanced result parsing reliability with safer field access and default value fallbacks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->