### PR TITLE
feat(profile): support workspace, drivers and exporters in profiles

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -897,13 +897,29 @@ def profile(ctx):
 
 @profile.command('list')
 def profile_list():
-	table = Table()
+	table = Table(highlight=True)
 	table.add_column('Profile name', style='bold gold3')
 	table.add_column('Description', overflow='fold')
+	table.add_column('Enforced', justify='center')
+	table.add_column('Workspace', overflow='fold')
+	table.add_column('Drivers', overflow='fold')
+	table.add_column('Exporters', overflow='fold')
 	table.add_column('Options', overflow='fold')
 	for profile in PROFILES:
-		opts_str = ', '.join(f'[yellow3]{k}[/]=[dim yellow3]{v}[/]' for k, v in profile.opts.items())
-		table.add_row(profile.name, profile.description or '', opts_str)
+		opts_str = ', '.join(f'[yellow3]{k}[/]={v}' for k, v in profile.opts.items())
+		enforced_str = '[bold red]✓[/]' if profile.enforce else ''
+		workspace_str = profile.workspace or ''
+		drivers_str = ','.join(profile.drivers) if profile.drivers else ''
+		exporters_str = ','.join(profile.exporters) if profile.exporters else ''
+		table.add_row(
+			profile.name,
+			profile.description or '',
+			enforced_str,
+			workspace_str,
+			drivers_str,
+			exporters_str,
+			opts_str,
+		)
 	console.print(table)
 
 

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -888,7 +888,7 @@ def workspace_delete(name, driver, yes):
 # ----------#
 
 
-@cli.group(aliases=['p', 'profiles'])
+@cli.group(aliases=['p', 'pf', 'profiles'])
 @click.pass_context
 def profile(ctx):
 	"""Profiles"""

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -145,7 +145,7 @@ class Runner:
 		# Runner print opts
 		self.print_item = self.run_opts.get('print_item', False) and not self.dry_run
 		self.print_line = self.run_opts.get('print_line', False) and not self.quiet
-		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input
+		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input and not self.piped_output  # noqa: E501
 		self.print_start = self.run_opts.get('print_start', False) and not self.dry_run  # noqa: E501
 		self.print_end = self.run_opts.get('print_end', False) and not self.dry_run  # noqa: E501
 		self.print_target = self.run_opts.get('print_target', False) and not self.dry_run and not self.has_parent
@@ -317,7 +317,7 @@ class Runner:
 		if source == self.unique_name:
 			return True
 		prefix = self.unique_name + '_'
-		return source.startswith(prefix) and source[len(prefix):].isdigit()
+		return source.startswith(prefix) and source[len(prefix) :].isdigit()
 
 	@property
 	def self_targets(self):
@@ -455,6 +455,7 @@ class Runner:
 		drivers = self.context.get('drivers', [])
 		if drivers:
 			from secator.loader import discover_external_drivers
+
 			discover_external_drivers()
 		hooks_list = []
 		for driver in drivers:
@@ -464,6 +465,7 @@ class Runner:
 		merged_hooks = {}
 		if hooks_list:
 			from secator.utils import deep_merge_dicts
+
 			merged_hooks = deep_merge_dicts(*hooks_list)
 		self.register_hooks(merged_hooks)
 
@@ -1342,26 +1344,127 @@ class Runner:
 		non_enforced_templates = [p for p in templates if not p.enforce]
 		templates = non_enforced_templates + enforced_templates
 		profile_opts = {}
+		profile_workspace = None
+		profile_drivers = []
+		profile_exporters = None
+		default_ws = CONFIG.workspace.default or 'default'
 		for profile in templates:
 			self.debug(f'profile {profile.name} opts (enforced: {profile.enforce}): {profile.opts}', sub='init')
 			enforced = profile.enforce or False
 			description = profile.description or ''
+
+			# Merge opts (enforced overrides user opts; otherwise user opts win)
 			if enforced:
 				profile_opts.update(profile.opts)
 			else:
 				profile_opts.update({k: self.run_opts.get(k) or v for k, v in profile.opts.items()})
+
+			# Merge workspace (scalar): enforced overrides; otherwise apply only if user kept the default
+			ws = profile.workspace or None
+			if ws:
+				if enforced:
+					profile_workspace = ws
+				elif profile_workspace is None and self.workspace_name == default_ws:
+					profile_workspace = ws
+
+			# Merge drivers (list): always additive (hooks cannot be unregistered once loaded)
+			drivers = list(profile.drivers) if profile.drivers else []
+			if drivers:
+				profile_drivers.extend(drivers)
+
+			# Merge exporters (list): enforced replaces; otherwise union with user/config exporters
+			exporters = list(profile.exporters) if profile.exporters else []
+			if exporters:
+				if enforced:
+					profile_exporters = list(exporters)
+				else:
+					current = self.run_opts.get('output')
+					if isinstance(current, str):
+						current = [e for e in current.split(',') if e]
+					base = profile_exporters if profile_exporters is not None else (current or [])
+					profile_exporters = list(dict.fromkeys(base + exporters))
+
+			# Print loaded profile info
 			if self.print_profiles:
 				msg = f'Loaded profile [bold pink3]{profile.name}[/]'
 				if description:
 					msg += f' ([dim]{description}[/])'
 				if enforced:
 					msg += ' [bold red](enforced)[/]'
