### PR TITLE
fix: dynamic driver hooks not working in worker mode

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -102,6 +102,9 @@ app.conf.update(
 )
 app.autodiscover_tasks(['secator.hooks.mongodb'], related_name=None)
 if IN_WORKER:
+	from secator.loader import discover_external_drivers, discover_external_exporters
+	discover_external_drivers()
+	discover_external_exporters()
 	setup_handlers()
 
 

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -439,6 +439,34 @@ class Runner:
 		"""
 		return list(self.__iter__())
 
+	def __getstate__(self):
+		"""Custom pickle: strip hook functions so dynamically-loaded modules
+		(e.g. secator.hooks.cockpit) don't cause ModuleNotFoundError on workers.
+		Driver names in context['drivers'] are used to re-load hooks in __setstate__.
+		"""
+		state = self.__dict__.copy()
+		state['_hooks'] = {}
+		state['resolved_hooks'] = {name: [] for name in state['resolved_hooks']}
+		return state
+
+	def __setstate__(self, state):
+		"""Custom unpickle: restore runner state then re-register hooks."""
+		self.__dict__.update(state)
+		drivers = self.context.get('drivers', [])
+		if drivers:
+			from secator.loader import discover_external_drivers
+			discover_external_drivers()
+		hooks_list = []
+		for driver in drivers:
+			driver_hooks = import_dynamic(f'secator.hooks.{driver}', 'HOOKS')
+			if driver_hooks:
+				hooks_list.append(driver_hooks)
+		merged_hooks = {}
+		if hooks_list:
+			from secator.utils import deep_merge_dicts
+			merged_hooks = deep_merge_dicts(*hooks_list)
+		self.register_hooks(merged_hooks)
+
 	@classmethod
 	def delay(cls, config, targets, **run_opts):
 		"""Run runner asynchronously via Celery.

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -339,3 +339,95 @@ class TestDelayMethods(unittest.TestCase):
 			context={}
 		)
 		self.assertIsNotNone(sig)
+
+
+class TestRunnerPickle(unittest.TestCase):
+	"""Test that Runner objects with dynamic driver hooks can be pickled/unpickled."""
+
+	def test_runner_pickle_survives_missing_module_on_worker(self):
+		"""Reproduces the original bug: unpickling a runner whose hooks reference a
+		dynamically-loaded module that does not exist on the worker side.
+		Without the __getstate__/__setstate__ fix this raises ModuleNotFoundError."""
+		import pickle
+		import types
+		import sys
+		from secator.runners import Workflow
+		from secator.loader import get_configs_by_type
+
+		workflows = get_configs_by_type('workflow')
+		if not workflows:
+			self.skipTest('No workflows configured')
+
+		config = workflows[0]
+
+		# 1) CLI side: load the driver into sys.modules (as the loader does)
+		fake_module = types.ModuleType('secator.hooks.testdriver')
+
+		def on_start(runner, *args):
+			pass
+
+		on_start.__module__ = 'secator.hooks.testdriver'
+		on_start.__qualname__ = 'on_start'
+		fake_module.on_start = on_start
+		sys.modules['secator.hooks.testdriver'] = fake_module
+
+		hooks = {Workflow: {'on_start': [on_start]}}
+		runner = Workflow(config, inputs=['example.com'], run_opts={'dry_run': True}, hooks=hooks, context={})
+
+		# Pickle while the module is available (simulates the CLI/sender side)
+		pickled = pickle.dumps(runner)
+
+		# 2) Worker side: remove the module to simulate it not being installed
+		del sys.modules['secator.hooks.testdriver']
+
+		# Without the fix, unpickling would raise:
+		#   ModuleNotFoundError: No module named 'secator.hooks.testdriver'
+		# With the fix, __getstate__ strips hooks so the bytes contain no reference
+		# to the dynamic module and unpickling succeeds.
+		restored = pickle.loads(pickled)
+		self.assertEqual(restored.name, runner.name)
+		# Hooks were stripped; dynamic hook not re-registered (driver not in context['drivers'])
+		self.assertNotIn(on_start, restored.resolved_hooks.get('on_start', []))
+
+	def test_runner_pickle_restores_hooks_from_context_drivers(self):
+		"""Unpickling a Runner re-registers hooks from context['drivers']."""
+		import pickle
+		import sys
+		import types
+		from unittest.mock import patch
+		from secator.runners import Workflow
+		from secator.loader import get_configs_by_type
+
+		workflows = get_configs_by_type('workflow')
+		if not workflows:
+			self.skipTest('No workflows configured')
+
+		config = workflows[0]
+
+		# Simulate an external driver module
+		fake_module = types.ModuleType('secator.hooks.fakedriver')
+
+		def on_end(runner, *args):
+			pass
+
+		on_end.__module__ = 'secator.hooks.fakedriver'
+		on_end.__qualname__ = 'on_end'
+		fake_module.on_end = on_end
+		fake_module.HOOKS = {Workflow: {'on_end': [on_end]}}
+		sys.modules['secator.hooks.fakedriver'] = fake_module
+
+		try:
+			# Patch discover_external_drivers to avoid filesystem scanning;
+			# the module is already in sys.modules so import_dynamic will find it.
+			with patch('secator.loader.discover_external_drivers', return_value=['fakedriver']):
+				context = {'drivers': ['fakedriver']}
+				hooks = {Workflow: {'on_end': [on_end]}}
+				runner = Workflow(config, inputs=['example.com'], run_opts={'dry_run': True}, hooks=hooks, context=context)
+				pickled = pickle.dumps(runner)
+				restored = pickle.loads(pickled)
+				self.assertEqual(restored.name, runner.name)
+				# __setstate__ re-registers on_end from fakedriver via context['drivers']
+				self.assertIn(on_end, restored.resolved_hooks.get('on_end', []))
+
+		finally:
+			del sys.modules['secator.hooks.fakedriver']


### PR DESCRIPTION
Fixes #1124

## Problem

External drivers (e.g. `cockpit.py`) are loaded by the CLI via `importlib.util` and registered in `sys.modules` as `secator.hooks.<name>`. Hook functions from these modules carry `__module__ = 'secator.hooks.cockpit'`, so pickle serialises them by that path. The Celery worker never ran `discover_external_drivers()`, so the module was absent and every message containing a `Runner` object or `opts['hooks']` raised `DecodeError: ModuleNotFoundError: No module named 'secator.hooks.cockpit'`.

## Fix

1. **`secator/celery.py`**: call `discover_external_drivers()` / `discover_external_exporters()` at worker startup so all dynamic modules are in `sys.modules` before the worker begins deserialising messages.

2. **`secator/runners/_base.py`**: add `__getstate__`/`__setstate__` to `Runner` to strip hook function objects during pickling and re-register them from `context['drivers']` on the worker side.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External drivers and exporters are now automatically discovered when initializing worker processes.
  * Runner and Workflow objects can now be safely serialized and deserialized while preserving dynamically-loaded driver hooks.

* **Tests**
  * Added comprehensive tests for runner pickling and unpickling with external drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->