### PR TITLE
fix(cli): sanitize workspace name in report info path construction

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1381,7 +1381,7 @@ def report_info(runner_id, workspace, show_all):
 	if not runner_type.endswith('s'):
 		runner_type += 's'
 
-	report_path = Path(CONFIG.dirs.reports) / workspace_name / runner_type / runner_number / 'report.json'
+	report_path = Path(CONFIG.dirs.reports) / sanitize_folder_name(workspace_name) / runner_type / runner_number / 'report.json'
 	if not report_path.exists():
 		console.print(Error(message=f'Report not found: {report_path}'))
 		return

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1381,7 +1381,7 @@ def report_info(runner_id, workspace, show_all):
 	if not runner_type.endswith('s'):
 		runner_type += 's'
 
-	report_path = Path(CONFIG.dirs.reports) / sanitize_folder_name(workspace_name) / runner_type / runner_number / 'report.json'
+	report_path = Path(CONFIG.dirs.reports) / sanitize_folder_name(workspace_name) / runner_type / runner_number / 'report.json'  # noqa: E501
 	if not report_path.exists():
 		console.print(Error(message=f'Report not found: {report_path}'))
 		return


### PR DESCRIPTION
When a workspace name contains hyphens (e.g. `my-test-workspace`), the reports folder is created with underscores (`my_test_workspace`). The `report_info` command was using the raw workspace name to build the path, causing `secator r info scans/5` to fail because it looked for the hyphenated folder which does not exist.

Applies `sanitize_folder_name()` in `report_info` consistently with `report_delete` and `list_reports`.

Fixes #1145

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `report info` command to properly handle workspace names containing special characters or filesystem-unsafe characters by using sanitized folder name resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->