### PR TITLE
fix(config): fix remaining CodeRabbit issues in Config.set/get

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -679,7 +679,7 @@ def config_set(key, value, strategy):
 	  secator config set drivers.defaults redis --append  # append to list field
 	  secator config set wordlists.defaults.http mylist  # set a dict subkey
 	"""
-	CONFIG.set(key, value, strategy=strategy if strategy else None)
+	CONFIG.set(key, value, strategy=strategy or None)
 	config = CONFIG.validate()
 	if config:
 		CONFIG.get(key)

--- a/secator/config.py
+++ b/secator/config.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 from subprocess import call, DEVNULL
@@ -349,7 +350,10 @@ class Config(DotMap):
 			return None
 		if print:
 			if key:
-				yaml_str = Config.dump(DotMap({key: value}), partial=False)
+				nested = value
+				for part in reversed(key.split('.')):
+					nested = {part: nested}
+				yaml_str = Config.dump(DotMap(nested), partial=False)
 			else:
 				yaml_str = Config.dump(self, partial=False)
 			Config.print_yaml(yaml_str)
@@ -416,6 +420,8 @@ class Config(DotMap):
 					return
 			value = current
 		else:
+			if strategy in ('append', 'remove'):
+				console.print(f'[bold orange1]Strategy "{strategy}" is only supported for list fields; ignoring for "{key}".[/]')
 			# Try to convert value to expected type
 			try:
 				if isinstance(existing_value, list):
@@ -431,14 +437,12 @@ class Config(DotMap):
 				elif isinstance(existing_value, dict):
 					if isinstance(value, str):
 						if value.startswith('{') and value.endswith('}'):
-							import json
-
 							value = json.loads(value)
 				elif isinstance(existing_value, bool):
 					if isinstance(value, str):
 						value = value.lower() in ('true', '1', 't')
 					elif isinstance(value, (int, float)):
-						value = True if value == 1 else False
+						value = value == 1
 				elif isinstance(existing_value, int):
 					value = int(value)
 				elif isinstance(existing_value, float):
@@ -449,12 +453,13 @@ class Config(DotMap):
 				pass
 
 		if set_partial:
-			if value is None or value == target[final_key]:
+			if value is None:
 				if final_key in partial:
 					del partial[final_key]
 				return
-			else:
-				partial[final_key] = value
+			if value == target[final_key] and final_key not in partial:
+				return
+			partial[final_key] = value
 		target[final_key] = value
 
 	def _set_dict_key(self, parent_parts, subkey, value, set_partial=True, strategy=None):
@@ -542,14 +547,18 @@ class Config(DotMap):
 		Args:
 			target_path (Path | None): If passed, saves the config to this path.
 			partial (bool): Save partial config.
+
+		Returns:
+			Path | None: Path where config was saved, or None if no path configured.
 		"""
 		if not target_path:
 			if not self._path:
-				return
+				return None
 			target_path = self._path
 		with target_path.open('w') as f:
 			f.write(Config.dump(self, partial=partial))
 		self._path = target_path
+		return target_path
 
 	def print(self, partial=True):
 		"""Print config.


### PR DESCRIPTION
Fixes remaining issues from CodeRabbit's review of PR #1129:

- Move `import json` to module level
- Fix `save()` to return path on success (was returning None, suppressing CLI success messages)
- Fix `get()` to display nested keys as proper YAML structure
- Fix `set()` partial logic: separate None (unset) from same-value check
- Add warning when strategy='append'/'remove' used on non-list fields
- Simplify `value == 1` and `strategy or None`

Closes #1130

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected strategy value resolution in configuration settings to properly handle empty or null values
  * Enhanced configuration save functionality with improved state management and explicit return behavior
  * Added informative messaging when strategy parameters are applied to incompatible configuration fields
  * Improved nested configuration lookup rendering for dotted-key paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->