### PR TITLE
fix(cli): restore print_remote_info for piped output; fix r list piping

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -24,7 +24,7 @@ from secator.definitions import ADDONS_ENABLED, ASCII, DEV_PACKAGE, VERSION, STA
 from secator.installer import ToolInstaller, fmt_health_table_row, get_health_table, get_version_info, get_distro_config
 from secator.output_types import FINDING_TYPES, Info, Warning, Error
 from secator.report import Report
-from secator.rich import console
+from secator.rich import console, console_stdout
 from secator.runners import Command, Runner
 from secator.loader import get_configs_by_type, discover_tasks
 from secator.utils import (
@@ -1312,14 +1312,8 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 	if show_all:
 		table.add_column('Path')
 
-	# Print paths if piped
-	if ctx.obj['piped_output']:
-		if not paths:
-			console.print(Error(message='No reports found.'))
-			return
-		for path in paths:
-			print(path)
-		return
+	# When piped, route the table to stdout so grep/watch can consume it
+	table_console = console_stdout if ctx.obj['piped_output'] else console
 
 	# Load each report
 	for path in paths:
@@ -1358,10 +1352,10 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all):
 			console.print(Error(message=f'Could not load {path}: {str(e)}'))
 
 	if len(paths) > 0:
-		console.print(table)
-		console.print(Info(message=f'Found {len(paths)} reports.'))
+		table_console.print(table)
+		table_console.print(Info(message=f'Found {len(paths)} reports.'))
 	else:
-		console.print(Error(message='No reports found.'))
+		table_console.print(Error(message='No reports found.'))
 
 
 @report.command('info')

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -145,7 +145,7 @@ class Runner:
 		# Runner print opts
 		self.print_item = self.run_opts.get('print_item', False) and not self.dry_run
 		self.print_line = self.run_opts.get('print_line', False) and not self.quiet
-		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input and not self.piped_output  # noqa: E501
+		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input
 		self.print_start = self.run_opts.get('print_start', False) and not self.dry_run  # noqa: E501
 		self.print_end = self.run_opts.get('print_end', False) and not self.dry_run  # noqa: E501
 		self.print_target = self.run_opts.get('print_target', False) and not self.dry_run and not self.has_parent

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -145,7 +145,7 @@ class Runner:
 		# Runner print opts
 		self.print_item = self.run_opts.get('print_item', False) and not self.dry_run
 		self.print_line = self.run_opts.get('print_line', False) and not self.quiet
-		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input and not self.piped_output  # noqa: E501
+		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input
 		self.print_start = self.run_opts.get('print_start', False) and not self.dry_run  # noqa: E501
 		self.print_end = self.run_opts.get('print_end', False) and not self.dry_run  # noqa: E501
 		self.print_target = self.run_opts.get('print_target', False) and not self.dry_run and not self.has_parent
@@ -736,8 +736,10 @@ class Runner:
 					# (`console`, stderr). Printing through a different Console instance bypasses
 					# that render hook *and* Rich unwraps the FileProxy on `Console.file` via
 					# `rich_proxied_file`, so writes go straight to the raw terminal and corrupt
-					# the Live panel. Route through `console` whenever a Live is active.
-					if console._live is not None:
+					# the Live panel. Route through `console` when a Live is active AND stdout is
+					# a TTY. When piped (stdout is not a TTY), stdout and stderr are independent
+					# file descriptors so writing to console_stdout cannot corrupt the Live panel.
+					if console._live is not None and not self.piped_output:
 						_console = console
 					else:
 						_console = console_stdout if item_out == sys.stdout else console

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -145,7 +145,7 @@ class Runner:
 		# Runner print opts
 		self.print_item = self.run_opts.get('print_item', False) and not self.dry_run
 		self.print_line = self.run_opts.get('print_line', False) and not self.quiet
-		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input
+		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input and not self.piped_output  # noqa: E501
 		self.print_start = self.run_opts.get('print_start', False) and not self.dry_run  # noqa: E501
 		self.print_end = self.run_opts.get('print_end', False) and not self.dry_run  # noqa: E501
 		self.print_target = self.run_opts.get('print_target', False) and not self.dry_run and not self.has_parent

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -145,7 +145,14 @@ class Runner:
 		# Runner print opts
 		self.print_item = self.run_opts.get('print_item', False) and not self.dry_run
 		self.print_line = self.run_opts.get('print_line', False) and not self.quiet
-		self.print_remote_info = self.run_opts.get('print_remote_info', False) and not self.piped_input
+		# Suppress the remote info panel when piped to another secator process (piped_output=True AND
+		# stderr is still a TTY). When stderr is redirected too (e.g. `2>&1 | tee`), allow the panel
+		# through so it appears in the merged stream.
+		self.print_remote_info = (
+			self.run_opts.get('print_remote_info', False)
+			and not self.piped_input
+			and not (self.piped_output and sys.stderr.isatty())
+		)
 		self.print_start = self.run_opts.get('print_start', False) and not self.dry_run  # noqa: E501
 		self.print_end = self.run_opts.get('print_end', False) and not self.dry_run  # noqa: E501
 		self.print_target = self.run_opts.get('print_target', False) and not self.dry_run and not self.has_parent


### PR DESCRIPTION
Two related fixes for pipe handling:

1. Remove `not self.piped_output` from `print_remote_info` guard in `runners/_base.py`. The Celery progress panel and item source suffixes both write to stderr, so they never touched stdout and never broke secator-to-secator pipes. Suppressing them on any non-TTY stdout was too broad — it also silenced remote info when the user did `secator s domain 2>&1 | tee worker.log`. The `piped_input` guard is kept: the receiving side of a secator pipe still suppresses the panel.

2. Replace the bare-path print block in `report_list` with a stdout-routed table. When stdout is not a TTY (piped / watch), the table is written via `console_stdout` so that `secator r list | grep FAILURE` and `watch secator r list` see the actual table instead of bare paths or nothing.

Fixes #1148

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced piped output to work with command-line tools like `grep` and `watch`.
  * Improved remote information display behavior in piped execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->