### PR TITLE
feat(cli): dynamic install addons

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -2114,36 +2114,29 @@ def install_ai():
 
 def _install_external_addon(name, config):
 	"""Install an external addon defined in addons.json."""
-	import shlex
-	from secator.installer import SourceInstaller, ToolInstaller
+	from secator.installer import ToolInstaller
 
 	if CONFIG.offline_mode:
 		console.print(Error(message='Cannot run this command in offline mode.'))
 		sys.exit(1)
 
-	pypi_deps = config.get('pypi_dependencies', [])
 	next_steps = config.get('next_steps', [])
-
-	if pypi_deps:
-		quoted_deps = ' '.join(shlex.quote(dep) for dep in pypi_deps)
-		cmd = f'{sys.executable} -m pip install {quoted_deps}'
-		status = SourceInstaller.install(cmd)
-	else:
-		tool_attrs = {
-			'__name__': name,
-			'install_pre': config.get('install_pre', None),
-			'install_post': config.get('install_post', None),
-			'install_cmd_pre': config.get('install_cmd_pre', None),
-			'install_cmd': config.get('install_cmd', None),
-			'install_github_bin': config.get('install_github_bin', True),
-			'github_handle': config.get('github_handle') or config.get('install_github_handle', None),
-			'install_github_version_prefix': config.get('install_github_version_prefix', ''),
-			'install_ignore_bin': config.get('install_ignore_bin', []),
-			'install_version': config.get('install_version', None),
-			'install_binary_name': config.get('install_binary_name', None),
-		}
-		tool_cls = type(name, (), tool_attrs)
-		status = ToolInstaller.install(tool_cls)
+	tool_attrs = {
+		'__name__': name,
+		'install_pre': config.get('install_pre', None),
+		'install_post': config.get('install_post', None),
+		'install_cmd_pre': config.get('install_cmd_pre', None),
+		'install_cmd': config.get('install_cmd', None),
+		'install_github_bin': config.get('install_github_bin', True),
+		'github_handle': config.get('github_handle') or config.get('install_github_handle', None),
+		'install_github_version_prefix': config.get('install_github_version_prefix', ''),
+		'install_ignore_bin': config.get('install_ignore_bin', []),
+		'install_version': config.get('install_version', None),
+		'install_binary_name': config.get('install_binary_name', None),
+		'pypi_dependencies': config.get('pypi_dependencies', None),
+	}
+	tool_cls = type(name, (), tool_attrs)
+	status = ToolInstaller.install(tool_cls)
 
 	return_code = 0 if status.is_ok() else 1
 	if status.is_ok() and next_steps:

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -26,7 +26,7 @@ from secator.output_types import FINDING_TYPES, Info, Warning, Error
 from secator.report import Report
 from secator.rich import console
 from secator.runners import Command, Runner
-from secator.loader import get_configs_by_type, discover_tasks
+from secator.loader import get_configs_by_type, discover_tasks, load_external_addons
 from secator.utils import (
 	debug,
 	detect_host,
@@ -2110,6 +2110,67 @@ def install_ai():
 			'Run [bold green4]secator x ai -p "your prompt"[/] to run AI-powered pentesting.',
 		],
 	)
