### PR TITLE
feat(workspace): default profile per workspace

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -674,10 +674,12 @@ def config_set(key, value, strategy):
 	Examples:
 
 	\b
-	  secator config set debug ''                     # set a scalar field
-	  secator config set drivers.defaults redis       # replace list field
-	  secator config set drivers.defaults redis --append  # append to list field
-	  secator config set wordlists.defaults.http mylist  # set a dict subkey
+	  secator config set debug ''                                           # set a scalar field
+	  secator config set drivers.defaults redis                            # replace list field
+	  secator config set drivers.defaults redis --append                   # append to list field
+	  secator config set wordlists.defaults.http mylist                    # set a dict subkey
+	  secator config set workspace.default_profiles.my_ws aggressive,passive  # set workspace profiles
+	  secator config set workspace.default_profiles.my_ws test --append   # append to workspace profiles
 	"""
 	CONFIG.set(key, value, strategy=strategy if strategy else None)
 	config = CONFIG.validate()
@@ -704,9 +706,11 @@ def config_unset(key, value=None):
 	Examples:
 
 	\b
-	  secator config unset debug                      # reset scalar to default
-	  secator config unset drivers.defaults redis     # remove item from list
-	  secator config unset wordlists.defaults.http    # remove dict subkey
+	  secator config unset debug                                      # reset scalar to default
+	  secator config unset drivers.defaults redis                     # remove item from list
+	  secator config unset wordlists.defaults.http                    # remove dict subkey
+	  secator config unset workspace.default_profiles.my_ws test     # remove profile from workspace list
+	  secator config unset workspace.default_profiles.my_ws          # remove workspace profile list entirely
 	"""
 	CONFIG.unset(key, value=value)
 	config = CONFIG.validate()

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -678,8 +678,8 @@ def config_set(key, value, strategy):
 	  secator config set drivers.defaults redis                            # replace list field
 	  secator config set drivers.defaults redis --append                   # append to list field
 	  secator config set wordlists.defaults.http mylist                    # set a dict subkey
-	  secator config set workspace.default_profiles.my_ws aggressive,passive  # set workspace profiles
-	  secator config set workspace.default_profiles.my_ws test --append   # append to workspace profiles
+	  secator config set workspace.profiles.my_ws aggressive,passive  # set workspace profiles
+	  secator config set workspace.profiles.my_ws test --append   # append to workspace profiles
 	"""
 	CONFIG.set(key, value, strategy=strategy if strategy else None)
 	config = CONFIG.validate()
@@ -709,8 +709,8 @@ def config_unset(key, value=None):
 	  secator config unset debug                                      # reset scalar to default
 	  secator config unset drivers.defaults redis                     # remove item from list
 	  secator config unset wordlists.defaults.http                    # remove dict subkey
-	  secator config unset workspace.default_profiles.my_ws test     # remove profile from workspace list
-	  secator config unset workspace.default_profiles.my_ws          # remove workspace profile list entirely
+	  secator config unset workspace.profiles.my_ws test     # remove profile from workspace list
+	  secator config unset workspace.profiles.my_ws          # remove workspace profile list entirely
 	"""
 	CONFIG.unset(key, value=value)
 	config = CONFIG.validate()

--- a/secator/config.py
+++ b/secator/config.py
@@ -148,7 +148,6 @@ class Drivers(StrictModel):
 
 class Workspace(StrictModel):
 	default: str = ''
-	default_profile: List[str] = []
 	default_profiles: Dict[str, List[str]] = {}
 
 
@@ -452,7 +451,7 @@ class Config(DotMap):
 				pass
 
 		# Validate profile names before setting
-		if key in ('workspace.default_profile', 'profiles.defaults'):
+		if key in ('profiles.defaults',):
 			profile_names = value if isinstance(value, list) else ([value] if value else [])
 			if profile_names and not Config._validate_profile_names(profile_names):
 				return
@@ -494,7 +493,7 @@ class Config(DotMap):
 				return
 		else:
 			if subkey:
-				updated[subkey] = value
+				updated[subkey] = Config._parse_new_value(value)
 			elif isinstance(value, dict):
 				updated.update(value)
 
@@ -724,6 +723,46 @@ class Config(DotMap):
 
 		data = {k: v for k, v in data.items() if not k.startswith('_')}
 		return yaml.dump(data, Dumper=LineBreakDumper, sort_keys=False)
