### PR TITLE
feat(templates): add scan options with 'set' mapping support

### DIFF
--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -105,6 +105,7 @@ def decorate_command_options(opts):
 			conf.pop('pre_process', None)
 			conf.pop('requires_sudo', None)
 			conf.pop('prefix', None)
+			conf.pop('set', None)
 			choices = conf.pop('choices', None)
 			applies_to = conf.pop('applies_to', None)
 			default_from = conf.pop('default_from', None)

--- a/secator/configs/scans/domain.yaml
+++ b/secator/configs/scans/domain.yaml
@@ -11,6 +11,19 @@ tags: [recon, dns, ssl, network, http, crawl, takeovers, vuln, secrets]
 input_types:
   - host
 
+options:
+  passive:
+    is_flag: True
+    default: False
+    help: "Passive scan (no active requests to targets)"
+    short: ps
+    set:
+      domain_recon_passive: True
+      subdomain_recon_passive: True
+      host_recon_passive: True
+      url_crawl_passive: True
+      url_vuln_passive: True
+
 workflows:
   domain_recon:
   subdomain_recon:

--- a/secator/configs/scans/host.yaml
+++ b/secator/configs/scans/host.yaml
@@ -12,6 +12,17 @@ input_types:
   - host
   - ip
 
+options:
+  passive:
+    is_flag: True
+    default: False
+    help: "Passive scan (no active requests to targets)"
+    short: ps
+    set:
+      host_recon_passive: True
+      url_crawl_passive: True
+      url_vuln_passive: True
+
 workflows:
   host_recon:
   url_crawl:

--- a/secator/configs/scans/network.yaml
+++ b/secator/configs/scans/network.yaml
@@ -12,6 +12,18 @@ tags: [recon, cidr, dns, network, internal, http, crawl, ssl, vuln, secrets]
 input_types:
   - cidr_range
   - slug
+
+options:
+  passive:
+    is_flag: True
+    default: False
+    help: "Passive scan (no active requests to targets)"
+    short: ps
+    set:
+      host_recon_passive: True
+      url_crawl_passive: True
+      url_vuln_passive: True
+
 workflows:
   cidr_recon:
   host_recon:

--- a/secator/configs/scans/subdomain.yaml
+++ b/secator/configs/scans/subdomain.yaml
@@ -10,6 +10,19 @@ profile: default
 tags: [recon, dns, network, http, crawl, ssl, takeovers, vuln, secrets]
 input_types:
   - host
+
+options:
+  passive:
+    is_flag: True
+    default: False
+    help: "Passive scan (no active requests to targets)"
+    short: ps
+    set:
+      subdomain_recon_passive: True
+      host_recon_passive: True
+      url_crawl_passive: True
+      url_vuln_passive: True
+
 workflows:
   subdomain_recon:
   host_recon:

--- a/secator/configs/scans/url.yaml
+++ b/secator/configs/scans/url.yaml
@@ -10,6 +10,17 @@ profile: default
 tags: [http, crawl, fuzz, vuln, secrets]
 input_types:
   - url
+
+options:
+  passive:
+    is_flag: True
+    default: False
+    help: "Passive scan (no active requests to targets)"
+    short: ps
+    set:
+      url_crawl_passive: True
+      url_vuln_passive: True
+
 workflows:
   url_crawl:
   url_fuzz:

--- a/secator/runners/scan.py
+++ b/secator/runners/scan.py
@@ -15,6 +15,39 @@ class Scan(Runner):
 
 	default_exporters = CONFIG.scans.exporters
 
