### PR TITLE
feat(config): add strategy flag to Config.set for list/dict append and remove

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -665,9 +665,21 @@ def config_get(user, key=None):
 @config.command('set')
 @click.argument('key')
 @click.argument('value')
-def config_set(key, value):
-	"""Set config value."""
-	CONFIG.set(key, value)
+@click.option('--append', 'strategy', flag_value='append', default=False, help='Append value to existing list field.')
+def config_set(key, value, strategy):
+	"""Set config value.
+
+	Use --append to append a value to a list field instead of replacing it.
+
+	Examples:
+
+	\b
+	  secator config set debug ''                     # set a scalar field
+	  secator config set drivers.defaults redis       # replace list field
+	  secator config set drivers.defaults redis --append  # append to list field
+	  secator config set wordlists.defaults.http mylist  # set a dict subkey
+	"""
+	CONFIG.set(key, value, strategy=strategy if strategy else None)
 	config = CONFIG.validate()
 	if config:
 		CONFIG.get(key)
@@ -681,9 +693,22 @@ def config_set(key, value):
 
 @config.command('unset')
 @click.argument('key')
-def config_unset(key):
-	"""Unset a config value."""
-	CONFIG.unset(key)
+@click.argument('value', required=False)
+def config_unset(key, value=None):
+	"""Unset a config value.
+
+	When VALUE is provided and KEY is a list field, removes that item from the list.
+	When VALUE is omitted, removes the entire field (resets to default).
+	Also supports removing dict subkeys: secator config unset wordlists.defaults.http
+
+	Examples:
+
+	\b
+	  secator config unset debug                      # reset scalar to default
+	  secator config unset drivers.defaults redis     # remove item from list
+	  secator config unset wordlists.defaults.http    # remove dict subkey
+	"""
+	CONFIG.unset(key, value=value)
 	config = CONFIG.validate()
 	if config:
 		saved = CONFIG.save()

--- a/secator/config.py
+++ b/secator/config.py
@@ -355,24 +355,41 @@ class Config(DotMap):
 			Config.print_yaml(yaml_str)
 		return value
 
-	def set(self, key, value, set_partial=True):
+	def set(self, key, value, set_partial=True, strategy=None):
 		"""Set a value in the configuration using a dotted path.
 
 		Args:
 			key (str | None): Dotted key path.
 			value (Any): Value.
 			set_partial (bool): Set in partial config.
+			strategy (str | None): Strategy for updating list/dict fields.
+				None or 'replace': replace the value (default).
+				'append': append value to existing list, or add key to existing dict.
+				'remove': remove value from existing list, or remove key from existing dict.
 		"""
-		# Get existing value
-		existing_value = self.get(key, print=False)
-
 		# Convert dotted key path to the corresponding uppercase key used in _keymap
 		map_key = key.upper().replace('.', '_')
 
-		# Check if map key exists
+		# If key not found in keymap, check if parent path points to a dict field
+		# (handles setting/removing keys in a dict, e.g. wordlists.defaults.mykey)
 		if map_key not in self._keymap:
+			parts = key.split('.')
+			if len(parts) > 1:
+				parent_parts = parts[:-1]
+				dict_subkey = parts[-1]
+				try:
+					parent_value = self
+					for part in parent_parts:
+						parent_value = parent_value[part]
+					if isinstance(parent_value, dict):
+						return self._set_dict_key(parent_parts, dict_subkey, value, set_partial=set_partial, strategy=strategy)
+				except (KeyError, TypeError):
+					pass
 			console.print(f'[bold red]Key "{key}" not found in config keymap[/].')
 			return
+
+		# Get existing value
+		existing_value = self.get(key, print=False)
 
 		# Traverse to the second last key to handle the setting correctly
 		target = self
@@ -384,37 +401,52 @@ class Config(DotMap):
 		# Set the value on the final part of the path
 		final_key = self._keymap[map_key][-1]
 