+
+	@staticmethod
+	def _parse_new_value(value):
+		"""Try to parse a string value into a structured type (int, float, bool, list, or dict)."""
+		if not isinstance(value, str):
+			return value
+		if (value.startswith('{') and value.endswith('}')) or (value.startswith('[') and value.endswith(']')):
+			try:
+				import json
+				return json.loads(value)
+			except Exception:
+				pass
+		if ',' in value:
+			return [v.strip() for v in value.split(',')]
+		try:
+			return int(value)
+		except ValueError:
+			pass
+		try:
+			return float(value)
+		except ValueError:
+			pass
+		if value.lower() in ('true', 'false'):
+			return value.lower() == 'true'
+		return value
+
+	@staticmethod
+	def _validate_profile_names(profile_names):
+		"""Validate that all profile names exist. Returns True if all valid or validation cannot run."""
+		try:
+			from secator.loader import get_configs_by_type
+			available = [p.name for p in get_configs_by_type('profile')]
+			invalid = [p for p in profile_names if p not in available]
+			if invalid:
+				console.print(f'[bold red]Invalid profile names: {", ".join(invalid)}[/]')
+				return False
+		except Exception as e:
+			import logging
+			logging.debug('Profile validation skipped due to exception', exc_info=e)
+		return True
 
 	@staticmethod
 	def build_key_map(config, base_path=[]):

--- a/secator/config.py
+++ b/secator/config.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import MutableMapping
 from pathlib import Path
 from subprocess import call, DEVNULL
 from typing import Any, Dict, List
@@ -147,6 +148,8 @@ class Drivers(StrictModel):
 
 class Workspace(StrictModel):
 	default: str = ''
+	default_profile: List[str] = []
+	default_profiles: Dict[str, List[str]] = {}
 
 
 class Payloads(StrictModel):
@@ -369,9 +372,52 @@ class Config(DotMap):
 		# Convert dotted key path to the corresponding uppercase key used in _keymap
 		map_key = key.upper().replace('.', '_')
 
-		# Check if map key exists
+		# Check if map key exists; if not, try to find a dict ancestor for sub-key setting
 		if map_key not in self._keymap:
-			console.print(f'[bold red]Key "{key}" not found in config keymap[/].')
+			anchor_path, remaining_parts = Config._find_dict_anchor(self._keymap, self, key)
+			if anchor_path is None:
+				console.print(f'[bold red]Key "{key}" not found in config keymap[/].')
+				return
+
+			# Parse value without existing type info
+			value = Config._parse_new_value(value)
+
+			# Validate profile names before setting
+			if key == 'workspace.default_profile' or key.startswith('workspace.default_profiles.'):
+				profile_names = value if isinstance(value, list) else ([value] if value else [])
+				if profile_names and not Config._validate_profile_names(profile_names):
+					return
+
+			# Navigate to dict anchor
+			target = self
+			partial = self._partial
+			for part in anchor_path:
+				target = target[part]
+				partial = partial[part]
+
+			# Navigate through intermediate sub-parts, creating nested dicts as needed
+			for part in remaining_parts[:-1]:
+				if part not in target or not isinstance(target[part], dict):
+					target[part] = {}
+				if set_partial:
+					if part not in partial or not isinstance(partial[part], dict):
+						partial[part] = {}
+				target = target[part]
+				if set_partial:
+					partial = partial[part]
+
+			final_key = remaining_parts[-1]
+			if value is None:
+				if final_key in target:
+					del target[final_key]
+				if set_partial and final_key in partial:
+					del partial[final_key]
+			else:
+				target[final_key] = value
+				if set_partial:
+					partial[final_key] = value
+
+			self._keymap = Config.build_key_map(self)
 			return
 
 		# Traverse to the second last key to handle the setting correctly
@@ -416,6 +462,12 @@ class Config(DotMap):
 		except ValueError:
 			pass
 
+		# Validate profile names before setting
+		if key in ('workspace.default_profile', 'profiles.defaults'):
+			profile_names = value if isinstance(value, list) else ([value] if value else [])
+			if profile_names and not Config._validate_profile_names(profile_names):
+				return
+
 		if set_partial:
 			if value is None or value == target[final_key]:
 				if final_key in partial:
@@ -424,6 +476,75 @@ class Config(DotMap):
 			else:
 				partial[final_key] = value
 		target[final_key] = value
