### PR TITLE
fix(cli): fix update and addon install in universal script / zsh envs

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1870,8 +1870,13 @@ def run_install(title=None, cmd=None, packages=None, next_steps=None):
 		sys.exit(1)
 	# with console.status(f'[bold yellow] Installing {title}...'):
 	if cmd:
+		import shlex
 		from secator.installer import SourceInstaller
 
+		# Quote the package specifier to prevent shell glob expansion of extras (e.g. secator[worker])
+		if '-m pip install' in cmd:
+			parts = cmd.rsplit(' ', 1)
+			cmd = parts[0] + ' ' + shlex.quote(parts[1])
 		status = SourceInstaller.install(cmd)
 	elif packages:
 		from secator.installer import PackageInstaller
@@ -2152,7 +2157,7 @@ def update(all):
 		if 'pipx' in sys.executable:
 			ret = Command.execute(f'pipx install secator=={latest_version} --force')
 		else:
-			ret = Command.execute(f'pip install secator=={latest_version}')
+			ret = Command.execute(f'{sys.executable} -m pip install secator=={latest_version}')
 		if not ret.return_code == 0:
 			sys.exit(1)
 


### PR DESCRIPTION
## Summary

- **`secator update`**: Was using bare `pip install` which resolves to whatever `pip` is first in `PATH`, not necessarily the one in the venv where secator lives. Fixed to use `sys.executable -m pip install` — the same pattern used everywhere else in the CLI.
- **`secator install addons <name>`**: The `run_install` helper delegates to `SourceInstaller` which runs commands with `shell=True`. In shells where `/bin/sh` expands glob patterns (or when zsh is involved), `secator[worker]` gets interpreted as a character-class glob. Fixed by calling `shlex.quote()` on the package specifier in `run_install` before passing it to `SourceInstaller`, producing a shell-safe single-quoted argument.

## Test plan

- [ ] Run `secator update` from a fresh universal-script install (`~/.secator` venv) and confirm it upgrades correctly
- [ ] Run `secator install addons worker` (and other addons) from within a separate activated virtualenv on zsh and confirm the addon installs without glob errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation handling to prevent shell expansion issues with package extras
  * Enhanced update process to use the correct Python interpreter for pip operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->