### PR TITLE
fix(cli): driver order not respected in cli

### DIFF
--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -280,7 +280,7 @@ def register_runner(cli_endpoint, config):
 		# Build hooks from driver name
 		hooks = []
 		drivers = driver.split(',') if driver else []
-		drivers = list(set(CONFIG.drivers.defaults + drivers))
+		drivers = list(dict.fromkeys(CONFIG.drivers.defaults + drivers))
 		supported_drivers = get_available_drivers()
 		context['drivers'] = []
 		for driver in drivers:


### PR DESCRIPTION
When passing `--driver gcs,mongodb` on the CLI, or setting `drivers.defaults`, the order of hooks can get messed up (this can be ennoying because if gcs driver runs after mongodb, the record stored in mongodb doesn't have the GCS url in e.g: `url.screenshot_path`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved driver parsing to correctly handle duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->