+
+	@staticmethod
+	def _find_dict_anchor(keymap, config, key):
+		"""Find the deepest dict ancestor in the keymap for a dotted key path.
+
+		Returns:
+			tuple: (anchor_path, remaining_parts) or (None, None) if not found.
+		"""
+		parts = key.split('.')
+		for i in range(len(parts) - 1, 0, -1):
+			candidate_key = '_'.join(parts[:i]).upper()
+			if candidate_key in keymap:
+				candidate_path = keymap[candidate_key]
+				candidate_value = config
+				for part in candidate_path:
+					candidate_value = candidate_value[part]
+				# Accept both plain dict and DotMap (MutableMapping) to handle both cases
+				if isinstance(candidate_value, MutableMapping) and not isinstance(candidate_value, str):
+					return candidate_path, parts[i:]
+		return None, None
+
+	@staticmethod
+	def _parse_new_value(value):
+		"""Parse a string value when no existing type information is available."""
+		if not isinstance(value, str):
+			return value
+		import json
+		stripped = value.strip()
+		if stripped.startswith('[') and stripped.endswith(']'):
+			try:
+				return json.loads(stripped)
+			except (json.JSONDecodeError, ValueError):
+				pass
+		if stripped.startswith('{') and stripped.endswith('}'):
+			try:
+				return json.loads(stripped)
+			except (json.JSONDecodeError, ValueError):
+				pass
+		if ',' in value:
+			return [c.strip() for c in value.split(',')]
+		if value.lower() in ('true', 'false'):
+			return value.lower() == 'true'
+		try:
+			return int(value)
+		except ValueError:
+			pass
+		try:
+			return float(value)
+		except ValueError:
+			pass
+		return value
+
+	@staticmethod
+	def _validate_profile_names(profile_names):
+		"""Validate that profile names exist. Returns True if all are valid."""
+		if not profile_names:
+			return True
+		try:
+			from secator.loader import get_configs_by_type
+			available_profiles = get_configs_by_type('profile')
+			available_names = {p.name for p in available_profiles}
+			invalid = [n for n in profile_names if n not in available_names]
+			if invalid:
+				for name in invalid:
+					console.print(f'[bold red]Profile "{name}" not found. Run [bold green]secator profiles list[/] to see available profiles.[/]')
+				return False
+		except Exception:
+			pass
+		return True
 
 	def unset(self, key, set_partial=True):
 		"""Unset a value in the configuration using a dotted path.
@@ -621,10 +742,12 @@ class Config(DotMap):
 			if key.startswith('_'):  # ignore
 				continue
 			current_path = base_path + [key]
-			if isinstance(value, dict):
+			map_key = '_'.join(current_path).upper()
+			if isinstance(value, MutableMapping) and not isinstance(value, str):
+				key_map[map_key] = current_path  # include dict itself so sub-keys can be set
 				key_map.update(Config.build_key_map(value, current_path))
 			else:
-				key_map['_'.join(current_path).upper()] = current_path
+				key_map[map_key] = current_path
 		return key_map
 
 	def apply_env_overrides(self, print_errors=True):

--- a/secator/config.py
+++ b/secator/config.py
@@ -148,7 +148,7 @@ class Drivers(StrictModel):
 
 class Workspace(StrictModel):
 	default: str = ''
-	default_profiles: Dict[str, List[str]] = {}
+	profiles: Dict[str, List[str]] = {}
 
 
 class Payloads(StrictModel):
@@ -521,15 +521,15 @@ class Config(DotMap):
 		else:
 			if subkey:
 				new_val = Config._parse_new_value(value)
-				# For workspace.default_profiles, always coerce single strings to list
-				if parent_path == 'workspace.default_profiles' and isinstance(new_val, str):
+				# For workspace.profiles, always coerce single strings to list
+				if parent_path == 'workspace.profiles' and isinstance(new_val, str):
 					new_val = [new_val]
 				updated[subkey] = new_val
 			elif isinstance(value, dict):
 				updated.update(value)
 
-		# Validate profile names when setting workspace.default_profiles values
-		if parent_path == 'workspace.default_profiles' and subkey and subkey in updated and strategy != 'remove':
+		# Validate profile names when setting workspace.profiles values
+		if parent_path == 'workspace.profiles' and subkey and subkey in updated and strategy != 'remove':
 			new_val = updated[subkey]
 			if new_val:
 				profile_names = new_val if isinstance(new_val, list) else [new_val]

--- a/secator/config.py
+++ b/secator/config.py
@@ -471,9 +471,10 @@ class Config(DotMap):
 		Args:
 			parent_parts (list[str]): Path components to the dict field (e.g. ['wordlists', 'defaults']).
 			subkey (str | None): Key within the dict to set/remove.
-			value (Any): Value to set.
+			value (Any): Value to set, or item to remove when strategy='remove'.
 			set_partial (bool): Set in partial config.
-			strategy (str | None): 'remove' to delete the subkey.
+			strategy (str | None): 'remove' to delete the subkey or remove a list item;
+				'append' to append to an existing list value; None to replace.
 		"""
 		# Navigate to the dict
 		existing_dict = self
@@ -485,17 +486,55 @@ class Config(DotMap):
 			return
 
 		updated = dict(existing_dict)
+		parent_path = '.'.join(parent_parts)
+
 		if strategy == 'remove':
 			if subkey and subkey in updated:
-				del updated[subkey]
+				existing_val = updated[subkey]
+				if isinstance(existing_val, list) and value is not None:
+					# Remove item from list rather than deleting the key
+					if value in existing_val:
+						updated[subkey] = [v for v in existing_val if v != value]
+					else:
+						console.print(f'[bold orange1]Value "{value}" not found in {parent_path}.{subkey}[/].')
+						return
+				else:
+					del updated[subkey]
 			elif subkey:
-				console.print(f'[bold orange1]Key "{subkey}" not found in {".".join(parent_parts)}[/].')
+				console.print(f'[bold orange1]Key "{subkey}" not found in {parent_path}[/].')
 				return
-		else:
+		elif strategy == 'append':
 			if subkey:
