### PR TITLE
fix(httpx): bump httpx to v1.9.0

### DIFF
--- a/secator/tasks/httpx.py
+++ b/secator/tasks/httpx.py
@@ -96,7 +96,7 @@ class httpx(Http):
 	}
 	item_loaders = [JSONSerializer()]
 	install_pre = {'apk': ['chromium']}
-	install_version = 'v1.7.0'
+	install_version = 'v1.9.0'
 	install_cmd = 'go install -v github.com/projectdiscovery/httpx/cmd/httpx@[install_version]'
 	github_handle = 'projectdiscovery/httpx'
 	install_binary_name = 'httpx-toolkit'  # Rename to avoid conflict with Python httpx library


### PR DESCRIPTION
## Problem

The sitemap showed **IP addresses instead of domain names** in the hierarchy.

Root cause: httpx `<1.9.0` returned the *resolved IP address* in its JSON `host` field (e.g. for input `media.example.synology.me`, it emitted `"host": "82.61.x.x"`). secator stores that as `Url.host`, and the sitemap's `_roots` aggregation groups by `host`, so every domain scanned via httpx collapsed into its resolved IP.

## Fix

This was an upstream httpx bug, fixed in [projectdiscovery/httpx#2333](https://github.com/projectdiscovery/httpx/pull/2333). Bumping the pinned `install_version` from `v1.7.0` → `v1.9.0` makes httpx emit the actual hostname in `host`. No secator code change needed.

## Verification

```
$ secator x httpx secator.cloud --json
{"url": "https://secator.cloud", "host": "secator.cloud", ...}
```

`host` is now the domain (`secator.cloud`) instead of the resolved IP. Unit suite (`tests/unit/test_tasks.py`) passes.

## Scope

Affects **new** scan data going forward. Existing findings already stored with IP hosts are not changed retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)