### PR TITLE
fix: pass driver names to Runner instead of hook functions

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -144,7 +144,7 @@ def chunker(seq, size):
 
 
 @app.task(bind=True)
-def start_runner(self, config, targets, results=[], run_opts={}, hooks={}, validators={}, context={}):
+def start_runner(self, config, targets, results=[], run_opts={}, hooks={}, validators={}, context={}, drivers=[]):
 	context = context or {}
 	context['celery_id'] = self.request.id
 	run_opts['sync'] = False
@@ -163,6 +163,7 @@ def start_runner(self, config, targets, results=[], run_opts={}, hooks={}, valid
 		hooks=hooks,
 		validators=validators,
 		context=context,
+		drivers=drivers,
 	)
 	runner.run()
 

--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -277,28 +277,22 @@ def register_runner(cli_endpoint, config):
 		inputs = opts.pop('inputs')
 		inputs = expand_input(inputs, ctx)
 
-		# Build hooks from driver name
-		hooks = []
-		drivers = driver.split(',') if driver else []
-		drivers = list(dict.fromkeys(CONFIG.drivers.defaults + drivers))
+		# Validate and collect driver names
+		resolved_drivers = []
+		drivers_input = driver.split(',') if driver else []
+		drivers_input = list(dict.fromkeys(CONFIG.drivers.defaults + drivers_input))
 		supported_drivers = get_available_drivers()
 		context['drivers'] = []
-		for driver in drivers:
-			if driver in supported_drivers:
-				if driver in ADDONS_ENABLED and not ADDONS_ENABLED[driver]:
-					console.print(f'[bold red]Missing "{driver}" addon: please run `secator install addons {driver}`[/].')
+		for driver_name in drivers_input:
+			if driver_name in supported_drivers:
+				if driver_name in ADDONS_ENABLED and not ADDONS_ENABLED[driver_name]:
+					console.print(f'[bold red]Missing "{driver_name}" addon: please run `secator install addons {driver_name}`[/].')
 					sys.exit(1)
-				from secator.utils import import_dynamic
-
-				driver_hooks = import_dynamic(f'secator.hooks.{driver}', 'HOOKS')
-				if driver_hooks is None:
-					console.print(f'[bold red]Missing "secator.hooks.{driver}.HOOKS".[/]')
-					sys.exit(1)
-				hooks.append(driver_hooks)
-				context['drivers'].append(driver)
+				resolved_drivers.append(driver_name)
+				context['drivers'].append(driver_name)
 			else:
 				supported_drivers_str = ', '.join([f'[bold green]{_}[/]' for _ in supported_drivers])
-				console.print(f'[bold red]Driver "{driver}" is not supported.[/]')
+				console.print(f'[bold red]Driver "{driver_name}" is not supported.[/]')
 				console.print(f'Supported drivers: {supported_drivers_str}')
 				sys.exit(1)
 
@@ -320,10 +314,6 @@ def register_runner(cli_endpoint, config):
 
 			output_file = f'trace_memray_{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}.bin'
 			contextmanager = memray.Tracker(output_file)
-
-		from secator.utils import deep_merge_dicts
-
-		hooks = deep_merge_dicts(*hooks)
 
 		# Enable sync or not
 		if sync or dry_run:
@@ -373,7 +363,7 @@ def register_runner(cli_endpoint, config):
 				process = psutil.Process()
 				console.print(f'[bold yellow3]Initial RAM Usage: {process.memory_info().rss / 1024**2} MB[/]')
 			item_count = 0
-			runner = runner_cls(config, inputs, run_opts=opts, hooks=hooks, context=context)
+			runner = runner_cls(config, inputs, run_opts=opts, drivers=resolved_drivers, context=context)
 			for item in runner:
 				del item
 				item_count += 1

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -90,7 +90,7 @@ class Runner:
 	# Run duplicate check
 	enable_duplicate_check = True
 
-	def __init__(self, config, inputs=[], results=[], run_opts={}, hooks={}, validators={}, context={}):
+	def __init__(self, config, inputs=[], results=[], run_opts={}, hooks={}, validators={}, context={}, drivers=[]):
 		# Runner config
 		self.serialize_config = run_opts.get('serialize_config', True)
 		self.config = self._process_config(config)
