### PR TITLE
feat(cli): add 'last' keyword to report query in secator r show

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1125,12 +1125,13 @@ def _apply_format(results, fmt):
 @click.pass_context
 def report_show(ctx, report_query, output, time_delta, query, fmt, workspace, driver, dedupe):
 	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""
-	from secator.query.utils import parse_report_paths, python_expr_to_mongo
+	from secator.query.utils import parse_report_paths, python_expr_to_mongo, resolve_last_report_path
 
 	current = get_file_timestamp()
 	workspace_name = workspace or CONFIG.workspace.default or 'default'
 
-	# 1. Parse path-based runner filter
+	# 1. Resolve 'last' keyword to actual report IDs, then parse path-based runner filter
+	report_query = resolve_last_report_path(report_query, workspace_name)
 	runner_filter = parse_report_paths(report_query)
 	debug('runner paths filter', sub='query', obj=runner_filter)
 

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -2,8 +2,76 @@
 
 import json
 import re
+from pathlib import Path
 
-from secator.utils import debug
+from secator.config import CONFIG
+from secator.utils import debug, sanitize_folder_name
+
+
+def resolve_last_report_path(report_query, workspace_name, reports_dir=None):
+    """Resolve the 'last' keyword in report_query to actual report IDs.
+
+    Scans the local filesystem to find the most recent report IDs.
+
+    Examples:
+        'last'           → 'tasks/5'    (most recently modified report across all types)
+        'workflows/last' → 'workflows/3'
+        'scans/last'     → 'scans/7'
+        'tasks/last'     → 'tasks/12'
+    """
+    if not report_query or 'last' not in report_query:
+        return report_query
+
+    reports_base = Path(reports_dir).expanduser() if reports_dir else Path(CONFIG.dirs.reports).expanduser()
+    workspace_folder = sanitize_folder_name(workspace_name)
+
+    resolved_parts = []
+    for part in [p.strip() for p in report_query.split(',') if p.strip()]:
+        if part == 'last':
+            best_mtime = None
+            best_part = None
+            for runner_type in ['tasks', 'workflows', 'scans']:
+                runner_path = reports_base / workspace_folder / runner_type
+                if not runner_path.exists():
+                    continue
+                for f in runner_path.iterdir():
+                    if not f.is_dir():
+                        continue
+                    try:
+                        int(f.name)
+                    except ValueError:
+                        continue
+                    report_file = f / 'report.json'
+                    if report_file.exists():
+                        mtime = report_file.stat().st_mtime
+                        if best_mtime is None or mtime > best_mtime:
+                            best_mtime = mtime
+                            best_part = f'{runner_type}/{f.name}'
+            if best_part:
+                resolved_parts.append(best_part)
+        elif '/' in part:
+            runner_type, runner_id = part.split('/', 1)
+            runner_id = runner_id.strip().rstrip('/')
+            if runner_id == 'last':
+                runner_path = reports_base / workspace_folder / runner_type.strip()
+                if runner_path.exists():
+                    ids = []
+                    for f in runner_path.iterdir():
+                        if f.is_dir():
+                            try:
+                                ids.append(int(f.name))
+                            except ValueError:
+                                continue
+                    if ids:
+                        resolved_parts.append(f'{runner_type}/{max(ids)}')
+            else:
+                resolved_parts.append(part)
+        else:
+            resolved_parts.append(part)
+
+    result = ','.join(resolved_parts) if resolved_parts else None
+    debug('resolve_last_report_path', sub='query', obj={'input': report_query, 'output': result})
+    return result
 
 
 def parse_report_paths(paths_str):

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,4 +1,10 @@
-from secator.query.utils import parse_report_paths, python_expr_to_mongo
+import json
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+from secator.query.utils import parse_report_paths, python_expr_to_mongo, resolve_last_report_path
 
 
 class TestParseReportPaths:
@@ -123,4 +129,68 @@ class TestPythonExprToMongo:
     def test_and_with_quoted_value_containing_and(self):
         result = python_expr_to_mongo("tag.name == 'this and that' and tag.match == 'x'")
         assert result == {'_type': 'tag', 'name': 'this and that', 'match': 'x'}
+
+
+class TestResolveLastReportPath:
+
+    def _make_report(self, base, workspace, runner_type, report_id):
+        """Create a minimal report.json at the expected path."""
+        report_dir = Path(base) / workspace / runner_type / str(report_id)
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_file = report_dir / 'report.json'
+        report_file.write_text(json.dumps({'info': {}, 'results': {}}))
+        return report_file
+
+    def setup_method(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp)
+
+    def test_none_returns_none(self):
+        assert resolve_last_report_path(None, 'ws', self.tmp) is None
+
+    def test_no_last_keyword_passthrough(self):
+        assert resolve_last_report_path('scans/5', 'ws', self.tmp) == 'scans/5'
+        assert resolve_last_report_path('tasks/3,workflows/2', 'ws', self.tmp) == 'tasks/3,workflows/2'
+
+    def test_tasks_last_resolves_to_highest_id(self):
+        self._make_report(self.tmp, 'ws', 'tasks', 1)
+        self._make_report(self.tmp, 'ws', 'tasks', 3)
+        self._make_report(self.tmp, 'ws', 'tasks', 2)
+        result = resolve_last_report_path('tasks/last', 'ws', self.tmp)
+        assert result == 'tasks/3'
+
+    def test_workflows_last_resolves_to_highest_id(self):
+        self._make_report(self.tmp, 'ws', 'workflows', 0)
+        self._make_report(self.tmp, 'ws', 'workflows', 4)
+        result = resolve_last_report_path('workflows/last', 'ws', self.tmp)
+        assert result == 'workflows/4'
+
+    def test_scans_last_resolves_to_highest_id(self):
+        self._make_report(self.tmp, 'ws', 'scans', 7)
+        result = resolve_last_report_path('scans/last', 'ws', self.tmp)
+        assert result == 'scans/7'
+
+    def test_last_alone_resolves_to_most_recently_modified(self):
+        self._make_report(self.tmp, 'ws', 'tasks', 1)
+        time.sleep(0.01)
+        self._make_report(self.tmp, 'ws', 'workflows', 2)
+        result = resolve_last_report_path('last', 'ws', self.tmp)
+        assert result == 'workflows/2'
+
+    def test_last_alone_no_reports_returns_none(self):
+        result = resolve_last_report_path('last', 'ws', self.tmp)
+        assert result is None
+
+    def test_last_with_nonexistent_runner_type_returns_none(self):
+        result = resolve_last_report_path('tasks/last', 'ws', self.tmp)
+        assert result is None
+
+    def test_non_numeric_dirs_ignored(self):
+        self._make_report(self.tmp, 'ws', 'tasks', 5)
+        non_numeric = Path(self.tmp) / 'ws' / 'tasks' / 'abc'
+        non_numeric.mkdir(parents=True, exist_ok=True)
+        result = resolve_last_report_path('tasks/last', 'ws', self.tmp)
+        assert result == 'tasks/5'
 

--- a/tests/unit/test_report_show_e2e.py
+++ b/tests/unit/test_report_show_e2e.py
@@ -245,3 +245,92 @@ class TestReportShowApiBackend(unittest.TestCase):
 
 		self.assertEqual(result.exit_code, 0)
 		self.assertEqual(captured.get('results', {}).get('vulnerability', []), [])
