### PR TITLE
fix(ai): handle OutputType objects from query results

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -416,9 +416,8 @@ def _handle_query(action: Dict, ctx: ActionContext) -> Generator:
 		)
 		for result in results:
 			if isinstance(result, OutputType):
-				result._context.update(context)
-			else:
-				result["_context"].update(context)
+				result = result.toDict()
+			result["_context"].update(context)
 			yield result
 
 	except Exception as e:

--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -415,7 +415,10 @@ def _handle_query(action: Dict, ctx: ActionContext) -> Generator:
 			_context=context
 		)
 		for result in results:
-			result["_context"].update(context)
+			if isinstance(result, OutputType):
+				result._context.update(context)
+			else:
+				result["_context"].update(context)
 			yield result
 
 	except Exception as e:
@@ -425,7 +428,7 @@ def _handle_query(action: Dict, ctx: ActionContext) -> Generator:
 			extra_data={"results": "failed", "limit": limit},
 			_context=context
 		)
-		yield Error.from_exception(e)
+		yield Error.from_exception(e, _context=context)
 
 
 def _handle_follow_up(action: Dict, ctx: ActionContext) -> Generator:


### PR DESCRIPTION
When scope='current', the query engine receives pre-loaded results from the runner's self.results, which are OutputType instances (e.g. Url). The _handle_query function was trying to subscript them as dicts, causing 'TypeError: Url object is not subscriptable'.

Also passes _context=context to Error.from_exception so fallback errors always carry tool_call_id, preventing the downstream KeyError in _dispatch_and_collect.

Fixes #1141

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure errors emitted during query operations now carry proper action context information.
  * Enhanced result processing to correctly handle different result formats while maintaining context data across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->