+	def _expand_scan_opts(self):
+		"""Expand scan options with 'set' mappings into run_opts.
+
+		Scan options can define a 'set' key that maps option values to workflow-specific
+		options. When a scan option is truthy, the 'set' mappings are expanded into
+		run_opts so child workflows can resolve them via their opt_aliases.
+
+		Example YAML:
+		    options:
+		      passive:
+		        is_flag: True
+		        default: False
+		        help: "Passive scan"
+		        set:
+		          domain_recon_passive: True
+		          host_recon_passive: True
+		"""
+		scan_options = self.config.options.toDict() if self.config.options else {}
+		for opt_name, opt_conf in scan_options.items():
+			if not isinstance(opt_conf, dict):
+				continue
+			set_mapping = opt_conf.get('set')
+			if not set_mapping:
+				continue
+			opt_value = self.run_opts.get(opt_name)
+			if opt_value is None:
+				opt_value = opt_conf.get('default', False)
+			if opt_value:
+				set_items = set_mapping.toDict() if hasattr(set_mapping, 'toDict') else set_mapping
+				for k, v in set_items.items():
+					if k not in self.run_opts:
+						self.run_opts[k] = v
+
 	def build_celery_workflow(self):
 		"""Build Celery workflow for scan execution.
 
@@ -25,7 +58,21 @@ class Scan(Runner):
 		from secator.celery import mark_runner_started, mark_runner_completed
 		from secator.template import TemplateLoader
 
-		scan_opts = self.config.options
+		self._expand_scan_opts()
+
+		# Build scan_opts from scan config options. The options key may contain either:
+		# - literal values (old format): {threads: 5} → passed through as-is
+		# - option definitions (new format): {passive: {is_flag: True, default: False}} →
+		#   extract the default value to avoid passing definition dicts to child workflows
+		scan_options_raw = self.config.options.toDict() if self.config.options else {}
+		scan_opts = {}
+		for k, v in scan_options_raw.items():
+			if isinstance(v, dict):
+				default = v.get('default')
+				if default is not None:
+					scan_opts[k] = default
+			else:
+				scan_opts[k] = v
 
 		# Set hooks and reports
 		self.enable_hooks = False   # Celery will handle hooks

--- a/secator/template.py
+++ b/secator/template.py
@@ -183,7 +183,7 @@ def get_config_options(config, exec_opts=None, output_opts=None, type_mapping=No
 				conf = dict(v).copy()
 				opt_name = k
 				conf['prefix'] = f'{node.type.capitalize()} {node.name}'
-				if len(same_opts) > 0:  # opt name conflict, change opt name
+				if len(same_opts) > 0 or k in config_opts:  # opt name conflict, change opt name
 					opt_name = f'{node.name}.{k}'
 					debug(f'[bold]{config.name}[/] -> [bold blue]{node.id}[/] -> [bold green]{k}[/] renamed to [bold green]{opt_name}[/] [dim red](duplicated)[/]', sub=f'cli.{config.name}')  # noqa: E501
 				all_opts[opt_name] = conf

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -116,6 +116,25 @@ class TestTree(unittest.TestCase):
 				'test2': {}
 			}
 		}
+		self.scan_config_with_opts = {
+			'type': 'scan',
+			'name': 'test',
+			'options': {
+				'nuclei': {
+					'is_flag': True,
+					'default': False,
+					'help': 'Run nuclei scans on all workflows',
+					'set': {
+						'test1_nuclei': True,
+						'test2_nuclei': True,
+					}
+				}
+			},
+			'workflows': {
+				'test1': {},
+				'test2': {}
+			}
+		}
 		self.template_dir = CONFIG.dirs.templates
 		self.custom_workflow_path_1 = self.template_dir / 'test.yml'
 		self.custom_workflow_path_2 = self.template_dir / 'test2.yml'
@@ -269,3 +288,77 @@ class TestTree(unittest.TestCase):
 		# Should use the default from httpx task (False)
 		self.assertIn('tls-grab', opts_3)
 		self.assertEqual(opts_3['tls-grab']['default'], False)
+
+	def test_get_config_options_scan_with_scan_level_opts(self):
+		"""Scan-level options should be preserved and not overwritten by workflow options."""
+		find_templates.cache_clear()
+		config = TemplateLoader(input=self.scan_config_with_opts)
+		opts = get_config_options(config)
+		# Scan-level 'nuclei' option should exist with scan prefix
+		self.assertIn('nuclei', opts)
+		self.assertEqual(opts['nuclei']['prefix'], 'scan')
+		self.assertEqual(opts['nuclei']['default'], False)
+		# Workflow-level 'nuclei' options should be renamed to avoid overwriting scan-level option
+		self.assertIn('test1-nuclei', opts)
+		self.assertEqual(opts['test1-nuclei']['prefix'], 'Workflow test1')
+		self.assertIn('test2-nuclei', opts)
+		self.assertEqual(opts['test2-nuclei']['prefix'], 'Workflow test2')
+
+	def test_expand_scan_opts(self):
+		"""Scan option 'set' mapping should expand into run_opts for child workflows."""
+		from secator.runners import Scan
+		find_templates.cache_clear()
+		config = TemplateLoader(input=self.scan_config_with_opts)
+		scan = Scan(config, run_opts={'dry_run': True, 'nuclei': True})
+		# Before build_celery_workflow, run_opts should only have 'nuclei'
+		self.assertNotIn('test1_nuclei', scan.run_opts)
+		self.assertNotIn('test2_nuclei', scan.run_opts)
+		scan.run()
+		# After running, the 'set' mapping should have been expanded
+		self.assertIn('test1_nuclei', scan.run_opts)
+		self.assertIn('test2_nuclei', scan.run_opts)
+		self.assertTrue(scan.run_opts['test1_nuclei'])
+		self.assertTrue(scan.run_opts['test2_nuclei'])
+
+	def test_expand_scan_opts_default_false(self):
+		"""Scan option with default=False should not expand set mapping."""
+		from secator.runners import Scan
+		find_templates.cache_clear()
+		config = TemplateLoader(input=self.scan_config_with_opts)
+		# Don't pass nuclei=True, so it stays at default False
+		scan = Scan(config, run_opts={'dry_run': True})
+		scan.run()
+		# 'set' mapping should NOT have been expanded since nuclei=False
+		self.assertNotIn('test1_nuclei', scan.run_opts)
+		self.assertNotIn('test2_nuclei', scan.run_opts)
+
+	def test_expand_scan_opts_does_not_override_explicit_opts(self):
+		"""Scan option 'set' mapping should not override already-set workflow options."""
+		from secator.runners import Scan
+		find_templates.cache_clear()
+		config = TemplateLoader(input=self.scan_config_with_opts)
+		# Explicitly set test1_nuclei to False while nuclei=True at scan level
+		scan = Scan(config, run_opts={'dry_run': True, 'nuclei': True, 'test1_nuclei': False})
+		scan.run()
+		# test1_nuclei should remain False (explicitly set, not overwritten by 'set' expansion)
+		self.assertFalse(scan.run_opts['test1_nuclei'])
+		# test2_nuclei should be True from the 'set' expansion
+		self.assertTrue(scan.run_opts['test2_nuclei'])
+
+	def test_dry_run_with_scan_level_option_sets_workflow_conditions(self):
+		"""Dry run with scan-level option enabled should enable workflow task conditions."""
+		from secator.runners import Scan
+		find_templates.cache_clear()
+		config = TemplateLoader(input=self.scan_config_with_opts)
+		scan = Scan(config, run_opts={'dry_run': True, 'nuclei': True})
+		scan.run()
+		self.assertEqual(scan.status, 'SUCCESS')
+		self.assertEqual(len(scan.errors), 0)
+		messages = [r.message for r in scan.infos]
+		# nuclei tasks should NOT be skipped since nuclei=True was set via scan option
+		self.assertNotIn(
+			'Skipped task [bold gold3]nuclei/first[/] because condition is not met: [bold green]opts.nuclei[/]',
+			messages)
+		self.assertNotIn(
+			'Skipped task [bold gold3]nuclei/second[/] because condition is not met: [bold green]opts.nuclei[/]',
+			messages)


### PR DESCRIPTION
Closes #1118

## Summary

- Scan configs can define options with a `set` key that expands into workflow-specific options when enabled
- Adds `--passive` scan-level option to all 5 scan configs (domain, host, subdomain, url, network)
- Fixes scan option handling to extract default values from definition dicts
- Prevents workflow options from overwriting scan-level options with same name
- Strips internal `set` key from click option configs
- 5 new unit tests

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--passive` flag to domain, host, network, subdomain, and URL scans for passive assessment. When enabled, all scanning stages operate without making active network requests.

* **Bug Fixes**
  * Fixed command option parameter handling to prevent invalid parameters in command decorators.

* **Tests**
  * Added comprehensive tests for scan-level configuration options, passive mode expansion, and override protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->