+
+
+class TestReportShowLastKeyword(unittest.TestCase):
+	"""End-to-end CLI tests for `secator r show last` / `tasks/last` / etc."""
+
+	def setUp(self):
+		self.cli_runner = CliRunner()
+		self.temp_dir = tempfile.mkdtemp()
+
+	def tearDown(self):
+		shutil.rmtree(self.temp_dir)
+
+	def _write_report(self, runner_type, report_id, vulns):
+		report_dir = Path(self.temp_dir) / WORKSPACE / runner_type / str(report_id)
+		report_dir.mkdir(parents=True)
+		with open(report_dir / 'report.json', 'w') as f:
+			json.dump({'info': {'name': 'test'}, 'results': {'vulnerability': vulns}}, f)
+
+	def _invoke(self, report_query_arg):
+		from secator.cli import cli
+
+		captured = {}
+
+		def capture_send(report_self):
+			captured['results'] = report_self.data['results']
+
+		args = ['r', 'show', '-w', WORKSPACE, '--driver', 'local']
+		if report_query_arg:
+			args += [report_query_arg]
+
+		with mock.patch('secator.query.json.CONFIG') as mock_json_cfg, \
+				mock.patch('secator.query.utils.CONFIG') as mock_utils_cfg, \
+				mock.patch('secator.report.Report.send', capture_send):
+			mock_json_cfg.dirs.reports = Path(self.temp_dir)
+			mock_utils_cfg.dirs.reports = Path(self.temp_dir)
+			result = self.cli_runner.invoke(cli, args)
+
+		return result, captured
+
+	def test_tasks_last_shows_highest_id_results(self):
+		"""tasks/last resolves to the task folder with the highest numeric ID."""
+		self._write_report('tasks', 1, [CRITICAL_VULN.copy()])
+		self._write_report('tasks', 2, [MEDIUM_VULN.copy()])
+		result, captured = self._invoke('tasks/last')
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		vulns = captured.get('results', {}).get('vulnerability', [])
+		self.assertEqual(len(vulns), 1)
+		self.assertEqual(vulns[0]['name'], 'XSS')
+
+	def test_workflows_last_resolves(self):
+		"""workflows/last resolves to the workflow folder with the highest numeric ID."""
+		self._write_report('workflows', 0, [CRITICAL_VULN.copy()])
+		self._write_report('workflows', 3, [MEDIUM_VULN.copy()])
+		result, captured = self._invoke('workflows/last')
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		vulns = captured.get('results', {}).get('vulnerability', [])
+		self.assertEqual(len(vulns), 1)
+		self.assertEqual(vulns[0]['name'], 'XSS')
+
+	def test_scans_last_resolves(self):
+		"""scans/last resolves to the scan folder with the highest numeric ID."""
+		self._write_report('scans', 5, [CRITICAL_VULN.copy()])
+		result, captured = self._invoke('scans/last')
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		vulns = captured.get('results', {}).get('vulnerability', [])
+		self.assertEqual(len(vulns), 1)
+		self.assertEqual(vulns[0]['name'], 'SQL Injection')
+
+	def test_last_alone_shows_most_recently_modified(self):
+		"""'last' without a runner type shows the most recently written report."""
+		import time
+		self._write_report('tasks', 1, [CRITICAL_VULN.copy()])
+		time.sleep(0.05)
+		self._write_report('workflows', 1, [MEDIUM_VULN.copy()])
+		result, captured = self._invoke('last')
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		vulns = captured.get('results', {}).get('vulnerability', [])
+		self.assertEqual(len(vulns), 1)
+		self.assertEqual(vulns[0]['name'], 'XSS')
+
+	def test_last_no_reports_exits_cleanly(self):
+		"""'last' with no reports exits cleanly (falls back to showing all)."""
+		result, captured = self._invoke('last')
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
Adds a `last` special keyword to `secator r show` that resolves to the most recent report by scanning the local reports filesystem.

**Supported forms:**
- `secator r show last` — most recently modified report across all types
- `secator r show tasks/last` — highest-numbered task report
- `secator r show workflows/last` — highest-numbered workflow report
- `secator r show scans/last` — highest-numbered scan report

Closes #1111

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `report show` command now supports a `last` keyword to quickly reference the most recent report. Use `last` for the most recently modified report across all runner types, or specify a runner type (e.g., `tasks/last`) for the latest report from that runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->