-		# Try to convert value to expected type
-		try:
-			if isinstance(existing_value, list):
-				if isinstance(value, str):
-					if value.startswith('[') and value.endswith(']'):
-						value = value[1:-1]
-					if ',' in value:
-						value = [c.strip() for c in value.split(',')]
-					elif value:
-						value = [value]
-					else:
-						value = []
-			elif isinstance(existing_value, dict):
-				if isinstance(value, str):
-					if value.startswith('{') and value.endswith('}'):
-						import json
+		# Apply strategy for list fields
+		if strategy in ('append', 'remove') and isinstance(existing_value, list):
+			item = value
+			current = list(existing_value)
+			if strategy == 'append':
+				if item not in current:
+					current.append(item)
+			elif strategy == 'remove':
+				if item in current:
+					current.remove(item)
+				else:
+					console.print(f'[bold orange1]Value "{item}" not found in {key}[/].')
+					return
+			value = current
+		else:
+			# Try to convert value to expected type
+			try:
+				if isinstance(existing_value, list):
+					if isinstance(value, str):
+						if value.startswith('[') and value.endswith(']'):
+							value = value[1:-1]
+						if ',' in value:
+							value = [c.strip() for c in value.split(',')]
+						elif value:
+							value = [value]
+						else:
+							value = []
+				elif isinstance(existing_value, dict):
+					if isinstance(value, str):
+						if value.startswith('{') and value.endswith('}'):
+							import json
 
-						value = json.loads(value)
-			elif isinstance(existing_value, bool):
-				if isinstance(value, str):
-					value = value.lower() in ('true', '1', 't')
-				elif isinstance(value, (int, float)):
-					value = True if value == 1 else False
-			elif isinstance(existing_value, int):
-				value = int(value)
-			elif isinstance(existing_value, float):
-				value = float(value)
-			elif isinstance(existing_value, Path):
-				value = Path(value)
-		except ValueError:
-			pass
+							value = json.loads(value)
+				elif isinstance(existing_value, bool):
+					if isinstance(value, str):
+						value = value.lower() in ('true', '1', 't')
+					elif isinstance(value, (int, float)):
+						value = True if value == 1 else False
+				elif isinstance(existing_value, int):
+					value = int(value)
+				elif isinstance(existing_value, float):
+					value = float(value)
+				elif isinstance(existing_value, Path):
+					value = Path(value)
+			except ValueError:
+				pass
 
 		if set_partial:
 			if value is None or value == target[final_key]:
@@ -425,13 +457,83 @@ class Config(DotMap):
 				partial[final_key] = value
 		target[final_key] = value
 
-	def unset(self, key, set_partial=True):
+	def _set_dict_key(self, parent_parts, subkey, value, set_partial=True, strategy=None):
+		"""Set or remove a key within a dict config field.
+
+		Args:
+			parent_parts (list[str]): Path components to the dict field (e.g. ['wordlists', 'defaults']).
+			subkey (str | None): Key within the dict to set/remove.
+			value (Any): Value to set.
+			set_partial (bool): Set in partial config.
+			strategy (str | None): 'remove' to delete the subkey.
+		"""
+		# Navigate to the dict
+		existing_dict = self
+		for part in parent_parts:
+			existing_dict = existing_dict[part]
+
+		if not isinstance(existing_dict, dict):
+			console.print(f'[bold red]Path "{".".join(parent_parts)}" is not a dict field[/].')
+			return
+
+		updated = dict(existing_dict)
+		if strategy == 'remove':
+			if subkey and subkey in updated:
+				del updated[subkey]
+			elif subkey:
+				console.print(f'[bold orange1]Key "{subkey}" not found in {".".join(parent_parts)}[/].')
+				return
+		else:
+			if subkey:
+				updated[subkey] = value
+			elif isinstance(value, dict):
+				updated.update(value)
+
+		# Traverse to the parent of the dict to set the updated value
+		target = self
+		partial = self._partial
+		for part in parent_parts[:-1]:
+			target = target[part]
+			partial = partial[part]
+		dict_key = parent_parts[-1]
+
+		if set_partial:
+			partial[dict_key] = updated
+		target[dict_key] = updated
+
+	def unset(self, key, value=None, set_partial=True):
 		"""Unset a value in the configuration using a dotted path.
 
 		Args:
 			key (str): Dotted key path.
+			value (Any | None): If provided and the field is a list, remove this item from the list.
+				If the field is a dict, this is ignored (use the key to specify the dict subkey to remove).
 			set_partial (bool): Set in partial config.
 		"""