-				profile_opts_str = ', '.join([f'[bold yellow3]{k}[/]=[dim yellow3]{v}[/]' for k, v in profile.opts.items()])
+				profile_fields = dict(profile.opts)
+				if ws:
+					profile_fields['workspace'] = ws
+				if drivers:
+					profile_fields['drivers'] = drivers
+				if exporters:
+					profile_fields['exporters'] = exporters
+				profile_opts_str = ', '.join([f'[bold yellow3]{k}[/]=[dim yellow3]{v}[/]' for k, v in profile_fields.items()])  # noqa: E501
 				msg += rf' \[[dim]{profile_opts_str}[/]]'
 				self._print(Info(message=msg), rich=True)
+
+		# Apply opts
 		if profile_opts:
 			self.run_opts.update(profile_opts)
+
+		# Apply workspace (used downstream to build report folders)
+		if profile_workspace:
+			self.debug(f'profile workspace -> {profile_workspace}', sub='init')
+			self.workspace_name = profile_workspace
+			self.context['workspace_name'] = profile_workspace
+			self.context['workspace_id'] = profile_workspace
+
+		# Apply exporters (consumed from run_opts['output'] right after profile resolution)
+		if profile_exporters is not None:
+			self.debug(f'profile exporters -> {profile_exporters}', sub='init')
+			self.run_opts['output'] = ','.join(profile_exporters)
+
+		# Apply drivers (load + register hooks; context['drivers'] is reused by worker __setstate__)
+		if profile_drivers:
+			self._apply_profile_drivers(profile_drivers)
+
 		return templates
+
+	def _apply_profile_drivers(self, drivers):
+		"""Load and register driver hooks specified by profiles.
+
+		Drivers are added to ``context['drivers']`` (deduped) so their hooks are also
+		re-loaded on Celery workers via :meth:`Runner.__setstate__`. Hooks are only loaded
+		for drivers not already present, since CLI-provided drivers are already registered.
+
+		Args:
+			drivers (list[str]): Driver names specified by profiles.
+		"""
+		from secator.loader import discover_external_drivers, get_available_drivers
+		from secator.utils import deep_merge_dicts
+
+		existing = list(self.context.get('drivers', []))
+		new_drivers = [d for d in dict.fromkeys(drivers) if d not in existing]
+		if not new_drivers:
+			return
+		discover_external_drivers()
+		supported = get_available_drivers()
+		hooks_list = []
+		validated = []
+		for driver in new_drivers:
+			if driver not in supported:
+				self._print(Warning(message=f'Profile driver "{driver}" is not supported - skipping.'), rich=True)
+				continue
+			if driver in ADDONS_ENABLED and not ADDONS_ENABLED[driver]:
+				self._print(Warning(message=f'Profile driver "{driver}" requires the "{driver}" addon: run `secator install addons {driver}` - skipping.'), rich=True)  # noqa: E501
+				continue
+			driver_hooks = import_dynamic(f'secator.hooks.{driver}', 'HOOKS')
+			if driver_hooks is None:
+				self._print(Warning(message=f'Missing "secator.hooks.{driver}.HOOKS" - skipping.'), rich=True)
+				continue
+			validated.append(driver)
+			hooks_list.append(driver_hooks)
+		if not validated:
+			return
+		self.debug(f'profile drivers -> {validated}', sub='init')
+		merged_hooks = deep_merge_dicts(*hooks_list)
+		self.register_hooks(merged_hooks)
+		self._hooks = deep_merge_dicts(self._hooks, merged_hooks)
+		self.context['drivers'] = list(dict.fromkeys(existing + validated))
 
 	@classmethod
 	def get_func_path(cls, func):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -367,6 +367,13 @@ class TestCli(unittest.TestCase):
 		assert result.exit_code == 0
 		assert 'Profile name' in result.output
 
+	def test_profile_list_command_aliases(self):
+		for alias in ['p', 'pf', 'profiles']:
+			result = self.runner.invoke(cli, [alias, 'list'])
+			assert not result.exception, f'alias {alias!r} raised {result.exception}'
+			assert result.exit_code == 0, f'alias {alias!r} exited {result.exit_code}'
+			assert 'Profile name' in result.output, f'alias {alias!r} output missing table'
+
 	def test_alias_list_command(self):
 		result = self.runner.invoke(cli, ['alias', 'list'])
 		assert not result.exception

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -362,14 +362,16 @@ class TestCli(unittest.TestCase):
 		assert 'Workspace name' in result.output
 
 	def test_profile_list_command(self):
