### PR TITLE
feat(cli): saved queries and `secator query` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ secator config unset queries.critical_vulns
 
 ```sh
 # Run a saved query, formatting the output
-secator query critical_vulns -ws secator.cloud -f "vulnerability.matched_at"
+secator query critical_vulns -ws secator.cloud -f "{vulnerability.matched_at}"
 
 # Run a raw filter expression directly
 secator query "vulnerability.severity == 'high' && vulnerability.tags ~= 'exploitable'"

--- a/README.md
+++ b/README.md
@@ -244,6 +244,44 @@ secator w url_<TAB>     # completes to url_crawl, url_fuzz, url_dirsearch, etc.
 secator x nmap --profiles ag<TAB>  # completes to aggressive
 ```
 
+### Queries
+
+`secator` lets you save named report queries and run them with the `secator query` command.
+
+Queries are stored in your config under the `queries` namespace (`~/.secator/config.yml`):
+
+```sh
+# Add / update a query (name -> filter expression)
+secator config set queries.critical_vulns "vulnerability.severity_nb < 2"
+
+# List all saved queries
+secator config get queries
+
+# Remove a query
+secator config unset queries.critical_vulns
+```
+
+`secator query <arg>` resolves its argument in three steps:
+
+1. **Saved query name** — if `<arg>` matches a saved query, its expression is used.
+2. **Filter expression** — if `<arg>` looks like a filter (contains `==`, `<`, `~=`, `&&`, …), it is passed straight through.
+3. **Natural language** — otherwise it is sent to AI chat (`secator x ai --mode chat`).
+
+```sh
+# Run a saved query, formatting the output
+secator query critical_vulns -ws secator.cloud -f "vulnerability.matched_at"
+
+# Run a raw filter expression directly
+secator query "vulnerability.severity == 'high' && vulnerability.tags ~= 'exploitable'"
+
+# Ask a natural-language question (runs the AI chat task)
+secator query -ws secator.cloud "Analyze my workspace data"
+```
+
+`secator query` accepts the same options as `secator r show` (`-o/--output`,
+`-d/--time-delta`, `-f/--format`, `-w/-ws/--workspace`, `--driver`, `--dedupe`).
+On the AI-chat path only the workspace and prompt are used.
+
 ## Installing tools
 
 `secator` auto-installs tools when you first use them.

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1010,6 +1010,47 @@ def list_aliases(silent):
 
 
 # --------#
+# QUERY  #
+# --------#
+
+
+@cli.command(name='query', aliases=['q'])
+@click.argument('arg', required=False)
+@click.option('-o', '--output', type=str, default='console', help='Exporters')
+@click.option('-d', '--time-delta', type=str, default=None, help='Keep results newer than time delta. E.g: 26m, 1d, 1y')  # noqa: E501
+@click.option('--format', '-f', 'fmt', type=str, default=None, help="Format string for results, e.g. '{vulnerability.matched_at}'")  # noqa: E501
+@click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
+@click.pass_context
+def query(ctx, arg, output, time_delta, fmt, workspace, driver, dedupe):
+	"""Run a saved query, a raw filter expression, or an AI chat prompt.
+
+	ARG resolves in order:
+
+	\b
+	  1. a saved query name (see `secator config get queries`)
+	  2. a filter expression (e.g. "vulnerability.severity == 'high'")
+	  3. natural language -> AI chat (`secator x ai --mode chat`)
+	"""
+	if not arg:
+		raise click.UsageError('Missing argument ARG (a query name, expression, or prompt).')
+
+	# 1. Saved query name
+	if arg in CONFIG.queries:
+		run_report_show(None, output, time_delta, CONFIG.queries[arg], fmt, workspace, driver, dedupe)
+		return
+
+	# 2. Raw filter expression
+	if _looks_like_query_expr(arg):
+		run_report_show(None, output, time_delta, arg, fmt, workspace, driver, dedupe)
+		return
+
+	# 3. Natural language -> AI chat
+	run_ai_chat(ctx, arg, workspace)
+
+
+# --------#
 # REPORT #
 # --------#
 
@@ -1268,6 +1309,19 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	if fmt:
 		report.data['results'] = _apply_format(report.data['results'], fmt)
 	report.send()
+
+
+def run_ai_chat(ctx, prompt, workspace):
+	"""Run the `ai` task in chat mode with the given PROMPT.
+
+	Equivalent to: secator x ai --mode chat -ws <workspace> -p "<prompt>"
+	"""
+	task_group = ctx.find_root().command.commands['task']
+	ai_cmd = task_group.commands['ai']
+	invoke_kwargs = {'prompt': prompt, 'mode': 'chat'}
+	if workspace:
+		invoke_kwargs['workspace'] = workspace
+	ctx.invoke(ai_cmd, **invoke_kwargs)
 
 
 @report.command('show')

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1020,6 +1020,28 @@ def report():
 	pass
 
 
