### PR TITLE
fix(workflows): use scan reports dir for storing results

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -286,9 +286,9 @@ class Runner:
 
 	@property
 	def file_name(self):
-		"""Filesystem-safe name for output files. Uses node_id when running inside a workflow/scan to avoid conflicts when the same task appears in multiple workflows."""
+		"""Filesystem-safe name for output files. Uses node_id when inside a workflow/scan to avoid conflicts."""
 		if self.config.node_id:
-			base = self.config.node_id.replace('.', '_')
+			base = self.config.node_id.replace('.', '_').replace('/', '_')
 		else:
 			base = self.name.replace('/', '_')
 		return f'{base}_{self.chunk}' if self.chunk else base

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -285,8 +285,8 @@ class Runner:
 		return {k: v for k, v in self.run_opts.items() if k.endswith('_')}
 
 	@property
-	def file_name(self):
-		"""Filesystem-safe name for output files. Uses node_id when inside a workflow/scan to avoid conflicts."""
+	def fqn(self):
+		"""Fully qualified name. Uses node_id when inside a workflow/scan to avoid conflicts."""
 		if self.config.node_id:
 			base = self.config.node_id.replace('.', '_').replace('/', '_')
 		else:
@@ -1060,7 +1060,7 @@ class Runner:
 		if self.enable_pyinstrument:
 			self.debug('stopping profiler', sub='end')
 			self.profiler.stop()
-			profile_path = Path(self.reports_folder) / f'{self.file_name}_profile.html'
+			profile_path = Path(self.reports_folder) / f'{self.fqn}_profile.html'
 			with profile_path.open('w', encoding='utf-8') as f_html:
 				f_html.write(self.profiler.output_html())
 			self._print_item(Info(message=f'Wrote profile to {str(profile_path)}'), force=True)

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -285,6 +285,15 @@ class Runner:
 		return {k: v for k, v in self.run_opts.items() if k.endswith('_')}
 
 	@property
+	def file_name(self):
+		"""Filesystem-safe name for output files. Uses node_id when running inside a workflow/scan to avoid conflicts when the same task appears in multiple workflows."""
+		if self.config.node_id:
+			base = self.config.node_id.replace('.', '_')
+		else:
+			base = self.name.replace('/', '_')
+		return f'{base}_{self.chunk}' if self.chunk else base
+
+	@property
 	def elapsed(self):
 		if self.done:
 			return self.end_time - self.start_time
@@ -1051,7 +1060,7 @@ class Runner:
 		if self.enable_pyinstrument:
 			self.debug('stopping profiler', sub='end')
 			self.profiler.stop()
-			profile_path = Path(self.reports_folder) / f'{self.unique_name}_profile.html'
+			profile_path = Path(self.reports_folder) / f'{self.file_name}_profile.html'
 			with profile_path.open('w', encoding='utf-8') as f_html:
 				f_html.write(self.profiler.output_html())
 			self._print_item(Info(message=f'Wrote profile to {str(profile_path)}'), force=True)

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -1229,7 +1229,7 @@ class Command(Runner):
 		# If inputs has multiple elements and the tool has input_flag set to OPT_PIPE_INPUT, use cat-piped_input input.
 		# Otherwise pass the file path to the tool.
 		else:
-			fpath = f'{self.reports_folder}/.inputs/{self.file_name}.txt'
+			fpath = f'{self.reports_folder}/.inputs/{self.fqn}.txt'
 
 			# Write the input to a file
 			with open(fpath, 'w') as f:
@@ -1238,7 +1238,7 @@ class Command(Runner):
 					f.write('\n')
 
 			if self.file_copy_sudo:
-				sudo_fpath = f'/tmp/{self.file_name}.txt'
+				sudo_fpath = f'/tmp/{self.fqn}.txt'
 				shutil.copy(fpath, sudo_fpath)
 				fpath = sudo_fpath
 

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -1229,7 +1229,7 @@ class Command(Runner):
 		# If inputs has multiple elements and the tool has input_flag set to OPT_PIPE_INPUT, use cat-piped_input input.
 		# Otherwise pass the file path to the tool.
 		else:
-			fpath = f'{self.reports_folder}/.inputs/{self.unique_name}.txt'
+			fpath = f'{self.reports_folder}/.inputs/{self.file_name}.txt'
 
 			# Write the input to a file
 			with open(fpath, 'w') as f:
@@ -1238,7 +1238,7 @@ class Command(Runner):
 					f.write('\n')
 
 			if self.file_copy_sudo:
-				sudo_fpath = f'/tmp/{self.unique_name}.txt'
+				sudo_fpath = f'/tmp/{self.file_name}.txt'
 				shutil.copy(fpath, sudo_fpath)
 				fpath = sudo_fpath
 

--- a/secator/runners/scan.py
+++ b/secator/runners/scan.py
@@ -43,6 +43,7 @@ class Scan(Runner):
 			run_opts['has_parent'] = True
 			run_opts['enable_reports'] = False
 			run_opts['print_profiles'] = False
+			run_opts['reports_folder'] = str(self.reports_folder)
 			opts = merge_opts(scan_opts, workflow_opts, run_opts)
 			name = name.split('/')[0]
 			config = TemplateLoader(name=f'workflow/{name}')

--- a/secator/tasks/arjun.py
+++ b/secator/tasks/arjun.py
@@ -68,7 +68,7 @@ class arjun(HttpBase):
 
 		self.output_path = self.get_opt_value(OUTPUT_PATH)
 		if not self.output_path:
-			self.output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
+			self.output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'
 		self.cmd += f' -oJ {shlex.quote(self.output_path)}'
 
 	@staticmethod

--- a/secator/tasks/arjun.py
+++ b/secator/tasks/arjun.py
@@ -68,7 +68,7 @@ class arjun(HttpBase):
 
 		self.output_path = self.get_opt_value(OUTPUT_PATH)
 		if not self.output_path:
-			self.output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.json'
+			self.output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
 		self.cmd += f' -oJ {shlex.quote(self.output_path)}'
 
 	@staticmethod

--- a/secator/tasks/dirsearch.py
+++ b/secator/tasks/dirsearch.py
@@ -70,7 +70,7 @@ class dirsearch(HttpFuzzer):
 	def on_init(self):
 		self.output_path = self.get_opt_value(OUTPUT_PATH)
 		if not self.output_path:
-			self.output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.json'
+			self.output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
 		self.cmd += f' -o {shlex.quote(self.output_path)}'
 
 	@staticmethod

--- a/secator/tasks/dirsearch.py
+++ b/secator/tasks/dirsearch.py
@@ -70,7 +70,7 @@ class dirsearch(HttpFuzzer):
 	def on_init(self):
 		self.output_path = self.get_opt_value(OUTPUT_PATH)
 		if not self.output_path:
-			self.output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
+			self.output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'
 		self.cmd += f' -o {shlex.quote(self.output_path)}'
 
 	@staticmethod

--- a/secator/tasks/gitleaks.py
+++ b/secator/tasks/gitleaks.py
@@ -68,7 +68,7 @@ class gitleaks(Command):
 		# add output path
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'
 		self.output_path = output_path
 		self.cmd += f' -r {shlex.quote(self.output_path)}'
 		self.cmd += ' --exit-code 0'

--- a/secator/tasks/gitleaks.py
+++ b/secator/tasks/gitleaks.py
@@ -68,7 +68,7 @@ class gitleaks(Command):
 		# add output path
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
 		self.output_path = output_path
 		self.cmd += f' -r {shlex.quote(self.output_path)}'
 		self.cmd += ' --exit-code 0'

--- a/secator/tasks/h8mail.py
+++ b/secator/tasks/h8mail.py
@@ -31,7 +31,7 @@ class h8mail(OSInt):
 	def on_start(self):
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'
 		self.output_path = output_path
 		output_path_quoted = shlex.quote(self.output_path)
 		self.cmd = self.cmd.replace('--json ', f'--json {output_path_quoted} ')

--- a/secator/tasks/h8mail.py
+++ b/secator/tasks/h8mail.py
@@ -31,7 +31,7 @@ class h8mail(OSInt):
 	def on_start(self):
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
 		self.output_path = output_path
 		output_path_quoted = shlex.quote(self.output_path)
 		self.cmd = self.cmd.replace('--json ', f'--json {output_path_quoted} ')

--- a/secator/tasks/nmap.py
+++ b/secator/tasks/nmap.py
@@ -143,7 +143,7 @@ class nmap(ReconPort):
 	def on_cmd(self):
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.xml'
+			output_path = f'{self.reports_folder}/.outputs/{self.fqn}.xml'
 		self.output_path = output_path
 		self.cmd += f' -oX {shlex.quote(self.output_path)}'
 		tcp_syn_stealth = self.cmd_options.get('tcp_syn_stealth')

