### PR TITLE
fix: revert "fix(runner): show task source name even when output is piped"

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -145,7 +145,7 @@ class Runner:
 		# Runner print opts
 		self.print_item = self.run_opts.get('print_item', False) and not self.dry_run
 		self.print_line = self.run_opts.get('print_line', False) and not self.quiet
-		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input
+		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input and not self.piped_output  # noqa: E501
 		self.print_start = self.run_opts.get('print_start', False) and not self.dry_run  # noqa: E501
 		self.print_end = self.run_opts.get('print_end', False) and not self.dry_run  # noqa: E501
 		self.print_target = self.run_opts.get('print_target', False) and not self.dry_run and not self.has_parent


### PR DESCRIPTION
Reverts freelabz/secator#1121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote information display logic to properly handle piped input and output states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->