-				updated[subkey] = Config._parse_new_value(value)
+				existing_val = updated.get(subkey, [])
+				parsed = Config._parse_new_value(value)
+				items = parsed if isinstance(parsed, list) else [parsed]
+				if isinstance(existing_val, list):
+					new_list = list(existing_val)
+					for item in items:
+						if item not in new_list:
+							new_list.append(item)
+					updated[subkey] = new_list
+				else:
+					updated[subkey] = Config._parse_new_value(value)
 			elif isinstance(value, dict):
 				updated.update(value)
+		else:
+			if subkey:
+				new_val = Config._parse_new_value(value)
+				# For workspace.default_profiles, always coerce single strings to list
+				if parent_path == 'workspace.default_profiles' and isinstance(new_val, str):
+					new_val = [new_val]
+				updated[subkey] = new_val
+			elif isinstance(value, dict):
+				updated.update(value)
+
+		# Validate profile names when setting workspace.default_profiles values
+		if parent_path == 'workspace.default_profiles' and subkey and subkey in updated and strategy != 'remove':
+			new_val = updated[subkey]
+			if new_val:
+				profile_names = new_val if isinstance(new_val, list) else [new_val]
+				if not Config._validate_profile_names(profile_names):
+					return
 
 		# Traverse to the parent of the dict to set the updated value
 		target = self

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -1316,7 +1316,7 @@ class Runner:
 				existing_profile_names.add(p)
 
 		# Add workspace-specific default profiles
-		workspace_defaults = CONFIG.workspace.default_profiles.get(self.workspace_name, [])
+		workspace_defaults = CONFIG.workspace.profiles.get(self.workspace_name, [])
 		for p in workspace_defaults:
 			if p not in existing_profile_names:
 				profiles.append(p)

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -1279,8 +1279,19 @@ class Runner:
 			elif isinstance(p, TemplateLoader):
 				existing_profile_names.add(p.name)
 
-		default_profiles = CONFIG.profiles.defaults
-		for p in default_profiles:
+		# Add global default profiles (profiles.defaults kept for backward compat; workspace.default_profile is preferred)
+		global_defaults = list(CONFIG.profiles.defaults)
+		for p in CONFIG.workspace.default_profile:
+			if p not in global_defaults:
+				global_defaults.append(p)
+		for p in global_defaults:
+			if p not in existing_profile_names:
+				profiles.append(p)
+
+		# Add workspace-specific default profiles
+		workspace_defaults_map = CONFIG.workspace.default_profiles
+		workspace_defaults = workspace_defaults_map[self.workspace_name] if self.workspace_name in workspace_defaults_map else []
+		for p in workspace_defaults:
 			if p not in existing_profile_names:
 				profiles.append(p)
 

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -1309,21 +1309,18 @@ class Runner:
 			elif isinstance(p, TemplateLoader):
 				existing_profile_names.add(p.name)
 
-		# Add global default profiles (profiles.defaults kept for backward compat; workspace.default_profile is preferred)
-		global_defaults = list(CONFIG.profiles.defaults)
-		for p in CONFIG.workspace.default_profile:
-			if p not in global_defaults:
-				global_defaults.append(p)
-		for p in global_defaults:
+		# Add global default profiles
+		for p in list(CONFIG.profiles.defaults):
 			if p not in existing_profile_names:
 				profiles.append(p)
+				existing_profile_names.add(p)
 
 		# Add workspace-specific default profiles
-		workspace_defaults_map = CONFIG.workspace.default_profiles
-		workspace_defaults = workspace_defaults_map[self.workspace_name] if self.workspace_name in workspace_defaults_map else []
+		workspace_defaults = CONFIG.workspace.default_profiles.get(self.workspace_name, [])
 		for p in workspace_defaults:
 			if p not in existing_profile_names:
 				profiles.append(p)
+				existing_profile_names.add(p)
 
 		# Abort if no profiles
 		if not profiles:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -74,6 +74,52 @@ class TestConfig(unittest.TestCase):
 		self.assertEqual(config.addons.gdrive.enabled, True)
 		self.assertEqual(config._partial.addons.gdrive.enabled, True)
 