@@ -100,6 +100,7 @@ class Runner:
 		self.run_opts = run_opts.copy()
 		self.sync = run_opts.get('sync', True)
 		self.context = context
+		self.drivers = list(drivers) or list(context.get('drivers', []))
 
 		# Runner state
 		self.uuids = set()
@@ -121,6 +122,7 @@ class Runner:
 		self.skipped = False
 		self.results_buffer = []
 		self._hooks = hooks
+		self._validators = validators
 
 		# Runner process options
 		self.no_poll = self.run_opts.get('no_poll', False)
@@ -177,6 +179,7 @@ class Runner:
 		self.resolved_hooks = {name: [] for name in HOOKS + getattr(self, 'hooks', [])}
 		self.debug('registering hooks', obj=list(self.resolved_hooks.keys()), sub='init')
 		self.register_hooks(hooks)
+		self._load_driver_hooks()
 
 		# Validators
 		self.resolved_validators = {name: [] for name in VALIDATORS + getattr(self, 'validators', [])}
@@ -453,7 +456,7 @@ class Runner:
 		"""
 		from secator.celery import start_runner
 
-		hooks = run_opts.pop('hooks', {})
+		drivers = run_opts.pop('drivers', [])
 		results = run_opts.pop('results', [])
 		context = run_opts.pop('context', {})
 		validators = run_opts.pop('validators', [])
@@ -463,9 +466,9 @@ class Runner:
 				'targets': targets,
 				'results': results,
 				'run_opts': run_opts,
-				'hooks': hooks,
 				'validators': validators,
 				'context': context,
+				'drivers': drivers,
 			},
 			queue='celery',
 		)
@@ -977,6 +980,28 @@ class Runner:
 				fun = self.get_func_path(hook)
 				self.debug('hook registered', obj={'name': key, 'fun': fun}, sub='init')
 			self.resolved_hooks[key].extend(user_hooks)
+
+	def _load_driver_hooks(self):
+		"""Load and register hooks from named drivers."""
+		for driver_name in self.drivers:
+			driver_hooks = import_dynamic(f'secator.hooks.{driver_name}', 'HOOKS')
+			if driver_hooks:
+				self.register_hooks(driver_hooks)
+
+	def __getstate__(self):
+		state = self.__dict__.copy()
+		state['resolved_hooks'] = {k: [] for k in state.get('resolved_hooks', {})}
+		state['resolved_validators'] = {k: [] for k in state.get('resolved_validators', {})}
+		return state
+
+	def __setstate__(self, state):
+		self.__dict__.update(state)
+		self.resolved_hooks = {name: [] for name in HOOKS + getattr(self, 'hooks', [])}
+		self.register_hooks(getattr(self, '_hooks', {}))
+		self._load_driver_hooks()
+		self.resolved_validators = {name: [] for name in VALIDATORS + getattr(self, 'validators', [])}
+		self.resolved_validators['validate_input'].append(self._validate_inputs)
+		self.register_validators(getattr(self, '_validators', {}))
 
 	def register_validators(self, validators):
 		"""Register validators.

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -150,6 +150,7 @@ class Command(Runner):
 
 		# Extract run opts
 		hooks = run_opts.pop('hooks', {})
+		drivers = run_opts.pop('drivers', [])
 		caller = run_opts.get('caller', None)
 		results = run_opts.pop('results', [])
 		context = run_opts.pop('context', {})
@@ -179,6 +180,7 @@ class Command(Runner):
 			hooks=hooks,
 			validators=validators,
 			context=context,
+			drivers=drivers,
 		)
 
 		# Cmd name

--- a/secator/runners/scan.py
+++ b/secator/runners/scan.py
@@ -64,7 +64,7 @@ class Scan(Runner):
 				self.inputs,
 				results=self.results,
 				run_opts=opts,
-				hooks=self._hooks,
+				drivers=self.drivers,
 				context=self.context.copy()
 			)
 			celery_workflow = workflow.build_celery_workflow(chain_previous_results=True)

