### PR TITLE
fix(config): skip type coercion when value is None in Config.set

### DIFF
--- a/secator/config.py
+++ b/secator/config.py
@@ -386,33 +386,34 @@ class Config(DotMap):
 
 		# Try to convert value to expected type
 		try:
-			if isinstance(existing_value, list):
-				if isinstance(value, str):
-					if value.startswith('[') and value.endswith(']'):
-						value = value[1:-1]
-					if ',' in value:
-						value = [c.strip() for c in value.split(',')]
-					elif value:
-						value = [value]
-					else:
-						value = []
-			elif isinstance(existing_value, dict):
-				if isinstance(value, str):
-					if value.startswith('{') and value.endswith('}'):
-						import json
+			if value is not None:
+				if isinstance(existing_value, list):
+					if isinstance(value, str):
+						if value.startswith('[') and value.endswith(']'):
+							value = value[1:-1]
+						if ',' in value:
+							value = [c.strip() for c in value.split(',')]
+						elif value:
+							value = [value]
+						else:
+							value = []
+				elif isinstance(existing_value, dict):
+					if isinstance(value, str):
+						if value.startswith('{') and value.endswith('}'):
+							import json
 
-						value = json.loads(value)
-			elif isinstance(existing_value, bool):
-				if isinstance(value, str):
-					value = value.lower() in ('true', '1', 't')
-				elif isinstance(value, (int, float)):
-					value = True if value == 1 else False
-			elif isinstance(existing_value, int):
-				value = int(value)
-			elif isinstance(existing_value, float):
-				value = float(value)
-			elif isinstance(existing_value, Path):
-				value = Path(value)
+							value = json.loads(value)
+				elif isinstance(existing_value, bool):
+					if isinstance(value, str):
+						value = value.lower() in ('true', '1', 't')
+					elif isinstance(value, (int, float)):
+						value = True if value == 1 else False
+				elif isinstance(existing_value, int):
+					value = int(value)
+				elif isinstance(existing_value, float):
+					value = float(value)
+				elif isinstance(existing_value, Path):
+					value = Path(value)
 		except ValueError:
 			pass
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -74,6 +74,16 @@ class TestConfig(unittest.TestCase):
 		self.assertEqual(config.addons.gdrive.enabled, True)
 		self.assertEqual(config._partial.addons.gdrive.enabled, True)
 
+	def test_unset_int_config_key(self):
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('runners.progress_update_frequency', 10)
+		self.assertEqual(config.get('runners.progress_update_frequency'), 10)
+		self.assertIn('progress_update_frequency', config._partial.runners)
+		# Should not raise TypeError for int-typed config keys
+		config.unset('runners.progress_update_frequency')
+		self.assertNotIn('progress_update_frequency', config._partial.runners)
+
 	def test_parse_home_dir_reduce(self):
 		from secator.config import Config
 		with self.config_test.open('w') as f:


### PR DESCRIPTION
Fix `secator c unset` crashing with TypeError for int, float, and Path typed config keys.

The type coercion block in `Config.set` called `int(value)`, `float(value)`, and `Path(value)` unconditionally. When `unset` passes `None` as the value, `int(None)` raises a TypeError.

Guard all type conversions with `if value is not None:` so unset works for any field type.

Fixes #1052

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where clearing or unsetting configuration values to `None` would cause unexpected errors during configuration updates, ensuring proper handling of null values across all configuration types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->