### PR TITLE
fix(nuclei): add -nh / -no-httpx option

### DIFF
--- a/secator/configs/workflows/host_recon.yaml
+++ b/secator/configs/workflows/host_recon.yaml
@@ -84,6 +84,7 @@ tasks:
     nuclei/network:
       description: Scan network and SSL vulnerabilities
       tags: [network, ssl]
+      no_httpx: true
       if: opts.nuclei and not opts.passive
 
     nuclei/url:

--- a/secator/tasks/nuclei.py
+++ b/secator/tasks/nuclei.py
@@ -53,6 +53,7 @@ class nuclei(VulnMulti):
 		'no_interactsh': {'is_flag': True, 'default': False, 'short': 'ni', 'help': 'Disable InteractSH server for OAST testing, exclude OAST based templates'},  # noqa: E501
 		'logs': {'is_flag': True, 'internal': True, 'display': True, 'help': 'Log errors (-elog) and traces (-tlog) to output dir'},  # noqa: E501
 		'new_templates': {'type': str, 'short': 'nt', 'help': 'Run only new templates added in latest nuclei-templates release'},  # noqa: E501
+		'no_httpx': {'is_flag': True, 'short': 'nh', 'help': 'Disable httpx probing for non-url inputs'},
 		'omit_raw': {'is_flag': True, 'short': 'or', 'default': True, 'help': 'Omit requests/response pairs in the JSON, JSONL, and Markdown outputs (for findings only)'},  # noqa: E501
 		'response_size_read': {'type': int, 'default': CONFIG.http.response_max_size_bytes, 'help': 'Max body size to read (bytes)'},  # noqa: E501
 		'severity': {'type': str, 'short': 's', 'help': 'Templates to run based on severity. Possible values: info, low, medium, high, critical, unknown'},  # noqa: E501


### PR DESCRIPTION
Add `-nh` / `-no-httpx` flag support to `nuclei`, and set it to True in the `host_recon`  workflow when we only process IPs.