+# Operators / tokens that mark a string as a filter expression rather than natural language.
+_QUERY_EXPR_OPERATORS = ('==', '!=', '<=', '>=', '~=', '<', '>', '&&', '||')
+_QUERY_EXPR_WORD_OPERATORS = (' and ', ' or ', ' in ')
+
+
+def _looks_like_query_expr(value):
+	"""Return True if VALUE looks like a report filter expression (vs natural language).
+
+	Heuristics (any match => expression):
+	  - contains a comparison/logical operator (==, !=, <, >, <=, >=, ~=, &&, ||)
+	  - contains a word operator surrounded by spaces ( and / or / in )
+	  - matches a bare dotted field-access path like 'word.word' (e.g. extra_data.published)
+	"""
+	if not value:
+		return False
+	if any(op in value for op in _QUERY_EXPR_OPERATORS):
+		return True
+	if any(op in value for op in _QUERY_EXPR_WORD_OPERATORS):
+		return True
+	return bool(re.fullmatch(r'\w+(?:\.\w+)+', value.strip()))
+
+
 def _apply_format(results, fmt):
 	"""Apply a --format string to report results, returning formatted strings grouped by type.
 

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -68,7 +68,7 @@ PROFILES = get_configs_by_type('profile')
 @click.option('--quiet', '-quiet', '-q', is_flag=True, default=False)
 @click.pass_context
 def cli(ctx, version, quiet):
-	"""Secator CLI."""
+	"""Secator CLI"""
 	ctx.obj = {'piped_input': S_ISFIFO(os.fstat(0).st_mode), 'piped_output': not sys.stdout.isatty()}
 	if not ctx.obj['piped_output'] and not quiet:
 		console.print(ASCII, highlight=False)
@@ -87,7 +87,7 @@ def cli(ctx, version, quiet):
 @cli.group(aliases=['x', 't', 'tasks'], invoke_without_command=True)
 @click.pass_context
 def task(ctx):
-	"""Run a task."""
+	"""Run a task"""
 	if ctx.invoked_subcommand is None:
 		ctx.get_help()
 
@@ -103,7 +103,7 @@ for config in TASKS:
 @cli.group(cls=OrderedGroup, aliases=['w', 'workflows'], invoke_without_command=True)
 @click.pass_context
 def workflow(ctx):
-	"""Run a workflow."""
+	"""Run a workflow"""
 	if ctx.invoked_subcommand is None:
 		ctx.get_help()
 
@@ -123,7 +123,7 @@ for config in WORKFLOWS:
 @cli.group(cls=OrderedGroup, aliases=['s', 'scans'], invoke_without_command=True)
 @click.pass_context
 def scan(ctx):
-	"""Run a scan."""
+	"""Run a scan"""
 	if ctx.invoked_subcommand is None:
 		ctx.get_help()
 
@@ -157,7 +157,7 @@ for config in SCANS:
 @click.option('--without-mingle', is_flag=True)
 @click.option('--without-heartbeat', is_flag=True)
 def worker(hostname, concurrency, reload, queue, pool, quiet, loglevel, check, dev, stop, show, use_command_runner, without_gossip, without_mingle, without_heartbeat):  # noqa: E501
-	"""Run a worker."""
+	"""Run a worker"""
 
 	# Check Celery addon is installed
 	if not ADDONS_ENABLED['worker']:
@@ -232,7 +232,7 @@ def worker(hostname, concurrency, reload, queue, pool, quiet, loglevel, check, d
 
 @cli.group(aliases=['u'])
 def util():
-	"""Run a utility."""
+	"""Run a utility"""
 	pass
 
 
@@ -240,7 +240,7 @@ def util():
 @click.option('--timeout', type=float, default=3, help='Proxy timeout (in seconds)')
 @click.option('--number', '-n', type=int, default=1, help='Number of proxies')
 def proxy(timeout, number):
-	"""Get random proxies from FreeProxy."""
+	"""Get random proxies from FreeProxy"""
 	import requests
 
 	if CONFIG.offline_mode:
@@ -277,7 +277,7 @@ def proxy(timeout, number):
 @click.option('--listen', '-l', is_flag=True, default=False, help='Spawn netcat listener on specified port')
 @click.option('--force', is_flag=True)
 def revshell(name, host, port, interface, listen, force):
-	"""Show reverse shell source codes and run netcat listener (-l)."""
+	"""Show reverse shell source codes and run netcat listener (-l)"""
 	if host is None:  # detect host automatically
 		host = detect_host(interface)
 		if not host:
@@ -344,7 +344,7 @@ def revshell(name, host, port, interface, listen, force):
 @click.option('--port', '-p', type=int, default=9001, help='HTTP server port')
 @click.option('--interface', '-i', type=str, default=None, help='Interface to use to auto-detect host IP')
 def serve(directory, host, port, interface):
-	"""Run HTTP server to serve payloads."""
+	"""Run HTTP server to serve payloads"""
 	fnames = list(os.listdir(directory))
 	if not fnames:
 		console.print(Warning(message=f'No payloads found in {directory}.'))
@@ -372,7 +372,7 @@ def serve(directory, host, port, interface):
 @click.option('--shell', type=click.Choice(['bash', 'zsh', 'fish']), default='bash', help='Shell type')
 @click.option('--install', is_flag=True, help='Install completion to shell config file')
 def completion(shell, install):
-	"""Show or install shell completion for secator."""
+	"""Show or install shell completion for secator"""
 	# Get completion script
 	env_var = '_SECATOR_COMPLETE'
 	completion_cmd = f'{env_var}={shell}_source secator'
@@ -523,7 +523,7 @@ def record(file, name, width, height, font_size, line_height, output_dir):
 
 @util.group()
 def gif():
-	"""GIF manipulation commands."""
+	"""GIF manipulation commands"""
 	if not ADDONS_ENABLED['dev']:
 		console.print(Error(message='Missing dev addon: please run "secator install addons dev"'))
 		sys.exit(1)
@@ -594,7 +594,7 @@ def info(input_gif):
 @util.command('build')
 @click.option('--version', type=str, help='Override version specified in pyproject.toml')
 def build(version):
-	"""Build secator PyPI package."""
+	"""Build secator PyPI package"""
 	if not DEV_PACKAGE:
 		console.print(Error(message='You MUST use a development version of secator to make builds'))
 		sys.exit(1)
@@ -622,7 +622,7 @@ def build(version):
 
 @util.command('publish')
 def publish():
-	"""Publish secator PyPI package."""
+	"""Publish secator PyPI package"""
 	if not DEV_PACKAGE:
 		console.print(Error(message='You MUST use a development version of secator to publish builds.'))
 		sys.exit(1)
@@ -646,7 +646,7 @@ def publish():
 
 @cli.group(aliases=['c'])
 def config():
-	"""View or edit config."""
+	"""View or edit config"""
 	pass
 
 
@@ -654,7 +654,7 @@ def config():
 @click.option('--user/--full', is_flag=True, help='Show config (user/full)')
 @click.argument('key', required=False)
 def config_get(user, key=None):
-	"""Get config value."""
+	"""Get config value"""
 	if key is None:
 		partial = user and default_config != CONFIG
 		CONFIG.print(partial=partial)
@@ -722,7 +722,7 @@ def config_unset(key, value=None):
 @config.command('edit')
 @click.option('--resume', is_flag=True)
 def config_edit(resume):
-	"""Edit config."""
+	"""Edit config"""
 	tmp_config = CONFIG.dirs.data / 'config.yml.patch'
 	if not tmp_config.exists() or not resume:
 		shutil.copyfile(config_path, tmp_config)
@@ -739,7 +739,7 @@ def config_edit(resume):
 @config.command('default')
 @click.option('--save', type=str, help='Save default config to file.')
 def config_default(save):
-	"""Get default config."""
+	"""Get default config"""
 	default_config.print(partial=False)
 	if save:
 		default_config.save(target_path=Path(save), partial=False)
@@ -750,7 +750,7 @@ def config_default(save):
 # @_config.command('reset')
 # @click.argument('key')
 # def config_reset(key):
-# 	"""Reset config value to default."""
+# 	"""Reset config value to default"""
 # 	success = CONFIG.set(key, None)
 # 	if success:
 # 		CONFIG.print()
@@ -763,13 +763,13 @@ def config_default(save):
 # -----------#
 @cli.group(aliases=['ws', 'workspaces'])
 def workspace():
-	"""Workspaces."""
+	"""Workspaces"""
 	pass
 
 
 @workspace.command('list')
 def workspace_list():
-	"""List workspaces."""
+	"""List workspaces"""
 	workspaces = {}
 	reports_dir = Path(CONFIG.dirs.reports)
 	# Discover all workspace directories (including empty ones)
@@ -804,7 +804,7 @@ def workspace_list():
 @workspace.command(name='use', aliases=['create'])
 @click.argument('name')
 def workspace_use(name):
-	"""Use a workspace (set as default)."""
+	"""Use a workspace (set as default)"""
 	CONFIG.set('workspace.default', name)
 	config = CONFIG.validate()
 	if config:
@@ -816,7 +816,7 @@ def workspace_use(name):
 
 @workspace.command('current')
 def workspace_current():
-	"""Show current default workspace."""
+	"""Show current default workspace"""
 	current = CONFIG.workspace.default or 'default'
 	console.print(f'Current workspace: [bold gold3]{current}[/]')
 
@@ -826,7 +826,7 @@ def workspace_current():
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
 @click.option('-y', '--yes', is_flag=True, default=False, help='Skip confirmation prompt')
 def workspace_delete(name, driver, yes):
-	"""Delete a workspace and all associated reports. NAME: workspace name."""
+	"""Delete a workspace and all associated reports. NAME: workspace name"""
 	workspace_folder = Path(CONFIG.dirs.reports) / sanitize_folder_name(name)
 
 	actions = []
@@ -914,14 +914,14 @@ def profile_list():
 
 @cli.group(aliases=['a', 'aliases'])
 def alias():
-	"""Aliases."""
+	"""Aliases"""
 	pass
 
 
 @alias.command('enable')
 @click.pass_context
 def enable_aliases(ctx):
-	"""Enable aliases."""
+	"""Enable aliases"""
 	fpath = f'{CONFIG.dirs.data}/.aliases'
 	aliases = ctx.invoke(list_aliases, silent=True)
 	aliases_str = '\n'.join(aliases)
@@ -943,7 +943,7 @@ echo "source {fpath} >> ~/.bashrc" # or add this line to your ~/.bashrc to load 
 @alias.command('disable')
 @click.pass_context
 def disable_aliases(ctx):
-	"""Disable aliases."""
+	"""Disable aliases"""
 	fpath = f'{CONFIG.dirs.data}/.unalias'
 	aliases = ctx.invoke(list_aliases, silent=True)
 	aliases_str = ''
@@ -1024,15 +1024,7 @@ def list_aliases(silent):
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.pass_context
 def query(ctx, arg, output, time_delta, fmt, workspace, driver, dedupe):
-	"""Run a saved query, a raw filter expression, or an AI chat prompt.
-
-	ARG resolves in order:
-
-	\b
-	  1. a saved query name (see `secator config get queries`)
-	  2. a filter expression (e.g. "vulnerability.severity == 'high'")
-	  3. natural language -> AI chat (`secator x ai --mode chat`)
-	"""
+	"""Query"""
 	if not arg:
 		raise click.UsageError('Missing argument ARG (a query name, expression, or prompt).')
 
@@ -1057,7 +1049,7 @@ def query(ctx, arg, output, time_delta, fmt, workspace, driver, dedupe):
 
 @cli.group(aliases=['r', 'reports'])
 def report():
-	"""Reports."""
+	"""Reports"""
 	pass
 
 
@@ -1084,6 +1076,7 @@ def _looks_like_query_expr(value):
 	if re.fullmatch(r'\w+(?:\.\w+)+', value.strip()):
 		return True
 	from secator.output_types import OUTPUT_TYPES
+
 	return value.strip() in {cls.get_name() for cls in OUTPUT_TYPES}
 
 
@@ -1338,12 +1331,12 @@ def run_ai_chat(ctx, prompt, workspace):
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 def report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe):
-	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""
+	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)"""
 	run_report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe)
 
 
 def _load_report_data(path):
