### PR TITLE
feat(query): add --limit / -l option to secator r show

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1176,8 +1176,9 @@ def _apply_format(results, fmt):
 @click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
+@click.option('-l', '--limit', type=int, default=0, help='Limit number of results (0 = no limit)')
 @click.pass_context
-def report_show(ctx, report_query, output, time_delta, query, fmt, workspace, driver, dedupe):
+def report_show(ctx, report_query, output, time_delta, query, fmt, workspace, driver, dedupe, limit):
 	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""
 	from secator.query.utils import parse_report_paths, python_expr_to_mongo
 
@@ -1249,7 +1250,7 @@ def report_show(ctx, report_query, output, time_delta, query, fmt, workspace, dr
 	# 6. Build and send report via QueryEngine
 	dedupe_effective = CONFIG.runners.remove_duplicates if dedupe is None else dedupe
 	report = Report(runner, title=f'Consolidated report - {current}', exporters=exporters)
-	report.build(query=full_query, dedupe=dedupe_effective)
+	report.build(query=full_query, dedupe=dedupe_effective, limit=limit)
 	if fmt:
 		report.data['results'] = _apply_format(report.data['results'], fmt)
 	report.send()

--- a/secator/report.py
+++ b/secator/report.py
@@ -31,12 +31,13 @@ class Report:
 					f'[bold red]Could not create exporter {report_cls.__name__} for {self.__class__.__name__}: {str(e)}[/]\n[dim]{traceback_as_string(e)}[/]',  # noqa: E501
 				)
 
-	def build(self, query=None, dedupe=CONFIG.runners.remove_duplicates):
+	def build(self, query=None, dedupe=CONFIG.runners.remove_duplicates, limit=0):
 		"""Build report data structure using QueryEngine for filtering and dedup.
 
 		Args:
 			query (dict): MongoDB-style filter query (e.g. {'_type': 'vulnerability'}).
 			dedupe (bool): Whether to remove duplicate results.
+			limit (int): Maximum number of results to return (0 = no limit).
 		"""
 		if query is None:
 			query = {}
@@ -76,7 +77,7 @@ class Report:
 			context['workspace_name'] = self.workspace_name
 
 		engine = QueryEngine(self.workspace_name, context=context)
-		results = engine.search(query, dedupe=dedupe)
+		results = engine.search(query, limit=limit, dedupe=dedupe)
 
 		# Fill report (findings + targets)
 		from secator.output_types.target import Target

--- a/tests/unit/test_report_show_e2e.py
+++ b/tests/unit/test_report_show_e2e.py
@@ -66,7 +66,7 @@ class TestReportShowLocalBackend(unittest.TestCase):
 	def tearDown(self):
 		shutil.rmtree(self.temp_dir)
 
-	def _invoke(self, query_expr):
+	def _invoke(self, query_expr, extra_args=None):
 		from secator.cli import cli
 
 		captured = {}
@@ -77,6 +77,8 @@ class TestReportShowLocalBackend(unittest.TestCase):
 		args = ['r', 'show', '-w', WORKSPACE, '--driver', 'local']
 		if query_expr:
 			args += ['-q', query_expr]
+		if extra_args:
+			args += extra_args
 
 		with mock.patch('secator.query.json.CONFIG') as mock_cfg, \
 				mock.patch('secator.report.Report.send', capture_send):
@@ -94,6 +96,22 @@ class TestReportShowLocalBackend(unittest.TestCase):
 				vulns = captured.get('results', {}).get('vulnerability', [])
 				self.assertEqual(len(vulns), expected_count)
 				self.assertEqual(sorted(v['name'] for v in vulns), sorted(expected_names))
+
+	def test_limit_option(self):
+		"""--limit / -l restricts the number of results returned."""
+		result, captured = self._invoke(None, extra_args=['--limit', '1'])
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		vulns = captured.get('results', {}).get('vulnerability', [])
+		self.assertEqual(len(vulns), 1)
+
+	def test_limit_short_form(self):
+		"""Short form -l also restricts the number of results returned."""
+		result, captured = self._invoke(None, extra_args=['-l', '1'])
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		vulns = captured.get('results', {}).get('vulnerability', [])
+		self.assertEqual(len(vulns), 1)
 
 
 class TestReportShowMongoDBBackend(unittest.TestCase):


### PR DESCRIPTION
Add `--limit / -l` option to `secator r show` to expose the existing per-backend limit support through the CLI.

Changes:
- `secator/cli.py`: add `-l / --limit` click option
- `secator/report.py`: pass `limit` through `Report.build()` → `QueryEngine.search()`
- `tests/unit/test_report_show_e2e.py`: add tests for both long and short forms

Closes #1147

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `secator report show` command now accepts `--limit` / `-l` option to cap the number of returned results.

* **Tests**
  * Added end-to-end tests to verify the limit option functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->