### PR TITLE
fix(ai): yield Error for connection failures and use config context_window fallback

### DIFF
--- a/secator/ai/history.py
+++ b/secator/ai/history.py
@@ -21,17 +21,21 @@ def get_context_window(model: str) -> int:
         model: LLM model name
 
     Returns:
-        Context window size in tokens (default 128000 on error)
+        Context window size in tokens (falls back to CONFIG.addons.ai.context_window on error or empty info)
     """
+    from secator.config import CONFIG
     import litellm
     try:
         info = litellm.get_model_info(model)
-        context_window = info.get("max_input_tokens") or info.get("max_tokens", 128_000)
+        if not info:
+            debug('context_window=config fallback (empty model info)', sub='runner.ai.context', obj={'model': model})
+            return CONFIG.addons.ai.context_window
+        context_window = info.get("max_input_tokens") or info.get("max_tokens") or CONFIG.addons.ai.context_window
         debug(f'context_window={context_window}', sub='runner.ai.context', obj={'model': model})
         return context_window
     except Exception:
-        debug('context_window=128000 (fallback)', sub='runner.ai.context', obj={'model': model})
-        return 128_000  # Safe default
+        debug('context_window=config fallback (exception)', sub='runner.ai.context', obj={'model': model})
+        return CONFIG.addons.ai.context_window
 
 
 def truncate_to_tokens(

--- a/secator/ai/history.py
+++ b/secator/ai/history.py
@@ -33,8 +33,12 @@ def get_context_window(model: str) -> int:
         context_window = info.get("max_input_tokens") or info.get("max_tokens") or CONFIG.addons.ai.context_window
         debug(f'context_window={context_window}', sub='runner.ai.context', obj={'model': model})
         return context_window
-    except Exception:
-        debug('context_window=config fallback (exception)', sub='runner.ai.context', obj={'model': model})
+    except Exception as e:  # noqa: BLE001 - get_model_info() raises generic Exception for unmapped models
+        debug(
+            'context_window=config fallback (exception)',
+            sub='runner.ai.context',
+            obj={'model': model, 'error_type': e.__class__.__name__, 'error': str(e)}
+        )
         return CONFIG.addons.ai.context_window
 
 

--- a/secator/config.py
+++ b/secator/config.py
@@ -9,7 +9,7 @@ import shutil
 import yaml
 from dotenv import find_dotenv, load_dotenv
 from dotmap import DotMap
-from pydantic import AfterValidator, BaseModel, model_validator, ValidationError
+from pydantic import AfterValidator, BaseModel, Field, model_validator, ValidationError
 
 from secator.requests import requests
 from secator.rich import console, console_stdout
@@ -216,7 +216,7 @@ class AiAddon(StrictModel):
 	max_tokens: int = 30000
 	max_tokens_total: int = 100000
 	max_results: int = 500
-	context_window: int = 128_000
+	context_window: int = Field(default=128_000, ge=1)
 	user_response_timeout: int = 600
 	encrypt_pii: bool = True
 	permissions: Dict = {

--- a/secator/config.py
+++ b/secator/config.py
@@ -216,6 +216,7 @@ class AiAddon(StrictModel):
 	max_tokens: int = 30000
 	max_tokens_total: int = 100000
 	max_results: int = 500
+	context_window: int = 128_000
 	user_response_timeout: int = 600
 	encrypt_pii: bool = True
 	permissions: Dict = {

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -128,6 +128,11 @@ class ai(PythonRunner):
 		# Init all options
 		self._init_options()
 
+		# Verify model is configured and reachable
+		yield from self._verify_model()
+		if not self.model:
+			return
+
 		# Show prompt mode (diagnostic)
 		if self.run_opts.get("show_prompt", False):
 			show_mode = self.mode or "attack"
@@ -375,6 +380,11 @@ class ai(PythonRunner):
 					yield Error(message='Please set a valid API key with `secator config set addons.ai.api_key <KEY>`')
 					save_history(self.history, self.reports_folder, debug_fn=self.debug)
 					return
+				elif isinstance(e, litellm.APIConnectionError):
+					yield Error(message=f"Cannot connect to model '{self.model}': {e}")
+					yield Error(message='Check api_base and connectivity: `secator config set addons.ai.api_base <URL>`')
+					save_history(self.history, self.reports_folder, debug_fn=self.debug)
+					return
 				yield Error.from_exception(e)
 				save_history(self.history, self.reports_folder, debug_fn=self.debug)
 				return
@@ -445,6 +455,30 @@ class ai(PythonRunner):
 			self.print_info = False
 			self.print_warning = False
 			self.print_error = False
+
+	# -------------------------------------------------------------------------
+	# Model verification
+	# -------------------------------------------------------------------------
+
+	def _verify_model(self):
+		"""Check model is configured and that model info is available; yield Error/Warning if not."""
+		if not self.model:
+			yield Error(message='No AI model configured. Run `secator ai setup` or set `addons.ai.default_model`.')
+			return
+		try:
+			import litellm
+			info = litellm.get_model_info(self.model)
+			if not info:
+				yield Warning(
+					message=f'Model info not found for "{self.model}" in litellm registry. '
+					f'Context window defaults to {CONFIG.addons.ai.context_window} tokens. '
+					'If this is a custom/self-hosted model, set `addons.ai.context_window` accordingly.'
+				)
+		except Exception:
+			yield Warning(
+				message=f'Could not retrieve model info for "{self.model}". '
+				f'Context window defaults to {CONFIG.addons.ai.context_window} tokens.'
+			)
 
 	# -------------------------------------------------------------------------
 	# Mode detection

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -128,17 +128,17 @@ class ai(PythonRunner):
 		# Init all options
 		self._init_options()
 
-		# Verify model is configured and reachable
-		yield from self._verify_model()
-		if not self.model:
-			return
-
 		# Show prompt mode (diagnostic)
 		if self.run_opts.get("show_prompt", False):
 			show_mode = self.mode or "attack"
 			prompt = get_system_prompt(show_mode, workspace_path=str(self.reports_folder), backend=self.backend)
 			console.print(f"[bold orange3]System prompt ({show_mode})[/]\n")
 			console.print(prompt, highlight=False, soft_wrap=True)
+			return
+
+		# Verify model is configured and reachable
+		yield from self._verify_model()
+		if not self.model:
 			return
 
 		# Resume session

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -380,7 +380,13 @@ class ai(PythonRunner):
 					yield Error(message='Please set a valid API key with `secator config set addons.ai.api_key <KEY>`')
 					save_history(self.history, self.reports_folder, debug_fn=self.debug)
 					return
-				elif isinstance(e, litellm.APIConnectionError):
+				elif isinstance(e, litellm.APIConnectionError) or (
+					isinstance(e, litellm.InternalServerError) and 'connection error' in str(e).lower()
+				):
+					# Genuine connectivity failures (connection refused, DNS failure) surface in
+					# some litellm versions as InternalServerError("Connection error.") rather than
+					# APIConnectionError, so catch both and gate the latter on the connection message
+					# to avoid swallowing unrelated upstream 500 errors.
 					yield Error(message=f"Cannot connect to model '{self.model}': {e}")
 					yield Error(message='Check api_base and connectivity: `secator config set addons.ai.api_base <URL>`')
 					save_history(self.history, self.reports_folder, debug_fn=self.debug)

--- a/tests/unit/test_ai_history.py
+++ b/tests/unit/test_ai_history.py
@@ -355,7 +355,8 @@ class TestChatHistory(unittest.TestCase):
 
         result = get_context_window("unknown-model")
 
-        self.assertEqual(result, 128000)  # Default fallback
+        from secator.config import CONFIG
+        self.assertEqual(result, CONFIG.addons.ai.context_window)  # Config-driven default fallback
 
     def test_constants_defined(self):
         """Verify constants are defined."""


### PR DESCRIPTION
Fixes #1112

**Changes:**
- Add `context_window: int = 128_000` to `AiAddon` config as configurable default
- Fix `get_context_window()` to use `CONFIG.addons.ai.context_window` instead of hardcoded 128_000, and handle empty model info dict explicitly
- Add explicit `APIConnectionError` handler in `_run_loop` to yield clean Error messages instead of raw Python tracebacks
- Add `_verify_model()` generator to warn early when model is unconfigured or unknown in litellm registry

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable context window setting for AI models (default: 128,000)
  * Implemented model verification at task startup

* **Bug Fixes**
  * Improved context window detection to dynamically read from model information
  * Enhanced API connectivity error handling with improved fallback mechanisms and user-facing error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->