+	def test_set_dict_subkey_tasks_overrides(self):
+		"""Test that setting a sub-key within an empty dict field works."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('tasks.overrides.nuclei.input_chunk_size', '100')
+		self.assertEqual(config.tasks.overrides['nuclei']['input_chunk_size'], 100)
+		config.save()
+		yaml_data = Config.read_yaml(self.config_test)
+		self.assertEqual(yaml_data['tasks']['overrides']['nuclei']['input_chunk_size'], 100)
+
+	def test_set_workspace_default_profiles(self):
+		"""Test setting per-workspace default profiles."""
+		from secator.config import Config
+		from unittest.mock import patch, MagicMock
+		config = Config.parse(path=self.config_test)
+		mock_profile = MagicMock()
+		mock_profile.name = 'aggressive'
+		mock_profile2 = MagicMock()
+		mock_profile2.name = 'passive'
+		with patch('secator.config.Config._validate_profile_names', return_value=True):
+			config.set('workspace.default_profiles.my_ws', 'aggressive,passive')
+		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'passive'])
+		config.save()
+		yaml_data = Config.read_yaml(self.config_test)
+		self.assertEqual(yaml_data['workspace']['default_profiles']['my_ws'], ['aggressive', 'passive'])
+
+	def test_set_workspace_default_profile(self):
+		"""Test setting global default profile for all workspaces."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		with unittest.mock.patch('secator.config.Config._validate_profile_names', return_value=True):
+			config.set('workspace.default_profile', 'aggressive,passive')
+		self.assertEqual(config.workspace.default_profile, ['aggressive', 'passive'])
+
+	def test_set_invalid_profile_name_blocked(self):
+		"""Test that setting a non-existent profile name is rejected."""
+		from secator.config import Config
+		from unittest.mock import patch, MagicMock
+		config = Config.parse(path=self.config_test)
+		mock_profile = MagicMock()
+		mock_profile.name = 'aggressive'
+		with patch('secator.loader.get_configs_by_type', return_value=[mock_profile]):
+			config.set('workspace.default_profiles.my_ws', 'nonexistent_profile')
+		# Should not have been set
+		self.assertEqual(config.workspace.default_profiles.get('my_ws'), None)
+
 	def test_parse_home_dir_reduce(self):
 		from secator.config import Config
 		with self.config_test.open('w') as f:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -85,7 +85,7 @@ class TestConfig(unittest.TestCase):
 		self.assertEqual(yaml_data['tasks']['overrides']['nuclei']['input_chunk_size'], 100)
 
 	def test_set_workspace_default_profiles(self):
-		"""Test setting per-workspace default profiles."""
+		"""Test setting per-workspace default profiles via comma-separated string."""
 		from secator.config import Config
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
@@ -95,6 +95,54 @@ class TestConfig(unittest.TestCase):
 		config.save()
 		yaml_data = Config.read_yaml(self.config_test)
 		self.assertEqual(yaml_data['workspace']['default_profiles']['my_ws'], ['aggressive', 'passive'])
+
+	def test_set_workspace_default_profiles_single(self):
+		"""Test that a single profile string is coerced to a list."""
+		from secator.config import Config
+		from unittest.mock import patch
+		config = Config.parse(path=self.config_test)
+		with patch('secator.config.Config._validate_profile_names', return_value=True):
+			config.set('workspace.default_profiles.my_ws', 'aggressive')
+		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive'])
+
+	def test_set_workspace_default_profiles_append(self):
+		"""Test appending a profile to workspace default_profiles list."""
+		from secator.config import Config
+		from unittest.mock import patch
+		config = Config.parse(path=self.config_test)
+		with patch('secator.config.Config._validate_profile_names', return_value=True):
+			config.set('workspace.default_profiles.my_ws', 'aggressive,passive')
+			config.set('workspace.default_profiles.my_ws', 'stealth', strategy='append')
+		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
+		# Duplicate should not be added
+		with patch('secator.config.Config._validate_profile_names', return_value=True):
+			config.set('workspace.default_profiles.my_ws', 'passive', strategy='append')
+		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
+
+	def test_unset_workspace_default_profiles_item(self):
+		"""Test removing a single profile from workspace default_profiles list."""
+		from secator.config import Config
+		from unittest.mock import patch
+		config = Config.parse(path=self.config_test)
+		with patch('secator.config.Config._validate_profile_names', return_value=True):
+			config.set('workspace.default_profiles.my_ws', 'aggressive,passive,stealth')
+		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
+		config.unset('workspace.default_profiles.my_ws', value='passive')
+		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'stealth'])
+		config.save()
+		yaml_data = Config.read_yaml(self.config_test)
+		self.assertEqual(yaml_data['workspace']['default_profiles']['my_ws'], ['aggressive', 'stealth'])
+
+	def test_unset_workspace_default_profiles_key(self):
+		"""Test removing an entire workspace entry from default_profiles."""
+		from secator.config import Config
+		from unittest.mock import patch
+		config = Config.parse(path=self.config_test)
+		with patch('secator.config.Config._validate_profile_names', return_value=True):
+			config.set('workspace.default_profiles.my_ws', 'aggressive,passive')
+		self.assertIn('my_ws', config.workspace.default_profiles)
+		config.unset('workspace.default_profiles.my_ws')
+		self.assertNotIn('my_ws', config.workspace.default_profiles)
 
 	def test_set_list_field_replace(self):
 		from secator.config import Config

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -84,65 +84,65 @@ class TestConfig(unittest.TestCase):
 		yaml_data = Config.read_yaml(self.config_test)
 		self.assertEqual(yaml_data['tasks']['overrides']['nuclei']['input_chunk_size'], 100)
 
-	def test_set_workspace_default_profiles(self):
+	def test_set_workspace_profiles(self):
 		"""Test setting per-workspace default profiles via comma-separated string."""
 		from secator.config import Config
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.default_profiles.my_ws', 'aggressive,passive')
-		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'passive'])
+			config.set('workspace.profiles.my_ws', 'aggressive,passive')
+		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'passive'])
 		config.save()
 		yaml_data = Config.read_yaml(self.config_test)