--- a/secator/tasks/nmap.py
+++ b/secator/tasks/nmap.py
@@ -143,7 +143,7 @@ class nmap(ReconPort):
 	def on_cmd(self):
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.xml'
+			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.xml'
 		self.output_path = output_path
 		self.cmd += f' -oX {shlex.quote(self.output_path)}'
 		tcp_syn_stealth = self.cmd_options.get('tcp_syn_stealth')

--- a/secator/tasks/testssl.py
+++ b/secator/tasks/testssl.py
@@ -69,7 +69,7 @@ class testssl(Command):
 	def on_cmd(self):
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
 		self.output_path = output_path
 		self.cmd += f' --jsonfile {shlex.quote(self.output_path)}'
 

--- a/secator/tasks/testssl.py
+++ b/secator/tasks/testssl.py
@@ -69,7 +69,7 @@ class testssl(Command):
 	def on_cmd(self):
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'
 		self.output_path = output_path
 		self.cmd += f' --jsonfile {shlex.quote(self.output_path)}'
 

--- a/secator/tasks/trivy.py
+++ b/secator/tasks/trivy.py
@@ -73,7 +73,7 @@ class trivy(Vuln):
 
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
 		self.output_path = output_path
 		self.cmd = self.cmd.replace(f' -mode {mode}', '').replace('trivy', f'trivy {mode}')
 		self.cmd += f' -o {shlex.quote(self.output_path)}'

--- a/secator/tasks/trivy.py
+++ b/secator/tasks/trivy.py
@@ -73,7 +73,7 @@ class trivy(Vuln):
 
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'
 		self.output_path = output_path
 		self.cmd = self.cmd.replace(f' -mode {mode}', '').replace('trivy', f'trivy {mode}')
 		self.cmd += f' -o {shlex.quote(self.output_path)}'

--- a/secator/tasks/wafw00f.py
+++ b/secator/tasks/wafw00f.py
@@ -53,7 +53,7 @@ class wafw00f(Command):
 	def on_cmd(self):
 		self.output_path = self.get_opt_value(OUTPUT_PATH)
 		if not self.output_path:
-			self.output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.json'
+			self.output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
 		self.cmd += f' -o {shlex.quote(self.output_path)}'
 
 		self.headers = self.get_opt_value(HEADER)

--- a/secator/tasks/wafw00f.py
+++ b/secator/tasks/wafw00f.py
@@ -53,7 +53,7 @@ class wafw00f(Command):
 	def on_cmd(self):
 		self.output_path = self.get_opt_value(OUTPUT_PATH)
 		if not self.output_path:
-			self.output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
+			self.output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'
 		self.cmd += f' -o {shlex.quote(self.output_path)}'
 
 		self.headers = self.get_opt_value(HEADER)

--- a/secator/tasks/wpprobe.py
+++ b/secator/tasks/wpprobe.py
@@ -47,7 +47,7 @@ class wpprobe(Command):
 		self.cmd = re.sub(wpprobe.cmd, f'{wpprobe.cmd} {mode}', self.cmd, 1)
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'
 		self.output_path = output_path
 		self.cmd += f' -o {shlex.quote(self.output_path)}'
 

--- a/secator/tasks/wpprobe.py
+++ b/secator/tasks/wpprobe.py
@@ -47,7 +47,7 @@ class wpprobe(Command):
 		self.cmd = re.sub(wpprobe.cmd, f'{wpprobe.cmd} {mode}', self.cmd, 1)
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
 		self.output_path = output_path
 		self.cmd += f' -o {shlex.quote(self.output_path)}'
 

--- a/secator/tasks/wpscan.py
+++ b/secator/tasks/wpscan.py
@@ -96,7 +96,7 @@ class wpscan(VulnHttp):
 	def on_init(self):
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'
 		self.output_path = output_path
 		self.cmd += f' -o {shlex.quote(self.output_path)}'
 

--- a/secator/tasks/wpscan.py
+++ b/secator/tasks/wpscan.py
@@ -96,7 +96,7 @@ class wpscan(VulnHttp):
 	def on_init(self):
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
-			output_path = f'{self.reports_folder}/.outputs/{self.unique_name}.json'
+			output_path = f'{self.reports_folder}/.outputs/{self.file_name}.json'
 		self.output_path = output_path
 		self.cmd += f' -o {shlex.quote(self.output_path)}'
 


### PR DESCRIPTION
Workflows currently store their results in their own directories even when they are part of a scan. This fix passes the scan's `reports_folder` to child workflows so all results are saved to the scan's directory.

Fixes #1061

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reports folder path handling for workflow execution to ensure proper report destination assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->