+
+
+def _install_external_addon(name, config):
+	"""Install an external addon defined in addons.json."""
+	import shlex
+	from secator.installer import SourceInstaller, ToolInstaller
+
+	if CONFIG.offline_mode:
+		console.print(Error(message='Cannot run this command in offline mode.'))
+		sys.exit(1)
+
+	pypi_deps = config.get('pypi_dependencies', [])
+	next_steps = config.get('next_steps', [])
+
+	if pypi_deps:
+		quoted_deps = ' '.join(shlex.quote(dep) for dep in pypi_deps)
+		cmd = f'{sys.executable} -m pip install {quoted_deps}'
+		status = SourceInstaller.install(cmd)
+	else:
+		tool_attrs = {
+			'__name__': name,
+			'install_pre': config.get('install_pre', None),
+			'install_post': config.get('install_post', None),
+			'install_cmd_pre': config.get('install_cmd_pre', None),
+			'install_cmd': config.get('install_cmd', None),
+			'install_github_bin': config.get('install_github_bin', True),
+			'github_handle': config.get('github_handle') or config.get('install_github_handle', None),
+			'install_github_version_prefix': config.get('install_github_version_prefix', ''),
+			'install_ignore_bin': config.get('install_ignore_bin', []),
+			'install_version': config.get('install_version', None),
+			'install_binary_name': config.get('install_binary_name', None),
+		}
+		tool_cls = type(name, (), tool_attrs)
+		status = ToolInstaller.install(tool_cls)
+
+	return_code = 0 if status.is_ok() else 1
+	if status.is_ok() and next_steps:
+		console.print('[bold gold3]:wrench: Next steps:[/]')
+		for ix, step in enumerate(next_steps):
+			console.print(f'   :keycap_{ix}: {step}')
+	sys.exit(return_code)
+
+
+def _load_external_addon_commands():
+	"""Dynamically register install commands for addons defined in addons.json."""
+	external_addons = load_external_addons()
+	for addon_name, addon_config in external_addons.items():
+		if addon_name in addons.commands:
+			debug(f'Skipping external addon "{addon_name}": name conflicts with a built-in addon command', sub='cli')
+			continue
+
+		def _make_cmd(name, config):
+			@click.command(name, help=f'Install {name} addon.')
+			def _cmd():
+				_install_external_addon(name, config)
+			return _cmd
+
+		addons.add_command(_make_cmd(addon_name, addon_config))
+
+
+_load_external_addon_commands()
 
 
 @install.group()

--- a/secator/installer.py
+++ b/secator/installer.py
@@ -4,7 +4,9 @@ import getpass
 import os
 import platform
 import re
+import shlex
 import shutil
+import sys
 import tarfile
 import zipfile
 import io
@@ -65,8 +67,8 @@ class ToolInstaller:
 		status = InstallerStatus.UNKNOWN
 		has_cmd = hasattr(tool_cls, 'cmd')
 
-		# For non-Command tasks (e.g. PythonRunner), only proceed if they have an install_cmd
-		if not has_cmd and not getattr(tool_cls, 'install_cmd', None):
+		# For non-Command tasks (e.g. PythonRunner), only proceed if they have an install method
+		if not has_cmd and not getattr(tool_cls, 'install_cmd', None) and not getattr(tool_cls, 'pypi_dependencies', None):
 			return InstallerStatus.INSTALL_SKIPPED_OK
 
 		# Fail if not supported
@@ -74,7 +76,8 @@ class ToolInstaller:
 			tool_cls.install_pre,
 			tool_cls.github_handle,
 			tool_cls.install_cmd,
-			tool_cls.install_post]):
+			tool_cls.install_post,
+			getattr(tool_cls, 'pypi_dependencies', None)]):
 			return InstallerStatus.INSTALL_NOT_SUPPORTED
 
 		# Check PATH (only relevant for Command-based tasks that install binaries)
@@ -87,6 +90,14 @@ class ToolInstaller:
 		# Install pre-required packages
 		if tool_cls.install_pre:
 			status = PackageInstaller.install(tool_cls.install_pre)
+			if not status.is_ok():
+				cls.print_status(status, name)
+				return status
+
+		# Install PyPI packages
+		pypi_dependencies = getattr(tool_cls, 'pypi_dependencies', None)
+		if pypi_dependencies:
+			status = PipInstaller.install(pypi_dependencies)
 			if not status.is_ok():
 				cls.print_status(status, name)
 				return status
@@ -198,6 +209,25 @@ class PackageInstaller:
 			if not status.is_ok():
 				return status
 		return InstallerStatus.SUCCESS