-		self.assertEqual(yaml_data['workspace']['default_profiles']['my_ws'], ['aggressive', 'passive'])
+		self.assertEqual(yaml_data['workspace']['profiles']['my_ws'], ['aggressive', 'passive'])
 
-	def test_set_workspace_default_profiles_single(self):
+	def test_set_workspace_profiles_single(self):
 		"""Test that a single profile string is coerced to a list."""
 		from secator.config import Config
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.default_profiles.my_ws', 'aggressive')
-		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive'])
+			config.set('workspace.profiles.my_ws', 'aggressive')
+		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive'])
 
-	def test_set_workspace_default_profiles_append(self):
-		"""Test appending a profile to workspace default_profiles list."""
+	def test_set_workspace_profiles_append(self):
+		"""Test appending a profile to workspace profiles list."""
 		from secator.config import Config
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.default_profiles.my_ws', 'aggressive,passive')
-			config.set('workspace.default_profiles.my_ws', 'stealth', strategy='append')
-		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
+			config.set('workspace.profiles.my_ws', 'aggressive,passive')
+			config.set('workspace.profiles.my_ws', 'stealth', strategy='append')
+		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
 		# Duplicate should not be added
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.default_profiles.my_ws', 'passive', strategy='append')
-		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
+			config.set('workspace.profiles.my_ws', 'passive', strategy='append')
+		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
 
-	def test_unset_workspace_default_profiles_item(self):
-		"""Test removing a single profile from workspace default_profiles list."""
+	def test_unset_workspace_profiles_item(self):
+		"""Test removing a single profile from workspace profiles list."""
 		from secator.config import Config
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.default_profiles.my_ws', 'aggressive,passive,stealth')
-		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
-		config.unset('workspace.default_profiles.my_ws', value='passive')
-		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'stealth'])
+			config.set('workspace.profiles.my_ws', 'aggressive,passive,stealth')
+		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
+		config.unset('workspace.profiles.my_ws', value='passive')
+		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'stealth'])
 		config.save()
 		yaml_data = Config.read_yaml(self.config_test)
-		self.assertEqual(yaml_data['workspace']['default_profiles']['my_ws'], ['aggressive', 'stealth'])
+		self.assertEqual(yaml_data['workspace']['profiles']['my_ws'], ['aggressive', 'stealth'])
 
-	def test_unset_workspace_default_profiles_key(self):
-		"""Test removing an entire workspace entry from default_profiles."""
+	def test_unset_workspace_profiles_key(self):
+		"""Test removing an entire workspace entry from profiles."""
 		from secator.config import Config
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.default_profiles.my_ws', 'aggressive,passive')
-		self.assertIn('my_ws', config.workspace.default_profiles)
-		config.unset('workspace.default_profiles.my_ws')
-		self.assertNotIn('my_ws', config.workspace.default_profiles)
+			config.set('workspace.profiles.my_ws', 'aggressive,passive')
+		self.assertIn('my_ws', config.workspace.profiles)
+		config.unset('workspace.profiles.my_ws')
+		self.assertNotIn('my_ws', config.workspace.profiles)
 
 	def test_set_list_field_replace(self):
 		from secator.config import Config

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -87,26 +87,14 @@ class TestConfig(unittest.TestCase):
 	def test_set_workspace_default_profiles(self):
 		"""Test setting per-workspace default profiles."""
 		from secator.config import Config
-		from unittest.mock import patch, MagicMock
+		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
-		mock_profile = MagicMock()
-		mock_profile.name = 'aggressive'
-		mock_profile2 = MagicMock()
-		mock_profile2.name = 'passive'
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
 			config.set('workspace.default_profiles.my_ws', 'aggressive,passive')
 		self.assertEqual(config.workspace.default_profiles['my_ws'], ['aggressive', 'passive'])
 		config.save()
 		yaml_data = Config.read_yaml(self.config_test)
 		self.assertEqual(yaml_data['workspace']['default_profiles']['my_ws'], ['aggressive', 'passive'])
-
-	def test_set_workspace_default_profile(self):
-		"""Test setting global default profile for all workspaces."""
-		from secator.config import Config
-		config = Config.parse(path=self.config_test)
-		with unittest.mock.patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.default_profile', 'aggressive,passive')
-		self.assertEqual(config.workspace.default_profile, ['aggressive', 'passive'])
 
 	def test_set_list_field_replace(self):
 		from secator.config import Config

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -565,14 +565,13 @@ class TestCommandRunner(unittest.TestCase):
 
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
 			with patch('secator.runners._base.CONFIG.profiles.defaults', []):