-		result = self.runner.invoke(cli, ['profile', 'list'])
+		# Wide terminal so rich does not wrap the column headers across lines.
+		result = self.runner.invoke(cli, ['profile', 'list'], env={'COLUMNS': '400'})
 		assert not result.exception
 		assert result.exit_code == 0
-		assert 'Profile name' in result.output
+		for column in ['Profile name', 'Description', 'Enforced', 'Workspace', 'Drivers', 'Exporters', 'Options']:
+			assert column in result.output, f'column {column!r} missing from profile list output'
 
 	def test_profile_list_command_aliases(self):
 		for alias in ['p', 'pf', 'profiles']:
-			result = self.runner.invoke(cli, [alias, 'list'])
+			result = self.runner.invoke(cli, [alias, 'list'], env={'COLUMNS': '400'})
 			assert not result.exception, f'alias {alias!r} raised {result.exception}'
 			assert result.exit_code == 0, f'alias {alias!r} exited {result.exit_code}'
 			assert 'Profile name' in result.output, f'alias {alias!r} output missing table'

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -541,6 +541,108 @@ class TestCommandRunner(unittest.TestCase):
 						self.assertEqual(cmd.profiles[0].name, 'test_default')
 						self.assertEqual(cmd.run_opts.get('timeout'), 100)
 
+	def test_profile_workspace_applied_when_default(self):
+		"""A non-enforced profile workspace is applied when the user kept the default workspace."""
+		from secator.template import TemplateLoader
+		profile = TemplateLoader(input={
+			'name': 'ws_default_profile',
+			'type': 'profile',
+			'workspace': 'profile-ws',
+		})
+		with mock_command(MyCommand, TARGETS, {'profiles': [profile]}, []) as cmd:
+			self.assertEqual(cmd.workspace_name, 'profile-ws')
+			self.assertEqual(cmd.context.get('workspace_name'), 'profile-ws')
+			self.assertEqual(cmd.context.get('workspace_id'), 'profile-ws')
+
+	def test_profile_workspace_not_applied_when_user_set(self):
+		"""A non-enforced profile workspace yields to a user-specified workspace."""
+		from secator.template import TemplateLoader
+		profile = TemplateLoader(input={
+			'name': 'ws_user_profile',
+			'type': 'profile',
+			'workspace': 'profile-ws',
+		})
+		opts = {'profiles': [profile], 'context': {'workspace_name': 'user-ws'}}
+		with mock_command(MyCommand, TARGETS, opts, []) as cmd:
+			self.assertEqual(cmd.workspace_name, 'user-ws')
+
+	def test_profile_workspace_enforced_overrides_user(self):
+		"""An enforced profile workspace overrides a user-specified workspace."""
+		from secator.template import TemplateLoader
+		profile = TemplateLoader(input={
+			'name': 'ws_enforced_profile',
+			'type': 'profile',
+			'enforce': True,
+			'workspace': 'enforced-ws',
+		})
+		opts = {'profiles': [profile], 'context': {'workspace_name': 'user-ws'}}
+		with mock_command(MyCommand, TARGETS, opts, []) as cmd:
+			self.assertEqual(cmd.workspace_name, 'enforced-ws')
+
+	def test_profile_exporters_union(self):
+		"""A non-enforced profile unions its exporters with the user-specified ones."""
+		from secator.template import TemplateLoader
+		profile = TemplateLoader(input={
+			'name': 'exp_union_profile',
+			'type': 'profile',
+			'exporters': ['json', 'csv'],
+		})
+		with mock_command(MyCommand, TARGETS, {'profiles': [profile], 'output': 'txt'}, []) as cmd:
+			self.assertEqual(cmd.run_opts.get('output'), 'txt,json,csv')
+
+	def test_profile_exporters_enforced_replaces(self):
+		"""An enforced profile replaces the user-specified exporters."""
+		from secator.template import TemplateLoader
+		profile = TemplateLoader(input={
+			'name': 'exp_enforced_profile',
+			'type': 'profile',
+			'enforce': True,
+			'exporters': ['json'],
+		})
+		with mock_command(MyCommand, TARGETS, {'profiles': [profile], 'output': 'txt'}, []) as cmd:
+			self.assertEqual(cmd.run_opts.get('output'), 'json')
+
+	def test_profile_drivers_load_and_register(self):
+		"""A profile-specified driver is validated, loaded, registered and added to context['drivers']."""
+		import sys
+		import types
+		from secator.template import TemplateLoader
+
+		def driver_on_init(self):
+			pass
+
+		# Register a real fake hooks module so the real import_dynamic resolves it via sys.modules
+		# (robust against module-reloading from sibling tests calling clear_modules()).
+		fake_module = types.ModuleType('secator.hooks.fakedriver')
+		fake_module.HOOKS = {'on_init': [driver_on_init]}
+		sys.modules['secator.hooks.fakedriver'] = fake_module
+		self.addCleanup(sys.modules.pop, 'secator.hooks.fakedriver', None)
+
+		profile = TemplateLoader(input={
+			'name': 'driver_profile',
+			'type': 'profile',
+			'drivers': ['fakedriver'],
+		})
+		with patch('secator.loader.get_available_drivers', return_value=['fakedriver']), \
+			patch('secator.loader.discover_external_drivers', return_value=['fakedriver']):
+			with mock_command(MyCommand, TARGETS, {'profiles': [profile]}, []) as cmd:
+				self.assertIn('fakedriver', cmd.context.get('drivers', []))
+				self.assertIn(driver_on_init, cmd.resolved_hooks.get('on_init', []))
+				self.assertIn(driver_on_init, cmd._hooks.get('on_init', []))
+
+	def test_profile_unsupported_driver_skipped(self):
+		"""An unsupported profile driver is skipped without being added to context['drivers']."""
+		from secator.template import TemplateLoader
+		profile = TemplateLoader(input={
+			'name': 'bad_driver_profile',
+			'type': 'profile',
+			'drivers': ['doesnotexist'],
+		})
+		with patch('secator.loader.get_available_drivers', return_value=['mongodb']), \
+			patch('secator.loader.discover_external_drivers', return_value=[]):
+			with mock_command(MyCommand, TARGETS, {'profiles': [profile]}, []) as cmd:
+				self.assertNotIn('doesnotexist', cmd.context.get('drivers', []))
+
 
 class TestIsOwnSource(unittest.TestCase):
 	"""Verify _is_own_source correctly scopes errors to the owning runner."""