+
+
+class PipInstaller:
+	"""Install Python packages via pip."""
+
+	@classmethod
+	def install(cls, packages):
+		"""Install packages using the current Python's pip.
+
+		Args:
+			packages (list): List of package specifications to install (e.g. ['pandas', 'numpy>=1.0']).
+
+		Returns:
+			InstallerStatus: installer status.
+		"""
+		quoted = ' '.join(shlex.quote(pkg) for pkg in packages)
+		cmd = f'{sys.executable} -m pip install {quoted}'
+		console.print(Info(message=f'Installing PyPI packages: {quoted}'))
+		return SourceInstaller.install(cmd, install_prereqs=False)
 
 
 class SourceInstaller:

--- a/secator/loader.py
+++ b/secator/loader.py
@@ -236,3 +236,27 @@ def get_available_exporters():
 	"""Get all available exporters (internal + external)."""
 	from secator.definitions import AVAILABLE_EXPORTERS
 	return AVAILABLE_EXPORTERS + discover_external_exporters()
+
+
+@cache
+def load_external_addons():
+	"""Load external addons from addons.json in the templates directory.
+
+	Returns:
+		dict: Mapping of addon name to addon config dict. Empty dict if file absent or invalid.
+	"""
+	import json
+	addons_file = CONFIG.dirs.templates / 'addons.json'
+	if not addons_file.exists():
+		return {}
+	try:
+		with addons_file.open() as f:
+			data = json.load(f)
+		if not isinstance(data, dict):
+			console.print(f'[bold red]addons.json must be a JSON object, got {type(data).__name__}[/]')
+			return {}
+		debug(f'Loaded {len(data)} external addon(s) from {addons_file}', sub='template')
+		return data
+	except Exception as e:
+		console.print(f'[bold red]Could not load addons.json: {e}[/]')
+		return {}

--- a/secator/loader.py
+++ b/secator/loader.py
@@ -255,8 +255,13 @@ def load_external_addons():
 		if not isinstance(data, dict):
 			console.print(f'[bold red]addons.json must be a JSON object, got {type(data).__name__}[/]')
 			return {}
-		debug(f'Loaded {len(data)} external addon(s) from {addons_file}', sub='template')
-		return data
+		invalid = {k: v for k, v in data.items() if not isinstance(v, dict)}
+		if invalid:
+			for k, v in invalid.items():
+				console.print(f'[bold red]Skipping addon "{k}": config must be an object, got {type(v).__name__}[/]')
+		filtered = {k: v for k, v in data.items() if isinstance(v, dict)}
+		debug(f'Loaded {len(filtered)} external addon(s) from {addons_file}', sub='template')
+		return filtered
 	except Exception as e:
 		console.print(f'[bold red]Could not load addons.json: {e}[/]')
 		return {}

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -94,6 +94,7 @@ class Command(Runner):
 	install_ignore_bin = []
 	install_version = None
 	install_binary_name = None
+	pypi_dependencies = None
 
 	# Serializer
 	item_loader = None

--- a/secator/runners/python.py
+++ b/secator/runners/python.py
@@ -49,6 +49,7 @@ class PythonRunner(Runner):
 	install_binary_name = None
 	install_version = None
 	install_github_version_prefix = ''
+	pypi_dependencies = None
 	print_cmd_icon = ':zap:'
 
 	def __init__(self, inputs=[], **run_opts):

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -23,6 +23,7 @@ def _clear_loader_caches():
         'get_available_exporters',
         'find_templates',
         'get_configs_by_type',
+        'load_external_addons',
     ]:
         fn = getattr(loader, name, None)
         if fn and hasattr(fn, 'cache_clear'):
@@ -301,6 +302,82 @@ class TestGetAvailableExporters(unittest.TestCase):
             get_available_exporters.cache_clear()
             result = get_available_exporters()
         self.assertEqual(sorted(result), sorted(AVAILABLE_EXPORTERS))
