### PR TITLE
fix(cli): remove piped output behavior from 'secator r list'

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1291,8 +1291,7 @@ def _format_vuln_counts(counts):
 @click.option('-r', '--runner-type', type=str, default=None, help='Filter by runner type. Choices: task, workflow, scan')  # noqa: E501
 @click.option('-d', '--time-delta', type=str, default=None, help='Keep results newer than time delta. E.g: 26m, 1d, 1y')  # noqa: E501
 @click.option('--show-all', is_flag=True, default=False, help='Show all columns including report path')
-@click.pass_context
-def report_list(ctx, workspace, runner_type, time_delta, show_all):
+def report_list(workspace, runner_type, time_delta, show_all):
 	"""List all secator reports."""
 	paths = list_reports(workspace=workspace, type=runner_type, timedelta=human_to_timedelta(time_delta))
 	paths = sorted(paths, key=lambda x: x.stat().st_mtime, reverse=False)
@@ -1311,15 +1310,6 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 	table.add_column("Vulnerabilities")
 	if show_all:
 		table.add_column('Path')
-
-	# Print paths if piped
-	if ctx.obj['piped_output']:
-		if not paths:
-			console.print(Error(message='No reports found.'))
-			return
-		for path in paths:
-			print(path)
-		return
 
 	# Load each report
 	for path in paths:


### PR DESCRIPTION
When stdout was not a TTY (pipes, grep, watch, redirections), `secator r list` silently switched to printing bare JSON file paths instead of the table. This broke `secator r list | grep FAILURE` and `watch secator r list`.

Detecting whether the output is piped specifically to another secator command is not feasible in a simple, cross-platform way. The 'pipe to secator r show' use case this was meant to enable does not actually work either (report_show reads its argument from the CLI, not from stdin).

Fixes #1148

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated `report list` CLI command to consistently display results in Rich table format. The command no longer applies special handling for piped output; the `--show-all` flag continues to control column visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->