-				with patch('secator.runners._base.CONFIG.workspace.default_profile', []):
-					with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['ws_specific']}):
-						with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
-							mock_get_configs.return_value = [ws_profile]
-							with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'my_ws'}}, []) as cmd:
-								self.assertEqual(len(cmd.profiles), 1)
-								self.assertEqual(cmd.profiles[0].name, 'ws_specific')
-								self.assertEqual(cmd.run_opts.get('retries'), 5)
+				with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['ws_specific']}):
+					with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
+						mock_get_configs.return_value = [ws_profile]
+						with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'my_ws'}}, []) as cmd:
+							self.assertEqual(len(cmd.profiles), 1)
+							self.assertEqual(cmd.profiles[0].name, 'ws_specific')
+							self.assertEqual(cmd.run_opts.get('retries'), 5)
 
 	def test_workspace_specific_profiles_not_loaded_for_other_workspace(self):
 		"""Test that workspace-specific profiles are NOT loaded for a different workspace."""
@@ -598,12 +597,42 @@ class TestCommandRunner(unittest.TestCase):
 
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
 			with patch('secator.runners._base.CONFIG.profiles.defaults', []):
-				with patch('secator.runners._base.CONFIG.workspace.default_profile', []):
-					with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['ws_specific']}):
-						with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
-							mock_get_configs.return_value = [ws_profile]
-							with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'other_ws'}}, []) as cmd:
-								self.assertEqual(len(cmd.profiles), 0)
+				with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['ws_specific']}):
+					with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
+						mock_get_configs.return_value = [ws_profile]
+						with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'other_ws'}}, []) as cmd:
+							self.assertEqual(len(cmd.profiles), 0)
+
+	def test_workspace_profile_deduplication(self):
+		"""Test that a profile in both profiles.defaults and workspace.default_profiles is loaded only once."""
+		from secator.utils_test import clear_modules
+		clear_modules()
+
+		from secator.runners import Command
+		from secator.template import TemplateLoader
+		from secator.utils_test import mock_command
+		from unittest.mock import patch
+
+		class LocalMyCommand(Command):
+			input_types = ['slug']
+			cmd = 'dummy'
+			input_flag = '-u'
+			file_flag = None
+
+		shared_profile = TemplateLoader(input={
+			'name': 'shared_profile',
+			'type': 'profile',
+			'opts': {'retries': 3}
+		})
+
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
+			with patch('secator.runners._base.CONFIG.profiles.defaults', ['shared_profile']):
+				with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['shared_profile']}):
+					with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
+						mock_get_configs.return_value = [shared_profile]
+						with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'my_ws'}}, []) as cmd:
+							self.assertEqual(len(cmd.profiles), 1)
+							self.assertEqual(cmd.profiles[0].name, 'shared_profile')
 
 	def test_profile_workspace_applied_when_default(self):
 		"""A non-enforced profile workspace is applied when the user kept the default workspace."""

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -541,6 +541,103 @@ class TestCommandRunner(unittest.TestCase):
 						self.assertEqual(cmd.profiles[0].name, 'test_default')
 						self.assertEqual(cmd.run_opts.get('timeout'), 100)
 
+	def test_workspace_default_profile(self):
+		"""Test that workspace.default_profile is applied to all workspaces."""
+		from secator.utils_test import clear_modules
+		clear_modules()
+
+		from secator.runners import Command
+		from secator.template import TemplateLoader
+		from secator.utils_test import mock_command
+		from unittest.mock import patch
+
+		class LocalMyCommand(Command):
+			input_types = ['slug']
+			cmd = 'dummy'
+			input_flag = '-u'
+			file_flag = None
+
+		global_profile = TemplateLoader(input={
+			'name': 'global_default',
+			'type': 'profile',
+			'opts': {'timeout': 77}
+		})
+
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
+			with patch('secator.runners._base.CONFIG.profiles.defaults', []):
+				with patch('secator.runners._base.CONFIG.workspace.default_profile', ['global_default']):
+					with patch('secator.runners._base.CONFIG.workspace.default_profiles', {}):
+						with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
+							mock_get_configs.return_value = [global_profile]
+							with mock_command(LocalMyCommand, TARGETS, {}, []) as cmd:
+								self.assertEqual(len(cmd.profiles), 1)
+								self.assertEqual(cmd.profiles[0].name, 'global_default')
+								self.assertEqual(cmd.run_opts.get('timeout'), 77)
+
+	def test_workspace_specific_default_profiles(self):
+		"""Test that workspace.default_profiles loads profiles for the current workspace."""
+		from secator.utils_test import clear_modules
+		clear_modules()
+
+		from secator.runners import Command
+		from secator.template import TemplateLoader
+		from secator.utils_test import mock_command
+		from unittest.mock import patch
+
+		class LocalMyCommand(Command):
+			input_types = ['slug']
+			cmd = 'dummy'
+			input_flag = '-u'
+			file_flag = None
+
+		ws_profile = TemplateLoader(input={
+			'name': 'ws_specific',
+			'type': 'profile',
+			'opts': {'retries': 5}
+		})
+
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
+			with patch('secator.runners._base.CONFIG.profiles.defaults', []):
+				with patch('secator.runners._base.CONFIG.workspace.default_profile', []):
+					with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['ws_specific']}):
+						with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
+							mock_get_configs.return_value = [ws_profile]
+							with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'my_ws'}}, []) as cmd:
+								self.assertEqual(len(cmd.profiles), 1)
+								self.assertEqual(cmd.profiles[0].name, 'ws_specific')
+								self.assertEqual(cmd.run_opts.get('retries'), 5)
+
+	def test_workspace_specific_profiles_not_loaded_for_other_workspace(self):
+		"""Test that workspace-specific profiles are NOT loaded for a different workspace."""
+		from secator.utils_test import clear_modules
+		clear_modules()
+
+		from secator.runners import Command
+		from secator.template import TemplateLoader
+		from secator.utils_test import mock_command
+		from unittest.mock import patch
+
+		class LocalMyCommand(Command):
+			input_types = ['slug']
+			cmd = 'dummy'
+			input_flag = '-u'
+			file_flag = None
+
+		ws_profile = TemplateLoader(input={
+			'name': 'ws_specific',
+			'type': 'profile',
+			'opts': {'retries': 5}
+		})
+
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
+			with patch('secator.runners._base.CONFIG.profiles.defaults', []):
+				with patch('secator.runners._base.CONFIG.workspace.default_profile', []):
+					with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['ws_specific']}):
+						with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
+							mock_get_configs.return_value = [ws_profile]
+							with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'other_ws'}}, []) as cmd:
+								self.assertEqual(len(cmd.profiles), 0)
+
 
 class TestIsOwnSource(unittest.TestCase):
 	"""Verify _is_own_source correctly scopes errors to the owning runner."""

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -541,8 +541,8 @@ class TestCommandRunner(unittest.TestCase):
 						self.assertEqual(cmd.profiles[0].name, 'test_default')
 						self.assertEqual(cmd.run_opts.get('timeout'), 100)
 
