### PR TITLE
feat: dynamic driver and exporter loading

### DIFF
--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -12,23 +12,23 @@ from rich.console import Console
 
 from secator.config import CONFIG
 from secator.click import CLICK_LIST
-from secator.definitions import ADDONS_ENABLED, AVAILABLE_DRIVERS, AVAILABLE_EXPORTERS
+from secator.definitions import ADDONS_ENABLED
 from secator.runners import Scan, Task, Workflow
 from secator.template import get_config_options
 from secator.tree import build_runner_tree, prune_runner_tree
 from secator.utils import deduplicate, expand_input, get_command_category
-from secator.loader import get_configs_by_type
+from secator.loader import get_configs_by_type, get_available_drivers, get_available_exporters
 from secator.completion import complete_profiles, complete_workspaces, complete_drivers, complete_exporters
 
 
 WORKSPACES = next(os.walk(CONFIG.dirs.reports))[1]
 WORKSPACES_STR = '|'.join([f'[dim yellow3]{_}[/]' for _ in WORKSPACES])
 PROFILES_STR = ','.join([f'[dim yellow3]{_.name}[/]' for _ in get_configs_by_type('profile')])
-DRIVERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in AVAILABLE_DRIVERS])
+DRIVERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in get_available_drivers()])
 DRIVER_DEFAULTS_STR = ','.join(CONFIG.drivers.defaults) if CONFIG.drivers.defaults else None
 PROFILE_DEFAULTS_STR = ','.join(CONFIG.profiles.defaults) if CONFIG.profiles.defaults else None
 WORKSPACE_DEFAULT_STR = CONFIG.workspace.default if CONFIG.workspace.default else 'default'
-EXPORTERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in AVAILABLE_EXPORTERS])
+EXPORTERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in get_available_exporters()])
 
 CLI_OUTPUT_OPTS = {
 	'output': {'type': str, 'default': None, 'help': f'Output options [{EXPORTERS_STR}] [dim orange4](comma-separated)[/]', 'short': 'o', 'shell_complete': complete_exporters},  # noqa: E501
@@ -281,11 +281,11 @@ def register_runner(cli_endpoint, config):
 		hooks = []
 		drivers = driver.split(',') if driver else []
 		drivers = list(set(CONFIG.drivers.defaults + drivers))
-		supported_drivers = AVAILABLE_DRIVERS
+		supported_drivers = get_available_drivers()
 		context['drivers'] = []
 		for driver in drivers:
 			if driver in supported_drivers:
-				if not ADDONS_ENABLED[driver]:
+				if driver in ADDONS_ENABLED and not ADDONS_ENABLED[driver]:
 					console.print(f'[bold red]Missing "{driver}" addon: please run `secator install addons {driver}`[/].')
 					sys.exit(1)
 				from secator.utils import import_dynamic

--- a/secator/completion.py
+++ b/secator/completion.py
@@ -4,8 +4,7 @@ import os
 from click.shell_completion import CompletionItem
 
 from secator.config import CONFIG
-from secator.definitions import AVAILABLE_DRIVERS, AVAILABLE_EXPORTERS
-from secator.loader import get_configs_by_type
+from secator.loader import get_configs_by_type, get_available_drivers, get_available_exporters
 
 
 def complete_profiles(ctx, param, incomplete):
@@ -36,7 +35,7 @@ def complete_drivers(ctx, param, incomplete):
 	"""Complete driver names."""
 	return [
 		CompletionItem(name)
-		for name in AVAILABLE_DRIVERS
+		for name in get_available_drivers()
 		if name.startswith(incomplete)
 	]
 
@@ -45,6 +44,6 @@ def complete_exporters(ctx, param, incomplete):
 	"""Complete exporter names."""
 	return [
 		CompletionItem(name)
-		for name in AVAILABLE_EXPORTERS
+		for name in get_available_exporters()
 		if name.startswith(incomplete)
 	]

--- a/secator/loader.py
+++ b/secator/loader.py
@@ -11,9 +11,27 @@ import inspect
 import sys
 
 
+def _file_has_hooks(path):
+	"""Check if a Python file contains a HOOKS variable (driver indicator)."""
+	try:
+		return 'HOOKS =' in path.read_text()
+	except Exception:
+		return False
+
+
+def _file_has_exporter(path):
+	"""Check if a Python file contains an Exporter subclass."""
+	try:
+		return '(Exporter)' in path.read_text()
+	except Exception:
+		return False
+
+
 @cache
 def find_templates():
 	discover_tasks()  # always load tasks first
+	discover_external_drivers()  # load external drivers
+	discover_external_exporters()  # load external exporters
 	results = []
 	dirs = [CONFIGS_FOLDER]
 	if CONFIG.dirs.templates:
@@ -99,6 +117,8 @@ def discover_external_tasks():
 	prev_state = sys.dont_write_bytecode
 	sys.dont_write_bytecode = True
 	for path in CONFIG.dirs.templates.glob('**/*.py'):
+		if _file_has_hooks(path) or _file_has_exporter(path):
+			continue  # Skip driver/exporter files
 		try:
 			task_name = path.stem
 			module_name = f'secator.tasks.{task_name}'
@@ -127,3 +147,92 @@ def discover_external_tasks():
 			console.print(f'[bold red]Could not load external module {path.name}. Reason: {str(e)}.[/] ({path})')
 	sys.dont_write_bytecode = prev_state
 	return output
+
+
+@cache
+def discover_external_drivers():
+	"""Find external secator drivers."""
+	output = []
+	prev_state = sys.dont_write_bytecode
+	sys.dont_write_bytecode = True
+	for path in CONFIG.dirs.templates.glob('**/*.py'):
+		if not _file_has_hooks(path):
+			continue
+		try:
+			driver_name = path.stem
+			module_name = f'secator.hooks.{driver_name}'
+
+			spec = importlib.util.spec_from_file_location(module_name, path)
+			module = importlib.util.module_from_spec(spec)
+			if not spec:
+				console.print(f'[bold red]Could not load external driver {path.name}: invalid import spec.[/] ({path})')
+				continue
+			sys.modules[module_name] = module
+			spec.loader.exec_module(module)
+
+			if not hasattr(module, 'HOOKS'):
+				console.print(f'[bold orange1]Could not load external driver "{driver_name}" from {path.name}: missing HOOKS variable.[/] ({path})')  # noqa: E501
+				continue
+			console.print(f'[bold green]Successfully loaded external driver "{driver_name}"[/] ({path})')
+			output.append(driver_name)
+		except Exception as e:
+			console.print(f'[bold red]Could not load external driver from {path.name}. Reason: {str(e)}.[/] ({path})')
+	sys.dont_write_bytecode = prev_state
+	return output
+
+
+@cache
+def discover_external_exporters():
+	"""Find external secator exporters."""
+	import secator.exporters as exporters_pkg
+	from secator.exporters._base import Exporter
+	output = []
+	prev_state = sys.dont_write_bytecode
+	sys.dont_write_bytecode = True
+	for path in CONFIG.dirs.templates.glob('**/*.py'):
+		if not _file_has_exporter(path):
+			continue
+		try:
+			module_path = path.stem
+			module_name = f'secator.exporters.{module_path}'
+
+			spec = importlib.util.spec_from_file_location(module_name, path)
+			module = importlib.util.module_from_spec(spec)
+			if not spec:
+				console.print(f'[bold red]Could not load external exporter {path.name}: invalid import spec.[/] ({path})')
+				continue
+			sys.modules[module_name] = module
+			spec.loader.exec_module(module)
+
+			found = False
+			for attr_name in dir(module):
+				attr = getattr(module, attr_name)
+				if inspect.isclass(attr) and issubclass(attr, Exporter) and attr is not Exporter:
+					name_lower = attr_name.lower()
+					exporter_name = name_lower[:-8] if name_lower.endswith('exporter') else name_lower
+					lookup_name = exporter_name.capitalize() + 'Exporter'
+					setattr(exporters_pkg, lookup_name, attr)
+					console.print(f'[bold green]Successfully loaded external exporter "{exporter_name}"[/] ({path})')
+					output.append(exporter_name)
+					found = True
+
+			if not found:
+				console.print(f'[bold orange1]Could not load external exporter from {path.name}: no Exporter subclass found.[/] ({path})')  # noqa: E501
+		except Exception as e:
+			console.print(f'[bold red]Could not load external exporter from {path.name}. Reason: {str(e)}.[/] ({path})')
+	sys.dont_write_bytecode = prev_state
+	return output
+
+
+@cache
+def get_available_drivers():
+	"""Get all available drivers (internal + external)."""
+	from secator.definitions import AVAILABLE_DRIVERS
+	return AVAILABLE_DRIVERS + discover_external_drivers()
+
+
+@cache
+def get_available_exporters():
+	"""Get all available exporters (internal + external)."""
+	from secator.definitions import AVAILABLE_EXPORTERS
+	return AVAILABLE_EXPORTERS + discover_external_exporters()

--- a/secator/loader.py
+++ b/secator/loader.py
@@ -163,10 +163,10 @@ def discover_external_drivers():
 			module_name = f'secator.hooks.{driver_name}'
 
 			spec = importlib.util.spec_from_file_location(module_name, path)
-			module = importlib.util.module_from_spec(spec)
 			if not spec:
 				console.print(f'[bold red]Could not load external driver {path.name}: invalid import spec.[/] ({path})')
 				continue
+			module = importlib.util.module_from_spec(spec)
 			sys.modules[module_name] = module
 			spec.loader.exec_module(module)
 

--- a/secator/loader.py
+++ b/secator/loader.py
@@ -125,10 +125,10 @@ def discover_external_tasks():
 
 			# console.print(f'Importing module {module_name} from {path}')
 			spec = importlib.util.spec_from_file_location(module_name, path)
-			module = importlib.util.module_from_spec(spec)
 			if not spec:
 				console.print(f'[bold red]Could not load external module {path.name}: invalid import spec.[/] ({path})')
 				continue
+			module = importlib.util.module_from_spec(spec)
 			# console.print(f'Adding module "{module_name}" to sys path')
 			sys.modules[module_name] = module
 

--- a/tests/fixtures/test_driver.py
+++ b/tests/fixtures/test_driver.py
@@ -1,0 +1,5 @@
+HOOKS = {
+    'Task': {},
+    'Workflow': {},
+    'Scan': {},
+}

--- a/tests/fixtures/test_exporter.py
+++ b/tests/fixtures/test_exporter.py
@@ -1,0 +1,6 @@
+from secator.exporters._base import Exporter
+
+
+class TestExporter(Exporter):
+    def send(self):
+        pass

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1,0 +1,343 @@
+import shutil
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from secator.config import CONFIG
+from secator.utils_test import FIXTURES_DIR, clear_modules
+
+DRIVER_FIXTURE = Path(FIXTURES_DIR) / 'test_driver.py'
+EXPORTER_FIXTURE = Path(FIXTURES_DIR) / 'test_exporter.py'
+
+
+def _clear_loader_caches():
+    """Clear @cache results for all loader discovery functions."""
+    from secator import loader
+    for name in [
+        'discover_external_drivers',
+        'discover_external_exporters',
+        'discover_external_tasks',
+        'discover_tasks',
+        'get_available_drivers',
+        'get_available_exporters',
+        'find_templates',
+        'get_configs_by_type',
+    ]:
+        fn = getattr(loader, name, None)
+        if fn and hasattr(fn, 'cache_clear'):
+            fn.cache_clear()
+
+
+class TestFileDetectionHelpers(unittest.TestCase):
+    """Unit tests for _file_has_hooks and _file_has_exporter."""
+
+    def setUp(self):
+        self.template_dir = CONFIG.dirs.templates
+        self.template_dir.mkdir(parents=True, exist_ok=True)
+        self._tmp = []
+
+    def tearDown(self):
+        for f in self._tmp:
+            if f.exists():
+                f.unlink()
+
+    def _tmp_file(self, name, content):
+        path = self.template_dir / name
+        path.write_text(content)
+        self._tmp.append(path)
+        return path
+
+    def test_file_has_hooks_true(self):
+        from secator.loader import _file_has_hooks
+        f = self._tmp_file('hooks_yes.py', 'HOOKS = {}\n')
+        self.assertTrue(_file_has_hooks(f))
+
+    def test_file_has_hooks_false(self):
+        from secator.loader import _file_has_hooks
+        f = self._tmp_file('hooks_no.py', 'class Foo:\n    pass\n')
+        self.assertFalse(_file_has_hooks(f))
+
+    def test_file_has_hooks_nonexistent_returns_false(self):
+        from secator.loader import _file_has_hooks
+        self.assertFalse(_file_has_hooks(self.template_dir / 'missing_file.py'))
+
+    def test_file_has_exporter_true(self):
+        from secator.loader import _file_has_exporter
+        f = self._tmp_file('exp_yes.py', 'class Foo(Exporter):\n    pass\n')
+        self.assertTrue(_file_has_exporter(f))
+
+    def test_file_has_exporter_false(self):
+        from secator.loader import _file_has_exporter
+        f = self._tmp_file('exp_no.py', 'class Foo:\n    pass\n')
+        self.assertFalse(_file_has_exporter(f))
+
+    def test_file_has_exporter_nonexistent_returns_false(self):
+        from secator.loader import _file_has_exporter
+        self.assertFalse(_file_has_exporter(self.template_dir / 'missing_file.py'))
+
+
+class TestDiscoverExternalDrivers(unittest.TestCase):
+    """Tests for discover_external_drivers."""
+
+    def setUp(self):
+        self.template_dir = CONFIG.dirs.templates
+        self.template_dir.mkdir(parents=True, exist_ok=True)
+        self.driver_path = self.template_dir / 'test_driver.py'
+        clear_modules()
+        _clear_loader_caches()
+
+    def tearDown(self):
+        if self.driver_path.exists():
+            self.driver_path.unlink()
+        for key in list(sys.modules.keys()):
+            if 'secator.hooks.test_driver' in key:
+                del sys.modules[key]
+        _clear_loader_caches()
+
+    def test_valid_driver_is_discovered(self):
+        """Driver file with HOOKS dict is picked up by discover_external_drivers."""
+        shutil.copyfile(DRIVER_FIXTURE, self.driver_path)
+        from secator.loader import discover_external_drivers
+        result = discover_external_drivers()
+        self.assertIn('test_driver', result)
+
+    def test_no_driver_files_returns_empty(self):
+        """No driver files in the templates dir → driver not in result."""
+        from secator.loader import discover_external_drivers
+        result = discover_external_drivers()
+        self.assertNotIn('test_driver', result)
+
+    def test_driver_missing_hooks_attribute_is_skipped(self):
+        """File whose text matches 'HOOKS =' but deletes the attribute at runtime is skipped."""
+        path = self.template_dir / 'hookless.py'
+        path.write_text('HOOKS = {}\ndel HOOKS\n')
+        try:
+            from secator.loader import discover_external_drivers
+            discover_external_drivers.cache_clear()
+            result = discover_external_drivers()
+            self.assertNotIn('hookless', result)
+        finally:
+            if path.exists():
+                path.unlink()
+            for key in list(sys.modules.keys()):
+                if 'hookless' in key:
+                    del sys.modules[key]
+
+    def test_returns_list(self):
+        """discover_external_drivers always returns a list."""
+        from secator.loader import discover_external_drivers
+        self.assertIsInstance(discover_external_drivers(), list)
+
+    def test_result_is_cached(self):
+        """Calling discover_external_drivers twice returns the same list object."""
+        shutil.copyfile(DRIVER_FIXTURE, self.driver_path)
+        from secator.loader import discover_external_drivers
+        self.assertIs(discover_external_drivers(), discover_external_drivers())
+
+
+class TestDiscoverExternalExporters(unittest.TestCase):
+    """Tests for discover_external_exporters."""
+
+    def setUp(self):
+        self.template_dir = CONFIG.dirs.templates
+        self.template_dir.mkdir(parents=True, exist_ok=True)
+        self.exporter_path = self.template_dir / 'test_exporter.py'
+        clear_modules()
+        _clear_loader_caches()
+
+    def tearDown(self):
+        if self.exporter_path.exists():
+            self.exporter_path.unlink()
+        for key in list(sys.modules.keys()):
+            if 'secator.exporters.test_exporter' in key:
+                del sys.modules[key]
+        try:
+            import secator.exporters as pkg
+            if hasattr(pkg, 'TestExporter'):
+                delattr(pkg, 'TestExporter')
+        except Exception:
+            pass
+        _clear_loader_caches()
+
+    def test_valid_exporter_is_discovered(self):
+        """Exporter file with an Exporter subclass is picked up."""
+        shutil.copyfile(EXPORTER_FIXTURE, self.exporter_path)
+        from secator.loader import discover_external_exporters
+        result = discover_external_exporters()
+        # TestExporter → 'testexporter'[:-8] = 'test'
+        self.assertIn('test', result)
+
+    def test_exporter_registered_on_package(self):
+        """Discovered exporter class is set as attribute on secator.exporters."""
+        shutil.copyfile(EXPORTER_FIXTURE, self.exporter_path)
+        from secator.loader import discover_external_exporters
+        discover_external_exporters()
+        import secator.exporters as pkg
+        self.assertTrue(hasattr(pkg, 'TestExporter'))
+
+    def test_no_exporter_files_returns_empty(self):
+        """No exporter files in the templates dir → exporter not in result."""
+        from secator.loader import discover_external_exporters
+        result = discover_external_exporters()
+        self.assertNotIn('test', result)
+
+    def test_file_with_exporter_only_in_comment_is_skipped(self):
+        """File with '(Exporter)' only in a comment and no real subclass is skipped."""
+        path = self.template_dir / 'commented_exp.py'
+        # The text contains '(Exporter)' to pass the fast check, but no real subclass
+        path.write_text('# class Foo(Exporter): - this is just a comment\nclass Foo:\n    pass\n')
+        try:
+            from secator.loader import discover_external_exporters
+            discover_external_exporters.cache_clear()
+            result = discover_external_exporters()
+            self.assertNotIn('commented_exp', result)
+        finally:
+            if path.exists():
+                path.unlink()
+            for key in list(sys.modules.keys()):
+                if 'commented_exp' in key:
+                    del sys.modules[key]
+
+    def test_returns_list(self):
+        """discover_external_exporters always returns a list."""
+        from secator.loader import discover_external_exporters
+        self.assertIsInstance(discover_external_exporters(), list)
+
+    def test_result_is_cached(self):
+        """Calling discover_external_exporters twice returns the same list object."""
+        shutil.copyfile(EXPORTER_FIXTURE, self.exporter_path)
+        from secator.loader import discover_external_exporters
+        self.assertIs(discover_external_exporters(), discover_external_exporters())
+
+
+class TestGetAvailableDrivers(unittest.TestCase):
+    """Tests for get_available_drivers."""
+
+    def setUp(self):
+        _clear_loader_caches()
+
+    def tearDown(self):
+        _clear_loader_caches()
+
+    def test_includes_all_internal_drivers(self):
+        """Every entry in AVAILABLE_DRIVERS appears in get_available_drivers()."""
+        from secator.loader import get_available_drivers
+        from secator.definitions import AVAILABLE_DRIVERS
+        result = get_available_drivers()
+        for driver in AVAILABLE_DRIVERS:
+            self.assertIn(driver, result)
+
+    def test_appends_external_drivers(self):
+        """External drivers returned by discover_external_drivers appear in the result."""
+        from secator.loader import get_available_drivers
+        with mock.patch('secator.loader.discover_external_drivers', return_value=['ext_driver']):
+            get_available_drivers.cache_clear()
+            result = get_available_drivers()
+        self.assertIn('ext_driver', result)
+
+    def test_no_duplicates(self):
+        """Result list contains no duplicate entries."""
+        from secator.loader import get_available_drivers
+        result = get_available_drivers()
+        self.assertEqual(len(result), len(set(result)))
+
+    def test_returns_list(self):
+        """get_available_drivers returns a list."""
+        from secator.loader import get_available_drivers
+        self.assertIsInstance(get_available_drivers(), list)
+
+    def test_empty_external_returns_only_internal(self):
+        """When no external drivers exist, result equals AVAILABLE_DRIVERS."""
+        from secator.loader import get_available_drivers
+        from secator.definitions import AVAILABLE_DRIVERS
+        with mock.patch('secator.loader.discover_external_drivers', return_value=[]):
+            get_available_drivers.cache_clear()
+            result = get_available_drivers()
+        self.assertEqual(sorted(result), sorted(AVAILABLE_DRIVERS))
+
+
+class TestGetAvailableExporters(unittest.TestCase):
+    """Tests for get_available_exporters."""
+
+    def setUp(self):
+        _clear_loader_caches()
+
+    def tearDown(self):
+        _clear_loader_caches()
+
+    def test_includes_all_internal_exporters(self):
+        """Every entry in AVAILABLE_EXPORTERS appears in get_available_exporters()."""
+        from secator.loader import get_available_exporters
+        from secator.definitions import AVAILABLE_EXPORTERS
+        result = get_available_exporters()
+        for exporter in AVAILABLE_EXPORTERS:
+            self.assertIn(exporter, result)
+
+    def test_appends_external_exporters(self):
+        """External exporters returned by discover_external_exporters appear in the result."""
+        from secator.loader import get_available_exporters
+        with mock.patch('secator.loader.discover_external_exporters', return_value=['ext_exp']):
+            get_available_exporters.cache_clear()
+            result = get_available_exporters()
+        self.assertIn('ext_exp', result)
+
+    def test_no_duplicates(self):
+        """Result list contains no duplicate entries."""
+        from secator.loader import get_available_exporters
+        result = get_available_exporters()
+        self.assertEqual(len(result), len(set(result)))
+
+    def test_returns_list(self):
+        """get_available_exporters returns a list."""
+        from secator.loader import get_available_exporters
+        self.assertIsInstance(get_available_exporters(), list)
+
+    def test_empty_external_returns_only_internal(self):
+        """When no external exporters exist, result equals AVAILABLE_EXPORTERS."""
+        from secator.loader import get_available_exporters
+        from secator.definitions import AVAILABLE_EXPORTERS
+        with mock.patch('secator.loader.discover_external_exporters', return_value=[]):
+            get_available_exporters.cache_clear()
+            result = get_available_exporters()
+        self.assertEqual(sorted(result), sorted(AVAILABLE_EXPORTERS))
+
+
+class TestDiscoverExternalTasksSkipsDriversAndExporters(unittest.TestCase):
+    """discover_external_tasks must not attempt to load driver or exporter files."""
+
+    def setUp(self):
+        self.template_dir = CONFIG.dirs.templates
+        self.template_dir.mkdir(parents=True, exist_ok=True)
+        clear_modules()
+        _clear_loader_caches()
+
+    def tearDown(self):
+        for path in self.template_dir.glob('skiptest_*.py'):
+            path.unlink()
+        for key in list(sys.modules.keys()):
+            if 'skiptest_' in key:
+                del sys.modules[key]
+        _clear_loader_caches()
+
+    def test_driver_files_not_loaded_as_tasks(self):
+        """Files containing 'HOOKS =' are excluded from task discovery."""
+        path = self.template_dir / 'skiptest_driver.py'
+        path.write_text('HOOKS = {}\n')
+        from secator.loader import discover_external_tasks
+        result = discover_external_tasks()
+        result_names = [cls.__name__ for cls in result]
+        self.assertNotIn('skiptest_driver', result_names)
+
+    def test_exporter_files_not_loaded_as_tasks(self):
+        """Files containing '(Exporter)' are excluded from task discovery."""
+        path = self.template_dir / 'skiptest_exporter.py'
+        path.write_text('class SkipTestExporter(Exporter):\n    pass\n')
+        from secator.loader import discover_external_tasks
+        result = discover_external_tasks()
+        result_names = [cls.__name__ for cls in result]
+        self.assertNotIn('SkipTestExporter', result_names)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements dynamic loading of drivers and exporters from the `~/.secator/templates` folder, following the same pattern used for tasks, workflows, scans, and profiles.

## Changes

- `secator/loader.py`: Add `discover_external_drivers()`, `discover_external_exporters()`, `get_available_drivers()`, `get_available_exporters()`; update `find_templates()` to trigger these at startup; update `discover_external_tasks()` to skip driver/exporter files
- `secator/cli_helper.py`: Use dynamic driver/exporter lists for help text and validation; skip `ADDONS_ENABLED` check for external drivers
- `secator/completion.py`: Tab completion includes dynamically discovered drivers/exporters

Closed #1114

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drivers and exporters are now dynamically discovered and loaded at runtime.
  * Support for external and third-party drivers and exporters has been added.
  * CLI completion and help text now accurately reflect all available drivers and exporters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->