+		if value is not None:
+			# Remove item from list
+			self.set(key, value, set_partial=set_partial, strategy='remove')
+			return
+
+		# Check if key points to a dict subkey that should be removed
+		map_key = key.upper().replace('.', '_')
+		if map_key not in self._keymap:
+			parts = key.split('.')
+			if len(parts) > 1:
+				parent_parts = parts[:-1]
+				dict_subkey = parts[-1]
+				try:
+					parent_value = self
+					for part in parent_parts:
+						parent_value = parent_value[part]
+					if isinstance(parent_value, dict):
+						self._set_dict_key(parent_parts, dict_subkey, None, set_partial=set_partial, strategy='remove')
+						return
+				except (KeyError, TypeError):
+					pass
+			console.print(f'[bold red]Key "{key}" not found in config keymap[/].')
+			return
+
 		self.set(key, None, set_partial=set_partial)
 
 	def save(self, target_path: Path = None, partial=True):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -74,6 +74,55 @@ class TestConfig(unittest.TestCase):
 		self.assertEqual(config.addons.gdrive.enabled, True)
 		self.assertEqual(config._partial.addons.gdrive.enabled, True)
 
+	def test_set_list_field_replace(self):
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('drivers.defaults', 'mongodb')
+		self.assertEqual(config.drivers.defaults, ['mongodb'])
+		config.set('drivers.defaults', 'redis')
+		self.assertEqual(config.drivers.defaults, ['redis'])
+
+	def test_set_list_field_append(self):
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('drivers.defaults', 'mongodb', strategy='append')
+		self.assertEqual(config.drivers.defaults, ['mongodb'])
+		config.set('drivers.defaults', 'redis', strategy='append')
+		self.assertEqual(config.drivers.defaults, ['mongodb', 'redis'])
+		# Duplicate should not be added
+		config.set('drivers.defaults', 'redis', strategy='append')
+		self.assertEqual(config.drivers.defaults, ['mongodb', 'redis'])
+
+	def test_unset_list_field_item(self):
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('drivers.defaults', 'mongodb', strategy='append')
+		config.set('drivers.defaults', 'redis', strategy='append')
+		self.assertEqual(config.drivers.defaults, ['mongodb', 'redis'])
+		config.unset('drivers.defaults', value='mongodb')
+		self.assertEqual(config.drivers.defaults, ['redis'])
+		config.save()
+		yaml_data = Config.read_yaml(self.config_test)
+		self.assertEqual(yaml_data['drivers']['defaults'], ['redis'])
+
+	def test_set_dict_subkey(self):
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		# Set a new key in wordlists.defaults (dict field)
+		config.set('wordlists.defaults.mylist', 'myurl')
+		self.assertEqual(config.wordlists.defaults['mylist'], 'myurl')
+		config.save()
+		yaml_data = Config.read_yaml(self.config_test)
+		self.assertEqual(yaml_data['wordlists']['defaults']['mylist'], 'myurl')
+
+	def test_unset_dict_subkey(self):
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('wordlists.defaults.mylist', 'myurl')
+		self.assertIn('mylist', config.wordlists.defaults)
+		config.unset('wordlists.defaults.mylist')
+		self.assertNotIn('mylist', config.wordlists.defaults)
+
 	def test_parse_home_dir_reduce(self):
 		from secator.config import Config
 		with self.config_test.open('w') as f:


### PR DESCRIPTION
Implements #346:

- Add `--append` flag to `secator config set` to append to list fields
- Make `VALUE` optional in `secator config unset` to remove items from list fields
- Support `secator config set <dict_field>.<key> <value>` for dict subkey updates
- Support `secator config unset <dict_field>.<key>` to remove dict subkeys
- Add `strategy` parameter to `Config.set` and `_set_dict_key` helper
- Add unit tests for all new behaviors

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--append` option to `secator config set` for appending to list fields instead of replacing them
  * Enhanced `secator config unset` to accept optional value parameter for removing specific list items or dictionary subkeys

* **Tests**
  * Added unit tests for list field operations and dictionary subkey management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->