-	def test_workspace_specific_default_profiles(self):
-		"""Test that workspace.default_profiles loads profiles for the current workspace."""
+	def test_workspace_specific_profiles(self):
+		"""Test that workspace.profiles loads profiles for the current workspace."""
 		from secator.utils_test import clear_modules
 		clear_modules()
 
@@ -565,7 +565,7 @@ class TestCommandRunner(unittest.TestCase):
 
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
 			with patch('secator.runners._base.CONFIG.profiles.defaults', []):
-				with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['ws_specific']}):
+				with patch('secator.runners._base.CONFIG.workspace.profiles', {'my_ws': ['ws_specific']}):
 					with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
 						mock_get_configs.return_value = [ws_profile]
 						with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'my_ws'}}, []) as cmd:
@@ -597,14 +597,14 @@ class TestCommandRunner(unittest.TestCase):
 
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
 			with patch('secator.runners._base.CONFIG.profiles.defaults', []):
-				with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['ws_specific']}):
+				with patch('secator.runners._base.CONFIG.workspace.profiles', {'my_ws': ['ws_specific']}):
 					with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
 						mock_get_configs.return_value = [ws_profile]
 						with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'other_ws'}}, []) as cmd:
 							self.assertEqual(len(cmd.profiles), 0)
 
 	def test_workspace_profile_deduplication(self):
-		"""Test that a profile in both profiles.defaults and workspace.default_profiles is loaded only once."""
+		"""Test that a profile in both profiles.defaults and workspace.profiles is loaded only once."""
 		from secator.utils_test import clear_modules
 		clear_modules()
 
@@ -627,7 +627,7 @@ class TestCommandRunner(unittest.TestCase):
 
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
 			with patch('secator.runners._base.CONFIG.profiles.defaults', ['shared_profile']):
-				with patch('secator.runners._base.CONFIG.workspace.default_profiles', {'my_ws': ['shared_profile']}):
+				with patch('secator.runners._base.CONFIG.workspace.profiles', {'my_ws': ['shared_profile']}):
 					with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
 						mock_get_configs.return_value = [shared_profile]
 						with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'my_ws'}}, []) as cmd:


### PR DESCRIPTION
Implements #https://github.com/freelabz/secator/issues/1110

## Summary

- Add `workspace.default_profile: List[str]` for global default profiles across all workspaces
- Add `workspace.default_profiles: Dict[str, List[str]]` for per-workspace default profiles
- Fix `config set` to allow setting new sub-keys within dict-type settings (fixes `tasks.overrides.nuclei.*` etc.)
- Add profile name validation when setting workspace profile config keys
- Load workspace-specific default profiles in Runner

## Test plan

- [x] Unit tests for dict sub-key setting in `test_config.py`
- [x] Unit tests for workspace profile loading in `test_runners.py`
- [ ] Run `secator test unit` to verify all existing tests pass

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Set default profiles for your workspace—either globally or customized per workspace.
  * Configuration updates now support automatic value parsing and profile validation.
  * Runners automatically apply workspace-level default profiles alongside global settings.

* **Tests**
  * Added tests for workspace profile configuration and resolution behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->