### PR TITLE
fix(tasks): force system OpenSSL in testssl to fix missing libproviders.so in Docker

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -60,6 +60,9 @@ class Command(Runner):
 	cwd = None
 	cwd_isolated = False
 
+	# Extra environment variables for subprocess
+	extra_env = {}
+
 	# Output encoding
 	encoding = 'utf-8'
 
@@ -526,7 +529,7 @@ class Command(Runner):
 				os.makedirs(self.cwd, exist_ok=True)
 
 			# Run the command using subprocess
-			env = os.environ
+			env = {**os.environ, **self.extra_env}
 			self.process = subprocess.Popen(
 				command,
 				stdin=subprocess.PIPE if sudo_password else None,

--- a/secator/tasks/testssl.py
+++ b/secator/tasks/testssl.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 
 from datetime import datetime
 
@@ -69,6 +70,11 @@ class testssl(Command):
 
 	@staticmethod
 	def on_cmd(self):
+		# Force system OpenSSL to avoid missing libproviders.so with bundled OpenSSL in Docker
+		openssl_path = shutil.which('openssl')
+		if openssl_path:
+			self.extra_env = {'OPENSSL': openssl_path}
+
 		output_path = self.get_opt_value(OUTPUT_PATH)
 		if not output_path:
 			output_path = f'{self.reports_folder}/.outputs/{self.fqn}.json'


### PR DESCRIPTION
testssl.sh bundles its own OpenSSL 3.x binary, but when installed via git clone, the libproviders.so provider library is absent from the bundle. This causes "Error configuring OpenSSL" before any scan can start.

Fix: Set the OPENSSL environment variable to the system openssl binary so testssl.sh bypasses its broken bundled OpenSSL.

Also adds a generic `extra_env` dict to the Command base class so any task can inject subprocess environment variables cleanly.

Fixes #1056 (Bug 3)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to inject custom environment variables during command execution, enabling flexible override of existing environment settings when needed.

* **Bug Fixes**
  * Resolved OpenSSL compatibility issues in containerized environments by properly routing to system OpenSSL, preventing failures from bundled libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->