### PR TITLE
fix(templates): support nested dot notation in field extractor

### DIFF
--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -10,7 +10,7 @@ def _format_nested(template, data):
 	"""Format a string template supporting nested dot notation like {extra_data.password}.
 
 	Replaces {key} and {key.subkey} tokens by traversing nested dicts.
-	Raises KeyError for missing or non-traversable keys so misconfigured templates surface loudly.
+	Missing or non-traversable keys resolve to empty string.
 	"""
 	def replace_token(match):
 		key = match.group(1)
@@ -23,9 +23,7 @@ def _format_nested(template, data):
 				value = None
 			if value is None:
 				break
-		if value is None:
-			raise KeyError(f"Missing placeholder: {key}")
-		return str(value)
+		return str(value) if value is not None else ''
 	return re.sub(r'\{([\w.]+)\}', replace_token, template)
 
 
@@ -238,13 +236,17 @@ def process_extractor(results, extractor, ctx=None):
 				item_dict = item.toDict()
 				group_key = _format_nested(_group_by, item_dict)
 				value = _format_nested(_field, item_dict)
+				if not group_key or not value:
+					continue
 				prefix = value.split('~')[0] if '~' in value else value
+				if not prefix:
+					continue
 				bucket = groups.setdefault(group_key, [])
 				if prefix not in bucket:
 					bucket.append(prefix)
 			results = [','.join(hosts) + '~' + group_key for group_key, hosts in groups.items()]
 		else:
-			results = [_format_nested(_field, item.toDict()) for item in results]
+			results = [v for v in (_format_nested(_field, item.toDict()) for item in results) if v]
 	# debug('after extract', obj={'results_count': len(results), 'key': ctx.get('key')}, sub='extractor')
 	return results
 

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -10,6 +10,7 @@ def _format_nested(template, data):
 	"""Format a string template supporting nested dot notation like {extra_data.password}.
 
 	Replaces {key} and {key.subkey} tokens by traversing nested dicts.
+	Raises KeyError for missing or non-traversable keys so misconfigured templates surface loudly.
 	"""
 	def replace_token(match):
 		key = match.group(1)
@@ -22,7 +23,9 @@ def _format_nested(template, data):
 				value = None
 			if value is None:
 				break
-		return str(value) if value is not None else ''
+		if value is None:
+			raise KeyError(f"Missing placeholder: {key}")
+		return str(value)
 	return re.sub(r'\{([\w.]+)\}', replace_token, template)
 
 

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -6,6 +6,26 @@ from secator.output_types import Error
 from secator.utils import deduplicate, debug
 
 
+def _format_nested(template, data):
+	"""Format a string template supporting nested dot notation like {extra_data.password}.
+
+	Replaces {key} and {key.subkey} tokens by traversing nested dicts.
+	"""
+	def replace_token(match):
+		key = match.group(1)
+		keys = key.split('.')
+		value = data
+		for k in keys:
+			if isinstance(value, dict):
+				value = value.get(k)
+			else:
+				value = None
+			if value is None:
+				break
+		return str(value) if value is not None else ''
+	return re.sub(r'\{([\w.]+)\}', replace_token, template)
+
+
 def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 	"""Run extractors and merge extracted values with option dict.
 
@@ -212,15 +232,16 @@ def process_extractor(results, extractor, ctx=None):
 			_group_by = '{' + _group_by + '}' if not already_formatted_gb else _group_by
 			groups = {}
 			for item in results:
-				group_key = _group_by.format(**item.toDict())
-				value = _field.format(**item.toDict())
+				item_dict = item.toDict()
+				group_key = _format_nested(_group_by, item_dict)
+				value = _format_nested(_field, item_dict)
 				prefix = value.split('~')[0] if '~' in value else value
 				bucket = groups.setdefault(group_key, [])
 				if prefix not in bucket:
 					bucket.append(prefix)
 			results = [','.join(hosts) + '~' + group_key for group_key, hosts in groups.items()]
 		else:
-			results = [_field.format(**item.toDict()) for item in results]
+			results = [_format_nested(_field, item.toDict()) for item in results]
 	# debug('after extract', obj={'results_count': len(results), 'key': ctx.get('key')}, sub='extractor')
 	return results
 

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -221,14 +221,13 @@ class TestExtractorFunctions(unittest.TestCase):
         result = process_extractor(self.results, extractor)
         self.assertEqual(result, ['nested_value', 'nested_value', 'nested_value'])
 
-        # Test that missing nested key raises KeyError (no silent empty-string substitution)
+        # Test that missing nested key yields empty string, which is filtered from results
         extractor = {
             'type': 'mock',
             'field': '{nested.nonexistent}'
         }
-        with self.assertRaises(KeyError) as cm:
-            process_extractor(self.results, extractor)
-        self.assertIn('nested.nonexistent', str(cm.exception))
+        result = process_extractor(self.results, extractor)
+        self.assertEqual(result, [])
 
     def test_process_extractor_group_by_combines_hosts(self):
         """group_by groups items by key and joins matched_at values with comma."""

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -205,13 +205,21 @@ class TestExtractorFunctions(unittest.TestCase):
         result = process_extractor(self.results, extractor)
         self.assertEqual(result, ['test1', 'test2', 'test3'])
 
-        # TODO: Test nested field access
-        # extractor = {
-        #     'type': 'mock',
-        #     'field': '{nested.subfield}'
-        # }
-        # result = process_extractor(self.results, extractor)
-        # self.assertEqual(result, ['nested_value', 'nested_value', 'nested_value'])
+        # Test nested field access with dot notation
+        extractor = {
+            'type': 'mock',
+            'field': '{nested.subfield}'
+        }
+        result = process_extractor(self.results, extractor)
+        self.assertEqual(result, ['nested_value', 'nested_value', 'nested_value'])
+
+        # Test nested field without braces
+        extractor = {
+            'type': 'mock',
+            'field': 'nested.subfield'
+        }
+        result = process_extractor(self.results, extractor)
+        self.assertEqual(result, ['nested_value', 'nested_value', 'nested_value'])
 
     def test_process_extractor_group_by_combines_hosts(self):
         """group_by groups items by key and joins matched_at values with comma."""

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -221,6 +221,15 @@ class TestExtractorFunctions(unittest.TestCase):
         result = process_extractor(self.results, extractor)
         self.assertEqual(result, ['nested_value', 'nested_value', 'nested_value'])
 
+        # Test that missing nested key raises KeyError (no silent empty-string substitution)
+        extractor = {
+            'type': 'mock',
+            'field': '{nested.nonexistent}'
+        }
+        with self.assertRaises(KeyError) as cm:
+            process_extractor(self.results, extractor)
+        self.assertIn('nested.nonexistent', str(cm.exception))
+
     def test_process_extractor_group_by_combines_hosts(self):
         """group_by groups items by key and joins matched_at values with comma."""
         extractor = {


### PR DESCRIPTION
Fixes #1062

Add `_format_nested()` helper in `process_extractor` to resolve `{extra_data.password}`-style dot notation by traversing nested dicts, matching the pattern used in `secator/query/json.py`'s `get_nested_field()`.

Previously, `str.format(**item.toDict())` was used, which fails for nested fields because Python's format strings attempt attribute access on dicts rather than dict key traversal.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nested field references using dot-notation in template formatting, allowing users to access nested data with notation like `{nested.subfield}`.
  * Improved robustness of formatting operations with graceful handling of missing nested values—now returns empty strings instead of errors when referenced fields are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->