--- a/secator/runners/task.py
+++ b/secator/runners/task.py
@@ -41,9 +41,8 @@ class Task(Runner):
 		self.enable_hooks = False   # Celery will handle hooks
 		self.enable_reports = self.run_opts.get('enable_reports', True)  # Task will handle reports
 
-		# Get hooks
-		hooks = self._hooks.get(Task, {})
-		opts['hooks'] = hooks
+		# Forward driver names so child tasks reload hooks on the worker
+		opts['drivers'] = self.drivers
 		opts['context'] = self.context.copy()
 		opts['reports_folder'] = str(self.reports_folder)
 

--- a/secator/runners/workflow.py
+++ b/secator/runners/workflow.py
@@ -35,9 +35,8 @@ class Workflow(Runner):
 		self.enable_reports = True  # Workflow will handle reports
 		self.print_item = not self.sync
 
-		# Get hooks
-		hooks = self._hooks.get(Task, {})
-		opts['hooks'] = hooks
+		# Forward driver names so child tasks reload hooks on the worker
+		opts['drivers'] = self.drivers
 		opts['context'] = self.context.copy()
 		opts['reports_folder'] = str(self.reports_folder)
 		opts['enable_reports'] = False  # Workflow will handle reports

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -339,3 +339,55 @@ class TestDelayMethods(unittest.TestCase):
 			context={}
 		)
 		self.assertIsNotNone(sig)
+
+
+class TestRunnerDrivers(unittest.TestCase):
+	"""Test that runners accept and propagate driver names correctly."""
+
+	def test_runner_accepts_drivers_param(self):
+		"""Runner stores driver names from the drivers= parameter."""
+		from secator.runners import Workflow
+		from secator.loader import get_configs_by_type
+
+		workflows = get_configs_by_type('workflow')
+		if not workflows:
+			self.skipTest('No workflows configured')
+
+		config = workflows[0]
+		runner = Workflow(config, ['example.com'], run_opts={'dry_run': True}, drivers=['mongodb'])
+		self.assertEqual(runner.drivers, ['mongodb'])
+
+	def test_runner_drivers_from_context(self):
+		"""Runner falls back to context['drivers'] when drivers= is empty."""
+		from secator.runners import Workflow
+		from secator.loader import get_configs_by_type
+
+		workflows = get_configs_by_type('workflow')
+		if not workflows:
+			self.skipTest('No workflows configured')
+
+		config = workflows[0]
+		runner = Workflow(config, ['example.com'], run_opts={'dry_run': True}, context={'drivers': ['gcs']})
+		self.assertEqual(runner.drivers, ['gcs'])
+
+	def test_runner_pickle_strips_hook_functions(self):
+		"""Pickling a Runner strips resolved_hooks function objects from the state."""
+		import pickle
+		from secator.runners import Workflow
+		from secator.loader import get_configs_by_type
+
+		workflows = get_configs_by_type('workflow')
+		if not workflows:
+			self.skipTest('No workflows configured')
+
+		config = workflows[0]
+		runner = Workflow(config, ['example.com'], run_opts={'dry_run': True})
+
+		state = runner.__getstate__()
+		# All hook lists in the pickled state should be empty
+		for hook_list in state['resolved_hooks'].values():
+			self.assertEqual(hook_list, [])
+		# Pickle/unpickle should not raise
+		data = pickle.dumps(runner)
+		restored = pickle.loads(data)
+		self.assertIsNotNone(restored)


### PR DESCRIPTION
Fixes #1124

Instead of importing driver HOOKS (function objects) at CLI time and serializing them through Celery pickle, pass driver names as strings. The Runner loads hooks from those names in `__init__` and restores them after unpickling via `__setstate__`, so the worker imports the module fresh on demand.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runners now accept a drivers parameter for enhanced extensibility and customization
  * Drivers are automatically propagated through workflow task execution
  * Improved runner state serialization to maintain driver configuration across distributed execution

* **Tests**
  * Added test coverage for driver parameter handling, context fallback behavior, and state persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->