### PR TITLE
fix(tests): update getasn integration test inputs and expected outputs

### DIFF
--- a/tests/integration/inputs.py
+++ b/tests/integration/inputs.py
@@ -6,7 +6,7 @@ INPUTS_TASKS = {
 	USERNAME: 'ocervell',
 	IP: '127.0.0.1',
 	CIDR_RANGE: '192.168.1.0/24',
-	'getasn': 'wikipedia.org',
+	'getasn': 'tesla',
 	'arjun': 'https://xss-game.appspot.com/level1/frame',
     'bbot': False, # disable bbot test
 	'bup': 'http://localhost:3000/ftp/coupons_2013.md.bak',

--- a/tests/integration/outputs.py
+++ b/tests/integration/outputs.py
@@ -175,7 +175,7 @@ OUTPUTS_TASKS = {
         Url(url='http://xss-game.appspot.com/feedback/level1/file/level.py', _source='gau')
     ],
     'getasn': [
-        Tag(name='asn', category='info', value='AS14907', match='wikipedia.org', _source='getasn')
+        Tag(name='asn', category='info', value='AS51602', match='tesla', _source='getasn')
     ],
     'gf': [
         Tag(name='xss', category='url_pattern', value='http://localhost:3000?q=test', match='http://localhost:3000?q=test', _source='gf')


### PR DESCRIPTION
Change getasn input from `wikipedia.org` to `tesla` and update expected ASN tag from AS14907/wikipedia.org to AS51602/tesla due to new blockages on bgp.he.net.

Closes #1083

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures and expected outputs for integration tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/freelabz/secator/pull/1084)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->