### PR TITLE
fix(target-filtering): secondary task should not take ancestor results as direct input

### DIFF
--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -44,15 +44,11 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		inputs = []
 	if ctx is None:
 		ctx = {}
-	# Pull parent_scope and node_chain_start from opts when not in ctx
-	# (_run_extractors in _base.py only adds ancestor_id to ctx)
 	if 'parent_scope' not in ctx:
 		ctx['parent_scope'] = opts.get('parent_scope')
 	if 'node_chain_start' not in ctx:
 		ctx['node_chain_start'] = opts.get('node_chain_start', False)
 	parent_scope = ctx.get('parent_scope')
-	ancestor_id = ctx.get('ancestor_id')
-	node_chain_start = ctx.get('node_chain_start', False)
 	extractors = {k: v for k, v in opts.items() if k.endswith('_')}
 	if dry_run:
 		input_extractors = {k: v for k, v in extractors.items() if k.rstrip('_') == 'targets'}

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -92,19 +92,11 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		debug('computed_inputs', obj=computed_inputs, sub='extractors')
 		inputs = computed_inputs
 	elif parent_scope and not opts.get('chunk'):
-		_meta_types = {'info', 'progress', 'state', 'error', 'target'}  # 'target' handled separately via scoped_targets above
 		scoped_targets = [
 			item.name for item in results
 			if item._type == 'target' and item._context.get('scope') == parent_scope
 		]
-		if not node_chain_start and ancestor_id:
-			ancestor_results = [
-				str(item) for item in results
-				if item._context.get('ancestor_id') == str(ancestor_id) and item._type not in _meta_types
-			]
-			combined = deduplicate(scoped_targets + ancestor_results)
-		else:
-			combined = deduplicate(scoped_targets)
+		combined = deduplicate(scoped_targets)
 		if combined:
 			debug('using scope-tagged targets as inputs', obj=combined, sub='extractors')
 			inputs = combined

--- a/tests/unit/test_target_filtering.py
+++ b/tests/unit/test_target_filtering.py
@@ -256,23 +256,6 @@ class TestRunExtractorsScopeFallback(unittest.TestCase):
         self.assertNotIn('other.com:80', inputs)
         self.assertNotIn('original.com', inputs)
 
-    def test_non_first_task_includes_ancestor_id_results(self):
-        """Non-first tasks (node_chain_start=False) must include ancestor_id-scoped results."""
-        t = Target(name='localhost:445')
-        t._context['scope'] = 'url_crawler'
-        url = Url(url='https://localhost:445/')
-        url._context['ancestor_id'] = 'url_crawler'
-        results = [t, url]
-
-        inputs, _, errors = run_extractors(
-            results, {},
-            inputs=[],
-            ctx={'parent_scope': 'url_crawler', 'ancestor_id': 'url_crawler', 'node_chain_start': False}
-        )
-        self.assertEqual(errors, [])
-        self.assertIn('localhost:445', inputs)
-        self.assertIn('https://localhost:445/', inputs)
-
     def test_fallback_preserves_original_inputs_when_no_scoped_targets(self):
         """If parent_scope set but no matching scope targets and no ancestor_id results, keep original inputs."""
         unscoped = Target(name='other.com')


### PR DESCRIPTION
Remove the ancestor_id-based fallback that caused secondary workflow tasks without input extractors to receive all ancestor results as direct targets. Now only scope-tagged Target objects are used as fallback inputs.

Also removes the test `test_non_first_task_includes_ancestor_id_results` that validated the unwanted behavior.

Fixes #1074

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified target combination logic when parent scope filtering is enabled. Input targets now derive exclusively from scope-matched results with consistent de-duplication.

* **Tests**
  * Updated target filtering test cases to align with revised scope-based target selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->