+
+
+class TestLoadExternalAddons(unittest.TestCase):
+    """Tests for load_external_addons."""
+
+    def setUp(self):
+        self.template_dir = CONFIG.dirs.templates
+        self.template_dir.mkdir(parents=True, exist_ok=True)
+        self.addons_file = self.template_dir / 'addons.json'
+        _clear_loader_caches()
+
+    def tearDown(self):
+        if self.addons_file.exists():
+            self.addons_file.unlink()
+        _clear_loader_caches()
+
+    def _write_addons(self, data):
+        import json
+        self.addons_file.write_text(json.dumps(data))
+
+    def test_returns_empty_dict_when_file_absent(self):
+        """No addons.json → empty dict returned."""
+        from secator.loader import load_external_addons
+        result = load_external_addons()
+        self.assertEqual(result, {})
+
+    def test_returns_dict_with_pypi_addon(self):
+        """Valid addons.json with pypi_dependencies is loaded correctly."""
+        self._write_addons({
+            'elasticsearch': {
+                'pypi_dependencies': ['elasticsearch<10'],
+                'next_steps': [],
+            }
+        })
+        from secator.loader import load_external_addons
+        result = load_external_addons()
+        self.assertIn('elasticsearch', result)
+        self.assertEqual(result['elasticsearch']['pypi_dependencies'], ['elasticsearch<10'])
+
+    def test_returns_dict_with_tool_addon(self):
+        """Valid addons.json with tool install fields is loaded correctly."""
+        self._write_addons({
+            'my_tool': {
+                'install_cmd': 'curl https://example.com/install.sh | sh',
+                'install_version': '1.0.0',
+            }
+        })
+        from secator.loader import load_external_addons
+        result = load_external_addons()
+        self.assertIn('my_tool', result)
+        self.assertEqual(result['my_tool']['install_version'], '1.0.0')
+
+    def test_returns_empty_dict_on_invalid_json(self):
+        """Malformed addons.json returns empty dict and does not raise."""
+        self.addons_file.write_text('not valid json {{{')
+        from secator.loader import load_external_addons
+        result = load_external_addons()
+        self.assertEqual(result, {})
+
+    def test_returns_empty_dict_when_root_is_not_object(self):
+        """addons.json containing a JSON array (not an object) returns empty dict."""
+        self._write_addons([{'pypi_dependencies': ['pkg']}])
+        from secator.loader import load_external_addons
+        result = load_external_addons()
+        self.assertEqual(result, {})
+
+    def test_result_is_cached(self):
+        """Calling load_external_addons twice returns the same dict object."""
+        self._write_addons({'myaddon': {'pypi_dependencies': ['mypkg']}})
+        from secator.loader import load_external_addons
+        self.assertIs(load_external_addons(), load_external_addons())
+
+    def test_returns_dict_type(self):
+        """load_external_addons always returns a dict."""
+        from secator.loader import load_external_addons
+        self.assertIsInstance(load_external_addons(), dict)
 
 
 class TestDiscoverExternalTasksSkipsDriversAndExporters(unittest.TestCase):

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -379,6 +379,17 @@ class TestLoadExternalAddons(unittest.TestCase):
         from secator.loader import load_external_addons
         self.assertIsInstance(load_external_addons(), dict)
 
+    def test_filters_out_non_dict_addon_entries(self):
+        """Addon entries with non-dict values are excluded; valid entries are still returned."""
+        self._write_addons({
+            'bad_addon': 'not-an-object',
+            'good_addon': {'install_cmd': 'echo install'},
+        })
+        from secator.loader import load_external_addons
+        result = load_external_addons()
+        self.assertNotIn('bad_addon', result)
+        self.assertIn('good_addon', result)
+
 
 class TestDiscoverExternalTasksSkipsDriversAndExporters(unittest.TestCase):
     """discover_external_tasks must not attempt to load driver or exporter files."""


### PR DESCRIPTION
Implements dynamic loading of addon install commands from `~/.secator/templates/addons.json` as requested in #1143.

## Changes
- `secator/loader.py`: new `load_external_addons()` — reads and caches addons.json
- `secator/cli.py`: `_install_external_addon()` and `_load_external_addon_commands()`
- `tests/unit/test_loader.py`: 7 unit tests for `load_external_addons`

Closes #1143

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for installing external addons via dedicated CLI commands (e.g., `secator install addons <name>`)
  * Installation process supports both package managers and custom tool installers
  * Post-installation guidance automatically displayed upon successful setup
  * Offline mode prevents addon installation to ensure consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->