-	"""Read report JSON to extract info section and count vulnerability severities."""
+	"""Read report JSON to extract info section and count vulnerability severities"""
 	info = {}
 	vuln_counts = {'critical': 0, 'high': 0, 'medium': 0, 'low': 0}
 	with open(path, 'r') as f:
@@ -1358,7 +1351,7 @@ def _load_report_data(path):
 
 
 def _format_vuln_counts(counts):
-	"""Format vulnerability counts as a colored rich string like '2H|10M|5L'."""
+	"""Format vulnerability counts as a colored rich string like '2H|10M|5L'"""
 	severity_labels = [
 		('critical', 'C', 'bold red'),
 		('high', 'H', 'red'),
@@ -1380,22 +1373,22 @@ def _format_vuln_counts(counts):
 @click.option('--show-all', is_flag=True, default=False, help='Show all columns including report path')
 @click.pass_context
 def report_list(ctx, workspace, runner_type, time_delta, show_all):
-	"""List all secator reports."""
+	"""List all secator reports"""
 	paths = list_reports(workspace=workspace, type=runner_type, timedelta=human_to_timedelta(time_delta))
 	paths = sorted(paths, key=lambda x: x.stat().st_mtime, reverse=False)
 
 	# Build table
 	table = Table()
-	table.add_column("Workspace", style="bold gold3")
-	table.add_column("Name")
-	table.add_column("Id")
-	table.add_column("Target")
-	table.add_column("Profiles")
-	table.add_column("Start Date")
-	table.add_column("End Date")
-	table.add_column("Elapsed")
-	table.add_column("Status", style="green")
-	table.add_column("Vulnerabilities")
+	table.add_column('Workspace', style='bold gold3')
+	table.add_column('Name')
+	table.add_column('Id')
+	table.add_column('Target')
+	table.add_column('Profiles')
+	table.add_column('Start Date')
+	table.add_column('End Date')
+	table.add_column('Elapsed')
+	table.add_column('Status', style='green')
+	table.add_column('Vulnerabilities')
 	if show_all:
 		table.add_column('Path')
 
@@ -1428,14 +1421,14 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 			# Update table
 			row = [
 				path_info['workspace'],
-				f"[bold blue]{report_info.get('name', '')}[/]",
+				f'[bold blue]{report_info.get("name", "")}[/]',
 				f'[link={Path(path).as_uri()}]{runner_id}[/link]',
 				first_target,
 				profiles_str,
 				humanize_date(report_info.get('start_time')),
 				humanize_date(report_info.get('end_time')),
 				report_info.get('elapsed_human', ''),
-				f"[{status_color}]{status}[/]",
+				f'[{status_color}]{status}[/]',
 				_format_vuln_counts(vuln_counts),
 			]
 			if show_all:
@@ -1456,7 +1449,7 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 @click.option('-ws', '-w', '--workspace', type=str, default=None, help='Workspace name')
 @click.option('--show-all', is_flag=True, default=False, help='Show all entries (do not truncate lists/dicts or errors)')  # noqa: E501
 def report_info(runner_id, workspace, show_all):
-	"""Show runner info from a report. RUNNER_ID: runner path (e.g. scans/0)."""
+	"""Show runner info from a report. RUNNER_ID: runner path (e.g. scans/0)"""
 	MAX_ENTRIES = 20
 
 	workspace_name = workspace or CONFIG.workspace.default or 'default'
@@ -1533,7 +1526,7 @@ def report_info(runner_id, workspace, show_all):
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
 @click.option('-y', '--yes', is_flag=True, default=False, help='Skip confirmation prompt')
 def report_delete(runner_id, workspace, driver, yes):
-	"""Delete a report. RUNNER_ID: runner path (e.g. tasks/24)."""
+	"""Delete a report. RUNNER_ID: runner path (e.g. tasks/24)"""
 	workspace_name = workspace or CONFIG.workspace.default or 'default'
 
 	parts = runner_id.split('/')
@@ -1640,18 +1633,18 @@ def report_delete(runner_id, workspace, driver, yes):
 # TODO: work on this
 # @cli.group(aliases=['d'])
 # def deploy():
-# 	"""Deploy secator."""
+# 	"""Deploy secator"""
 # 	pass
 
 # @deploy.command()
 # def docker_compose():
-# 	"""Deploy secator on docker-compose."""
+# 	"""Deploy secator on docker-compose"""
 # 	pass
 
 # @deploy.command()
 # @click.option('-t', '--target', type=str, default='minikube', help='Deployment target amongst minikube, gke')
 # def k8s():
-# 	"""Deploy secator on Kubernetes."""
+# 	"""Deploy secator on Kubernetes"""
 # 	pass
 
 
@@ -1666,7 +1659,7 @@ def report_delete(runner_id, workspace, driver, yes):
 @click.option('--strict', '-strict', is_flag=True, default=False, help='Fail if missing tools')
 @click.option('--bleeding', '-bleeding', is_flag=True, default=False, help='Check bleeding edge version of tools')
 def health(json_, debug, strict, bleeding):
-	"""Get health status."""
+	"""Health"""
 	tools = discover_tasks()
 	upgrade_cmd = ''
 	results = []
@@ -1824,7 +1817,7 @@ def health(json_, debug, strict, bleeding):
 
 @cli.command(name='cheatsheet', aliases=['cs'])
 def cheatsheet():
-	"""Display a cheatsheet of secator commands."""
+	"""Cheatsheet"""
 	from rich.panel import Panel
 	from rich import box
 
@@ -2057,7 +2050,7 @@ def run_install(title=None, cmd=None, packages=None, next_steps=None):
 
 @cli.group(aliases=['i'])
 def install():
-	"""Install langs, tools and addons."""
+	"""Install things"""
 	pass
 
 
@@ -2207,7 +2200,7 @@ def langs():
 
 @langs.command('go')
 def install_go():
-	"""Install Go."""
+	"""Install Go"""
 	run_install(
 		cmd='wget -O - https://raw.githubusercontent.com/freelabz/secator/main/scripts/install_go.sh | sudo sh',
 		title='Go',
@@ -2217,7 +2210,7 @@ def install_go():
 
 @langs.command('ruby')
 def install_ruby():
-	"""Install Ruby."""
+	"""Install Ruby"""
 	run_install(
 		packages={
 			'apt': ['ruby-full', 'rubygems'],
@@ -2234,7 +2227,7 @@ def install_ruby():
 @click.option('--cleanup', is_flag=True, default=False, help='Clean up tools after installation.')
 @click.option('--fail-fast', is_flag=True, default=False, help='Fail fast if any tool fails to install.')
 def install_tools(cmds, cleanup, fail_fast):
-	"""Install supported tools."""
+	"""Install supported tools"""
 	if CONFIG.offline_mode:
 		console.print(Error(message='Cannot run this command in offline mode.'))
 		sys.exit(1)
@@ -2294,7 +2287,7 @@ def install_tools(cmds, cleanup, fail_fast):
 @cli.command('update')
 @click.option('--all', '-a', is_flag=True, help='Update all secator dependencies (addons, tools, ...)')
 def update(all):
-	"""Update to latest version."""
+	"""Update to latest version"""
 	if CONFIG.offline_mode:
 		console.print(Error(message='Cannot run this command in offline mode.'))
 		sys.exit(1)
@@ -2349,7 +2342,7 @@ def update(all):
 
 @cli.group(cls=OrderedGroup)
 def test():
-	"""[dim]Run tests (dev build only)."""
+	"""[dim]Run tests (dev build only)"""
 	if not DEV_PACKAGE:
 		console.print(Error(message='You MUST use a development version of secator to run tests.'))
 		sys.exit(1)
@@ -2396,7 +2389,7 @@ def run_test(cmd, name=None, exit=True, verbose=False, use_command_runner=True):
 @test.command()
 @click.option('--linter', '-l', type=click.Choice(['flake8', 'ruff', 'isort', 'pylint']), default='flake8', help='Linter to use')  # noqa: E501
 def lint(linter):
-	"""Run lint tests."""
+	"""Run lint tests"""
 	opts = ''
 	if linter == 'pylint':
 		opts = '--indent-string "\t" --max-line-length 160 --disable=R,C,W'
@@ -2413,7 +2406,7 @@ def lint(linter):
 @click.option('--test', '-t', type=str, help='Secator test to run')
 @click.option('--no-coverage', is_flag=True, help='Disable coverage')
 def unit(tasks, workflows, scans, test, no_coverage):
-	"""Run unit tests."""
+	"""Run unit tests"""
 	os.environ['TEST_TASKS'] = tasks or ''
 	os.environ['TEST_WORKFLOWS'] = workflows or ''
 	os.environ['TEST_SCANS'] = scans or ''
@@ -2450,7 +2443,7 @@ def unit(tasks, workflows, scans, test, no_coverage):
 @click.option('--test', '-t', type=str, help='Secator test to run')
 @click.option('--no-cleanup', '-nc', is_flag=True, help='Do not perform cleanup (keep lab running, faster for relaunching tests)')  # noqa: E501
 def integration(tasks, workflows, scans, test, no_cleanup):
-	"""Run integration tests."""
+	"""Run integration tests"""
 	os.environ['TEST_TASKS'] = tasks or ''
 	os.environ['TEST_WORKFLOWS'] = workflows or ''
 	os.environ['TEST_SCANS'] = scans or ''
@@ -2483,7 +2476,7 @@ def integration(tasks, workflows, scans, test, no_cleanup):
 @click.option('--scans', type=str, default='', help='Secator scans to test (comma-separated)')
 @click.option('--test', '-t', type=str, help='Secator test to run')
 def template(tasks, workflows, scans, test):
-	"""Run integration tests."""
+	"""Run integration tests"""
 	os.environ['TEST_TASKS'] = tasks or ''
 	os.environ['TEST_WORKFLOWS'] = workflows or ''
 	os.environ['TEST_SCANS'] = scans or ''
@@ -2515,7 +2508,7 @@ def template(tasks, workflows, scans, test):
 @click.option('--scans', type=str, default='', help='Secator scans to test (comma-separated)')
 @click.option('--test', '-t', type=str, help='Secator test to run')
 def performance(tasks, workflows, scans, test):
-	"""Run integration tests."""
+	"""Run integration tests"""
 	os.environ['TEST_TASKS'] = tasks or ''
 	os.environ['TEST_WORKFLOWS'] = workflows or ''
 	os.environ['TEST_SCANS'] = scans or ''
@@ -2538,7 +2531,7 @@ def performance(tasks, workflows, scans, test):
 @click.option('--check', '-c', is_flag=True, default=False, help='Check task semantics only (no unit + integration tests)')  # noqa: E501
 @click.option('--system-exit', '-e', is_flag=True, default=True, help='Exit with system exit code')
 def task(name, verbose, check, system_exit):
-	"""Test a single task for semantics errors, and run unit + integration tests."""
+	"""Test a single task for semantics errors, and run unit + integration tests"""
 	console.print(f'[bold gold3]:wrench: Testing task {name} ...[/]')
 	task = [task for task in discover_tasks() if task.__name__ == name.strip()]
 	warnings = []
@@ -2676,7 +2669,7 @@ def task(name, verbose, check, system_exit):
 @click.option('--check', '-c', is_flag=True, default=False, help='Check task semantics only (no unit + integration tests)')  # noqa: E501
 @click.option('--verbose', '-v', is_flag=True, default=False, help='Print verbose output')
 def tasks(ctx, check, verbose):
-	"""Test all tasks for semantics errors, and run unit + integration tests."""
+	"""Test all tasks for semantics errors, and run unit + integration tests"""
 	results = []
 	for cls in discover_tasks():
 		success = ctx.invoke(task, name=cls.__name__, verbose=verbose, check=check, system_exit=False)
@@ -2710,7 +2703,7 @@ def check_test(condition, message, fail_message, results=[], warn=False):
 @click.option('--integration-only', '-i', is_flag=True, default=False, help='Only generate coverage for integration tests')  # noqa: E501
 @click.option('--template-only', '-t', is_flag=True, default=False, help='Only generate coverage for template tests')  # noqa: E501
 def coverage(unit_only, integration_only, template_only):
-	"""Run coverage combine + coverage report."""
+	"""Run coverage combine + coverage report"""
 	cmd = f'{sys.executable} -m coverage report -m --omit=*/site-packages/*,*/tests/*,*/templates/*'
 	if unit_only:
 		cmd += ' --data-file=.coverage.unit'

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1189,18 +1189,11 @@ def _apply_format(results, fmt):
 	return new_results
 
 
-@report.command('show')
-@click.argument('report_query', required=False)
-@click.option('-o', '--output', type=str, default='console', help='Exporters')
-@click.option('-d', '--time-delta', type=str, default=None, help='Keep results newer than time delta. E.g: 26m, 1d, 1y')  # noqa: E501
-@click.option('-q', '--query', type=str, default=None, help='Filter results (Python-like or MongoDB JSON)')
-@click.option('--format', '-f', 'fmt', type=str, default=None, help="Format string for results, e.g. '{tag.match}-{tag.name}' or '{port.host}:{port.port} || vulnerability.matched_at'")  # noqa: E501
-@click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
-@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
-@click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
-@click.pass_context
-def report_show(ctx, report_query, output, time_delta, query, fmt, workspace, driver, dedupe):
-	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""
+def run_report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe):
+	"""Build and send a consolidated report. Shared by `report show` and `query`.
+
+	REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3).
+	"""
 	from secator.query.utils import parse_report_paths, python_expr_to_mongo
 
 	current = get_file_timestamp()
@@ -1275,6 +1268,20 @@ def report_show(ctx, report_query, output, time_delta, query, fmt, workspace, dr
 	if fmt:
 		report.data['results'] = _apply_format(report.data['results'], fmt)
 	report.send()
+
+
+@report.command('show')
+@click.argument('report_query', required=False)
+@click.option('-o', '--output', type=str, default='console', help='Exporters')
+@click.option('-d', '--time-delta', type=str, default=None, help='Keep results newer than time delta. E.g: 26m, 1d, 1y')  # noqa: E501
+@click.option('-q', '--query', type=str, default=None, help='Filter results (Python-like or MongoDB JSON)')
+@click.option('--format', '-f', 'fmt', type=str, default=None, help="Format string for results, e.g. '{tag.match}-{tag.name}' or '{port.host}:{port.port} || vulnerability.matched_at'")  # noqa: E501
+@click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
+def report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe):
+	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""
+	run_report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe)
 
 
 def _load_report_data(path):

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1024,7 +1024,7 @@ def list_aliases(silent):
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.option('-l', '--limit', type=int, default=0, help='Limit number of results (0 = no limit)')
 @click.pass_context
-def query(ctx, arg, output, time_delta, fmt, workspace, driver, dedupe):
+def query(ctx, arg, output, time_delta, fmt, workspace, driver, dedupe, limit):
 	"""Query"""
 	if not arg:
 		raise click.UsageError('Missing argument ARG (a query name, expression, or prompt).')

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1073,6 +1073,7 @@ def _looks_like_query_expr(value):
 	  - contains a comparison/logical operator (==, !=, <, >, <=, >=, ~=, &&, ||)
 	  - contains a word operator surrounded by spaces ( and / or / in )
 	  - matches a bare dotted field-access path like 'word.word' (e.g. extra_data.published)
+	  - is a bare known output type name (url, vulnerability, domain, etc.)
 	"""
 	if not value:
 		return False
@@ -1080,7 +1081,10 @@ def _looks_like_query_expr(value):
 		return True
 	if any(op in value for op in _QUERY_EXPR_WORD_OPERATORS):
 		return True
-	return bool(re.fullmatch(r'\w+(?:\.\w+)+', value.strip()))
+	if re.fullmatch(r'\w+(?:\.\w+)+', value.strip()):
+		return True
+	from secator.output_types import OUTPUT_TYPES
+	return value.strip() in {cls.get_name() for cls in OUTPUT_TYPES}
 
 
 def _apply_format(results, fmt):

--- a/secator/config.py
+++ b/secator/config.py
@@ -45,6 +45,7 @@ class Directories(StrictModel):
 	payloads: Directory = ''
 	performance: Directory = ''
 	revshells: Directory = ''
+	queries: Directory = ''
 	celery: Directory = ''
 	celery_data: Directory = ''
 	celery_results: Directory = ''
@@ -52,7 +53,7 @@ class Directories(StrictModel):
 	@model_validator(mode='after')
 	def set_default_folders(self) -> Self:
 		"""Set folders to be relative to the data folders if they are unspecified in config."""
-		for folder in ['templates', 'reports', 'wordlists', 'cves', 'payloads', 'performance', 'revshells', 'celery', 'celery_data', 'celery_results']:  # noqa: E501
+		for folder in ['templates', 'reports', 'wordlists', 'cves', 'payloads', 'performance', 'revshells', 'queries', 'celery', 'celery_data', 'celery_results']:  # noqa: E501
 			rel_target = '/'.join(folder.split('_'))
 			val = getattr(self, folder) or self.data / rel_target
 			setattr(self, folder, val)
@@ -312,6 +313,7 @@ class SecatorConfig(StrictModel):
 	addons: Addons = Addons()
 	security: Security = Security()
 	providers: Providers = Providers()
+	queries: Dict[str, str] = {}
 	offline_mode: bool = False
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -246,19 +246,19 @@ class TestCli(unittest.TestCase):
 		result = self.runner.invoke(cli, ['task'])
 		assert not result.exception
 		assert result.exit_code == 0
-		assert 'Run a task.' in result.output
+		assert 'Run a task' in result.output
 
 	def test_workflow_command(self):
 		result = self.runner.invoke(cli, ['workflow'])
 		assert not result.exception
 		assert result.exit_code == 0
-		assert 'Run a workflow.' in result.output
+		assert 'Run a workflow' in result.output
 
 	def test_scan_command(self):
 		result = self.runner.invoke(cli, ['scan'])
 		assert not result.exception
 		assert result.exit_code == 0
-		assert 'Run a scan.' in result.output
+		assert 'Run a scan' in result.output
 
 	# def test_worker_command(self):
 	# 	result = self.runner.invoke(cli, ['worker', '--check'])

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -134,6 +134,27 @@ class TestConfig(unittest.TestCase):
 		data = Config.read_yaml(self.config_test)
 		self.assertNotIn(str(self.home), data['dirs']['data'])
 
+	def test_queries_field_default(self):
+		from secator.config import Config
+		config = Config.parse()
+		self.assertEqual(config.queries, {})
+
+	def test_set_get_unset_query(self):
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('queries.critical_vulns', 'vulnerability.severity_nb < 2')
+		self.assertEqual(config.queries['critical_vulns'], 'vulnerability.severity_nb < 2')
+		config.save()
+		yaml_data = Config.read_yaml(self.config_test)
+		self.assertEqual(yaml_data['queries']['critical_vulns'], 'vulnerability.severity_nb < 2')
+		config.unset('queries.critical_vulns')
+		self.assertNotIn('critical_vulns', config.queries)
+
+	def test_queries_dir_resolves_under_data(self):
+		from secator.config import Config
+		config = Config.parse()
+		self.assertEqual(config.dirs.queries, config.dirs.data / 'queries')
+
 
 @mock.patch('sys.stderr', devnull)
 class TestConfigEnv(unittest.TestCase):

--- a/tests/unit/test_query_cli.py
+++ b/tests/unit/test_query_cli.py
@@ -1,8 +1,25 @@
 """Unit tests for the `secator query` command and its dispatch helpers."""
 
+import json
+import shutil
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
+
 from click.testing import CliRunner
+
+WS = 'query_ws'
+CRIT = {
+	'_type': 'vulnerability', 'name': 'SQLi', 'severity': 'critical',
+	'matched_at': 'http://x/login', 'is_false_positive': False,
+	'_context': {'workspace_id': WS, 'workspace_duplicate': False},
+}
+MED = {
+	'_type': 'vulnerability', 'name': 'XSS', 'severity': 'medium',
+	'matched_at': 'http://x/search', 'is_false_positive': False,
+	'_context': {'workspace_id': WS, 'workspace_duplicate': False},
+}
 
 
 class TestLooksLikeQueryExpr(unittest.TestCase):
@@ -56,3 +73,47 @@ class TestRunAiChat(unittest.TestCase):
 		self.assertEqual(kwargs.get('prompt'), 'Analyze my workspace data')
 		self.assertEqual(kwargs.get('mode'), 'chat')
 		self.assertEqual(kwargs.get('workspace'), 'myws')
+
+
+class TestQueryDispatch(unittest.TestCase):
+
+	def setUp(self):
+		self.cli_runner = CliRunner()
+		self.temp_dir = tempfile.mkdtemp()
+		task_dir = Path(self.temp_dir) / WS / 'tasks' / '1'
+		task_dir.mkdir(parents=True)
+		with open(task_dir / 'report.json', 'w') as f:
+			json.dump({'info': {'name': 't'}, 'results': {'vulnerability': [CRIT.copy(), MED.copy()]}}, f)
+
+	def tearDown(self):
+		shutil.rmtree(self.temp_dir)
+
+	def _invoke(self, args):
+		from secator.cli import cli
+		captured = {}
+
+		def capture_send(report_self):
+			captured['results'] = report_self.data['results']
+
+		with mock.patch('secator.query.json.CONFIG') as mock_cfg, \
+				mock.patch('secator.report.Report.send', capture_send):
+			mock_cfg.dirs.reports = Path(self.temp_dir)
+			result = self.cli_runner.invoke(cli, args)
+		return result, captured
+
+	def test_named_query(self):
+		from secator.config import CONFIG
+		with mock.patch.dict(CONFIG.queries, {'crit': "vulnerability.severity == 'critical'"}, clear=False):
+			result, captured = self._invoke(['query', 'crit', '-ws', WS, '--driver', 'local'])
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		vulns = captured.get('results', {}).get('vulnerability', [])
+		self.assertEqual(sorted(v['name'] for v in vulns), ['SQLi'])
+
+	def test_raw_expression(self):
+		result, captured = self._invoke(
+			['query', "vulnerability.severity == 'medium'", '-ws', WS, '--driver', 'local'])
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		vulns = captured.get('results', {}).get('vulnerability', [])
+		self.assertEqual(sorted(v['name'] for v in vulns), ['XSS'])

--- a/tests/unit/test_query_cli.py
+++ b/tests/unit/test_query_cli.py
@@ -1,0 +1,37 @@
+"""Unit tests for the `secator query` command and its dispatch helpers."""
+
+import unittest
+
+
+class TestLooksLikeQueryExpr(unittest.TestCase):
+
+	def _check(self, value):
+		from secator.cli import _looks_like_query_expr
+		return _looks_like_query_expr(value)
+
+	def test_expressions_are_detected(self):
+		exprs = [
+			"vulnerability.severity == 'high'",
+			"vulnerability.severity_nb < 2",
+			"port.port > 1000",
+			"vulnerability.name ~= 'SQL'",
+			"a == 1 && b == 2",
+			"a == 1 || b == 2",
+			"vulnerability.severity == 'high' and vulnerability.confidence == 'high'",
+			"severity in ['high', 'critical']",
+			"extra_data.published",
+		]
+		for expr in exprs:
+			with self.subTest(expr=expr):
+				self.assertTrue(self._check(expr))
+
+	def test_natural_language_is_not_detected(self):
+		phrases = [
+			"Analyze my workspace data",
+			"critical_vulns",
+			"show me the most exploitable hosts",
+			"",
+		]
+		for phrase in phrases:
+			with self.subTest(phrase=phrase):
+				self.assertFalse(self._check(phrase))

--- a/tests/unit/test_query_cli.py
+++ b/tests/unit/test_query_cli.py
@@ -39,6 +39,11 @@ class TestLooksLikeQueryExpr(unittest.TestCase):
 			"vulnerability.severity == 'high' and vulnerability.confidence == 'high'",
 			"severity in ['high', 'critical']",
 			"extra_data.published",
+			# bare output type names
+			"url",
+			"vulnerability",
+			"domain",
+			"port",
 		]
 		for expr in exprs:
 			with self.subTest(expr=expr):
@@ -68,7 +73,7 @@ class TestRunAiChat(unittest.TestCase):
 			result = runner.invoke(cli, ['query', '-ws', 'myws', 'Analyze my workspace data'])
 		self.assertIsNone(result.exception, str(result.exception))
 		self.assertEqual(result.exit_code, 0)
-		self.assertTrue(mock_cb.called)
+		mock_cb.assert_called_once()
 		_, kwargs = mock_cb.call_args
 		self.assertEqual(kwargs.get('prompt'), 'Analyze my workspace data')
 		self.assertEqual(kwargs.get('mode'), 'chat')
@@ -96,7 +101,7 @@ class TestQueryDispatch(unittest.TestCase):
 			captured['results'] = report_self.data['results']
 
 		with mock.patch('secator.query.json.CONFIG') as mock_cfg, \
-				mock.patch('secator.report.Report.send', capture_send):
+			mock.patch('secator.report.Report.send', capture_send):
 			mock_cfg.dirs.reports = Path(self.temp_dir)
 			result = self.cli_runner.invoke(cli, args)
 		return result, captured

--- a/tests/unit/test_query_cli.py
+++ b/tests/unit/test_query_cli.py
@@ -1,6 +1,8 @@
 """Unit tests for the `secator query` command and its dispatch helpers."""
 
 import unittest
+from unittest import mock
+from click.testing import CliRunner
 
 
 class TestLooksLikeQueryExpr(unittest.TestCase):
@@ -35,3 +37,22 @@ class TestLooksLikeQueryExpr(unittest.TestCase):
 		for phrase in phrases:
 			with self.subTest(phrase=phrase):
 				self.assertFalse(self._check(phrase))
+
+
+class TestRunAiChat(unittest.TestCase):
+
+	def test_run_ai_chat_invokes_ai_task_command(self):
+		from secator.cli import cli
+
+		runner = CliRunner()
+		# Patch the registered `ai` task command's callback so no LLM runs.
+		ai_cmd = cli.commands['task'].commands['ai']
+		with mock.patch.object(ai_cmd, 'callback') as mock_cb:
+			result = runner.invoke(cli, ['query', '-ws', 'myws', 'Analyze my workspace data'])
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		self.assertTrue(mock_cb.called)
+		_, kwargs = mock_cb.call_args
+		self.assertEqual(kwargs.get('prompt'), 'Analyze my workspace data')
+		self.assertEqual(kwargs.get('mode'), 'chat')
+		self.assertEqual(kwargs.get('workspace'), 'myws')


### PR DESCRIPTION
## Summary

Adds saved, named report queries and a new `secator query` command that runs them, raw filter expressions, or natural-language AI chat.

- **Config:** new `queries: Dict[str, str]` field (name → filter expression), managed via the existing config commands — `secator config set/get/unset queries.<name>`. Stored in `~/.secator/config.yml`. Also adds a `dirs.queries` directory (`~/.secator/queries`, created for future file-based storage).
- **`secator query <arg>` (alias `q`):** resolves `<arg>` in three steps — (1) a saved query name, (2) a filter expression (detected by `_looks_like_query_expr`), (3) natural language → `secator x ai --mode chat`. Accepts the same options as `secator r show` (`-o`, `-d`, `-f`, `-w/-ws`, `--driver`, `--dedupe`).
- **Refactor:** extracted `run_report_show(...)` from the `report show` command so `query` reuses the exact same reporting logic; added a small `run_ai_chat(ctx, prompt, workspace)` helper.
- **Docs:** new "Queries" section in `README.md`.

### Examples
```sh
secator config set queries.critical_vulns "vulnerability.severity_nb < 2"
secator config get queries
secator query critical_vulns -ws secator.cloud -f "vulnerability.matched_at"   # saved query
secator query "vulnerability.severity == 'high' && vulnerability.tags ~= 'exploitable'"  # raw expression
secator query -ws secator.cloud "Analyze my workspace data"                    # AI chat
```

## Test Plan
- [x] `secator test unit --test test_config` — 24 passed (3 new)
- [x] `secator test unit --test test_query_cli` — 5 passed (new file: expr detection, AI dispatch, named-query + raw-expression e2e)
- [x] `secator test unit --test test_report_show_e2e` — 8 passed (refactor regression guard)
- [x] `secator test unit --test test_cli` — 60 passed
- [x] `secator test lint` — clean
- [x] Manual smoke: `config set/get/unset queries.*` and `query --help` work end-to-end

> Note: a pre-existing test-isolation bug (`StopIteration` in `cli_helper.py` module-level `next(os.walk(...))`) causes failures only when multiple suites are combined in one pytest run; it reproduces on the base commit and is unrelated to this change. All affected suites pass individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `secator query` command with three resolution modes: saved query names, direct filter expressions, and natural-language prompts via AI chat
  * Enabled saving and managing named queries in configuration

* **Documentation**
  * Updated README with usage guide and examples for the new query capability and its supported options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->