### PR TITLE
fix(cli): show _path and task source in secator r info errors/warnings

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1437,6 +1437,7 @@ def report_info(runner_id, workspace, show_all):
 			return '\n'.join(f'[bold]{k}[/]: {v}' for k, v in pairs) + tail
 		return str(value) if value is not None else ''
 
+	table.add_row('_path', str(report_path))
 	for key, value in info.items():
 		table.add_row(key, _format_value(value))
 

--- a/secator/output_types/error.py
+++ b/secator/output_types/error.py
@@ -34,7 +34,9 @@ class Error(OutputType):
 		return self.message
 
 	def __rich__(self):
-		s = rf"\[[bold red]ERR[/]] {self.message}"
+		source = (self._context or {}).get('node_id') or self._source
+		prefix = f'[dim]{_s(source)}[/] ' if source else ''
+		s = rf"\[[bold red]ERR[/]] {prefix}{self.message}"
 		if self.traceback:
 			traceback_pretty = '   ' + _s(self.traceback).replace('\n', '\n   ')
 			if self.traceback_title:

--- a/secator/output_types/warning.py
+++ b/secator/output_types/warning.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 import time
 from secator.output_types import OutputType
-from secator.utils import strip_rich_markup, rich_to_ansi
+from secator.utils import strip_rich_markup, rich_to_ansi, rich_escape as _s
 
 
 @dataclass
@@ -26,7 +26,9 @@ class Warning(OutputType):
 		self.message = strip_rich_markup(self.message)
 
 	def __rich__(self):
-		s = rf"\[[yellow]WRN[/]] {self.message_color}"
+		source = (self._context or {}).get('node_id') or self._source
+		prefix = f'[dim]{_s(source)}[/] ' if source else ''
+		s = rf"\[[yellow]WRN[/]] {prefix}{self.message_color}"
 		return s
 
 	def __repr__(self):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -484,6 +484,37 @@ class TestCli(unittest.TestCase):
 		assert not result.exception
 		assert result.exit_code == 0
 
+	def test_report_info_command(self):
+		"""report info shows _path at top and errors with source context."""
+		with tempfile.TemporaryDirectory() as tmpdir:
+			with mock.patch('secator.cli.CONFIG') as mock_cfg:
+				mock_cfg.dirs.reports = tmpdir
+				mock_cfg.workspace.default = 'default'
+				report_dir = os.path.join(tmpdir, 'default', 'tasks', '1')
+				os.makedirs(report_dir)
+				with open(os.path.join(report_dir, 'report.json'), 'w') as f:
+					import json as _json
+					_json.dump({
+						'info': {
+							'name': 'test_task',
+							'errors': [
+								{
+									'message': 'something went wrong',
+									'_source': 'nmap',
+									'_context': {'node_id': 'nmap_node_1'},
+									'_type': 'error',
+								}
+							]
+						},
+						'results': {}
+					}, f)
+				result = self.runner.invoke(cli, ['report', 'info', 'task/1'])
+				assert not result.exception, str(result.exception)
+				assert result.exit_code == 0
+				assert '_path' in result.output
+				assert 'something went wrong' in result.output
+				assert 'nmap_node_1' in result.output
+
 	@mock.patch('secator.cli.list_reports')
 	def test_report_list_command(self, mock_list_reports):
 		mock_list_reports.return_value = []

--- a/tests/unit/test_output_types.py
+++ b/tests/unit/test_output_types.py
@@ -1,5 +1,7 @@
 import unittest
 from secator.output_types import Vulnerability
+from secator.output_types.error import Error
+from secator.output_types.warning import Warning
 
 class TestOutputTypes(unittest.TestCase):
 	def test_merge_with(self):
@@ -38,3 +40,50 @@ class TestOutputTypes(unittest.TestCase):
 		assert vuln1.severity == 'high'
 		assert vuln1.severity_nb == 1
 		assert vuln1.name == 'CVE-2025-53020'
+
+
+class TestErrorRich(unittest.TestCase):
+
+	def test_error_rich_with_node_id(self):
+		err = Error(message='boom', _source='nmap', _context={'node_id': 'nmap_node_1'})
+		rich_str = err.__rich__()
+		assert 'nmap_node_1' in rich_str
+		assert 'boom' in rich_str
+
+	def test_error_rich_falls_back_to_source(self):
+		err = Error(message='boom', _source='nmap', _context={})
+		rich_str = err.__rich__()
+		assert 'nmap' in rich_str
+		assert 'boom' in rich_str
+
+	def test_error_rich_no_source(self):
+		err = Error(message='boom')
+		rich_str = err.__rich__()
+		assert 'boom' in rich_str
+		assert '[dim]' not in rich_str
+
+	def test_error_rich_node_id_takes_precedence_over_source(self):
+		err = Error(message='boom', _source='nmap', _context={'node_id': 'workflow_node'})
+		rich_str = err.__rich__()
+		assert 'workflow_node' in rich_str
+		assert 'nmap' not in rich_str
+
+
+class TestWarningRich(unittest.TestCase):
+
+	def test_warning_rich_with_node_id(self):
+		warn = Warning(message='watch out', _source='httpx', _context={'node_id': 'httpx_node_2'})
+		rich_str = warn.__rich__()
+		assert 'httpx_node_2' in rich_str
+		assert 'watch out' in rich_str
+
+	def test_warning_rich_falls_back_to_source(self):
+		warn = Warning(message='watch out', _source='httpx', _context={})
+		rich_str = warn.__rich__()
+		assert 'httpx' in rich_str
+		assert 'watch out' in rich_str
+
+	def test_warning_rich_no_source(self):
+		warn = Warning(message='watch out')
+		rich_str = warn.__rich__()
+		assert 'watch out' in rich_str


### PR DESCRIPTION
Show the report JSON path as `_path` key at the top of `secator r info` output, and show which task produced each error/warning using `_context.node_id` (or `_source` as fallback).

Fixes #1153

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error and warning messages now display source context for better troubleshooting
  * Report info command now shows the resolved report file path

* **Tests**
  * Added tests to validate error and warning message formatting
  * Added test for report info command functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->