### PR TITLE
fix(runner): show task source name even when output is piped

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -145,7 +145,7 @@ class Runner:
 		# Runner print opts
 		self.print_item = self.run_opts.get('print_item', False) and not self.dry_run
 		self.print_line = self.run_opts.get('print_line', False) and not self.quiet
-		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input and not self.piped_output  # noqa: E501
+		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input
 		self.print_start = self.run_opts.get('print_start', False) and not self.dry_run  # noqa: E501
 		self.print_end = self.run_opts.get('print_end', False) and not self.dry_run  # noqa: E501
 		self.print_target = self.run_opts.get('print_target', False) and not self.dry_run and not self.has_parent


### PR DESCRIPTION
Fix regression where task names were not shown in results when running with `2>&1 | tee scan.log`.

When stdout is not a TTY (piped), `piped_output=True` was suppressing `print_remote_info` and thus hiding the task name annotation on results. Removed the `and not self.piped_output` guard from the `print_remote_info` condition since the task name annotation lives in the rich/repr output going to stderr, which is unaffected by piping.

Closes #1091

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed remote information display when output piping is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->