### PR DESCRIPTION
## Summary

Profiles can now set `workspace`, `drivers` (list) and `exporters` (list) in addition to `opts`, so a profile can fully describe where results go, which drivers wire up, and how output is exported — not just task/workflow/scan option overrides.

```yaml
type: profile
name: example
enforce: false
workspace: my-workspace
drivers:
  - mongodb
exporters:
  - json
  - csv
opts:
  ...
```

## Semantics

All three fields honor the existing `enforce` flag, consistent with `opts`:

- **workspace** (scalar): enforced → overrides the user's workspace; non-enforced → applied only if the user kept the default workspace.
- **drivers** (list): additive. Hooks are loaded through the existing dynamic-driver mechanism (`discover_external_drivers` → `import_dynamic` → `register_hooks`) and added to `context['drivers']`, so **worker mode re-loads them automatically** via `Runner.__setstate__` (the #1126 path). Also merged into `self._hooks` so they propagate to sub-runners. Unsupported / addon-missing drivers emit a `Warning` and are skipped.
- **exporters** (list): enforced → replaces user/config exporters; non-enforced → unions with them (written back to `run_opts['output']`, consumed by the existing exporter resolution).

The "Loaded profile ..." log line now also shows the new fields.

## Implementation

All changes are contained in `Runner.resolve_profiles()` (`secator/runners/_base.py`) plus a small `_apply_profile_drivers()` helper. No profile schema change is needed (profiles are `TemplateLoader`/`DotMap`). No shipped profiles were modified.

## Known limitation

A profile that *adds* the `api` driver does not trigger the CLI-side workspace-name API lookup (`get_workspace_name`), since that only runs in `cli_helper.py`.

## Testing

End-to-end with an httpx task and a dropped `~/.secator/templates/test.yml` profile changing all three fields:

- workspace → reports written under `reports/test_workspace/...`
- drivers → custom external driver loaded and its hooks fired on both the Task and the httpx sub-runner
- exporters → `json` + `csv` reports produced
- precedence verified: `-ws cli-override` beat the non-enforced profile workspace; `-o txt` unioned to `txt, json, csv`

Adds 8 unit tests (workspace apply/block/enforce, exporter union/replace, driver load+register, unsupported-driver skip).

- `secator test unit --test test_runners` → 45 passed
- `secator test unit --test test_celery` → 16 passed (pickle/worker path unaffected)
- `secator test lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profiles now support workspace selection with configurable precedence levels (default, user-set, enforced).
  * Profiles now include driver and exporter configuration options.

* **Bug Fixes**
  * Improved remote information output handling in piped execution mode.

* **Tests**
  * Added unit tests for profile-driven configuration, covering workspace, driver, and exporter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->