### PR TITLE
feat(workspace): add automatic workspace routing

### DIFF
--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -215,7 +215,9 @@ def register_runner(cli_endpoint, config):
 		dry_run = opts['dry_run']
 		yaml = opts['yaml']
 		tree = opts['tree']
-		context = {'workspace_name': ws, 'workspace_id': ws}
+		from click.core import ParameterSource
+		ws_explicit = ctx.get_parameter_source('workspace') == ParameterSource.COMMANDLINE
+		context = {'workspace_name': ws, 'workspace_id': ws, 'workspace_explicit': ws_explicit}
 		enable_pyinstrument = opts['enable_pyinstrument']
 		enable_memray = opts['enable_memray']
 		contextmanager = nullcontext()

--- a/secator/config.py
+++ b/secator/config.py
@@ -148,6 +148,7 @@ class Drivers(StrictModel):
 
 class Workspace(StrictModel):
 	default: str = ''
+	routes: Dict[str, List[str]] = {}
 
 
 class Payloads(StrictModel):
@@ -481,10 +482,28 @@ class Config(DotMap):
 		updated = dict(existing_dict)
 		if strategy == 'remove':
 			if subkey and subkey in updated:
-				del updated[subkey]
+				existing = updated[subkey]
+				if isinstance(existing, list) and value is not None:
+					if value in existing:
+						existing = list(existing)
+						existing.remove(value)
+						updated[subkey] = existing
+					else:
+						console.print(f'[bold orange1]Value "{value}" not found in {".".join(parent_parts)}.{subkey}[/].')
+						return
+				else:
+					del updated[subkey]
 			elif subkey:
 				console.print(f'[bold orange1]Key "{subkey}" not found in {".".join(parent_parts)}[/].')
 				return
+		elif strategy == 'append':
+			if subkey:
+				existing_list = list(updated.get(subkey) or [])
+				if value not in existing_list:
+					existing_list.append(value)
+				updated[subkey] = existing_list
+			elif isinstance(value, dict):
+				updated.update(value)
 		else:
 			if subkey:
 				updated[subkey] = value

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -198,7 +198,7 @@ class Runner:
 		# Determine inputs
 		self.debug(f'resolving inputs with {len(self.dynamic_opts)} dynamic opts', obj=self.dynamic_opts, sub='init')
 		self.inputs = [inputs] if not isinstance(inputs, list) else inputs
-		self.inputs = list(set(self.inputs))
+		self.inputs = list(dict.fromkeys(self.inputs))
 		if self.caller != 'Task':
 			targets = [Target(name=target) for target in self.inputs]
 			for target in targets:
@@ -215,6 +215,16 @@ class Runner:
 		profiles_str = run_opts.get('profiles') or []
 		self.debug('resolving profiles', obj={'profiles': profiles_str}, sub='init')
 		self.profiles = self.resolve_profiles(profiles_str)
+
+		# Apply route-based workspace if no profile/explicit workspace was set
+		default_ws = CONFIG.workspace.default or 'default'
+		if not self.workspace_explicit and self.workspace_name == default_ws:
+			route_workspace = self._resolve_route_workspace(self.inputs)
+			if route_workspace:
+				self.debug(f'route workspace -> {route_workspace}', sub='init')
+				self.workspace_name = route_workspace
+				self.context['workspace_name'] = route_workspace
+				self.context['workspace_id'] = route_workspace
 
 		# Determine exporters
 		exporters_str = self.run_opts.get('output') or self.default_exporters
@@ -1438,14 +1448,6 @@ class Runner:
 			self.workspace_name = profile_workspace
 			self.context['workspace_name'] = profile_workspace
 			self.context['workspace_id'] = profile_workspace
-		elif not self.workspace_explicit and self.workspace_name == default_ws:
-			# No profile workspace and no explicit -ws: apply route-based workspace if routes match
-			route_workspace = self._resolve_route_workspace(self.inputs)
-			if route_workspace:
-				self.debug(f'route workspace -> {route_workspace}', sub='init')
-				self.workspace_name = route_workspace
-				self.context['workspace_name'] = route_workspace
-				self.context['workspace_id'] = route_workspace
 
 		# Apply exporters (consumed from run_opts['output'] right after profile resolution)
 		if profile_exporters is not None:

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -97,6 +97,7 @@ class Runner:
 		self.name = run_opts.get('name', config.name)
 		self.description = run_opts.get('description', config.description or '')
 		self.workspace_name = context.get('workspace_name', CONFIG.workspace.default or 'default')
+		self.workspace_explicit = context.get('workspace_explicit', False)
 		self.run_opts = run_opts.copy()
 		self.sync = run_opts.get('sync', True)
 		self.context = context
@@ -1412,6 +1413,14 @@ class Runner:
 			self.workspace_name = profile_workspace
 			self.context['workspace_name'] = profile_workspace
 			self.context['workspace_id'] = profile_workspace
+		elif not self.workspace_explicit and self.workspace_name == default_ws:
+			# No profile workspace and no explicit -ws: apply route-based workspace if routes match
+			route_workspace = self._resolve_route_workspace(self.inputs)
+			if route_workspace:
+				self.debug(f'route workspace -> {route_workspace}', sub='init')
+				self.workspace_name = route_workspace
+				self.context['workspace_name'] = route_workspace
+				self.context['workspace_id'] = route_workspace
 
 		# Apply exporters (consumed from run_opts['output'] right after profile resolution)
 		if profile_exporters is not None:
@@ -1423,6 +1432,27 @@ class Runner:
 			self._apply_profile_drivers(profile_drivers)
 
 		return templates
+
+	def _resolve_route_workspace(self, inputs):
+		"""Resolve workspace from configured routes based on inputs.
+
+		Args:
+			inputs (list[str]): List of inputs to match against route patterns.
+
+		Returns:
+			str | None: Matched workspace name, or None if no route matches.
+		"""
+		import fnmatch
+
+		routes = CONFIG.workspace.routes
+		if not routes:
+			return None
+		for workspace, patterns in routes.items():
+			for pattern in patterns:
+				for inp in inputs:
+					if fnmatch.fnmatch(str(inp), pattern):
+						return workspace
+		return None
 
 	def _apply_profile_drivers(self, drivers):
 		"""Load and register driver hooks specified by profiles.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -259,6 +259,32 @@ class TestConfig(unittest.TestCase):
 		config2 = Config.parse(path=self.config_test)
 		self.assertEqual(config2.workspace.routes['my_ws'], ['*vulnweb.com*', '*ocervell*'])
 
+	def test_workspace_routes_remove_existing_pattern(self):
+		"""Removing an existing pattern leaves the remaining patterns intact."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
+		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
+		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='remove')
+		self.assertEqual(config.workspace.routes['my_ws'], ['*ocervell*'])
+
+	def test_workspace_routes_remove_missing_pattern(self):
+		"""Removing a non-existent pattern is a no-op (warns but does not raise)."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
+		config.set('workspace.routes.my_ws', '*doesnotexist*', strategy='remove')
+		self.assertEqual(config.workspace.routes['my_ws'], ['*ocervell*'])
+
+	def test_workspace_routes_remove_workspace_key(self):
+		"""Unsetting a workspace key (no value) deletes it from routes entirely."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
+		self.assertIn('my_ws', config.workspace.routes)
+		config.unset('workspace.routes.my_ws')
+		self.assertNotIn('my_ws', config.workspace.routes)
+
 
 @mock.patch('sys.stderr', devnull)
 class TestConfigEnv(unittest.TestCase):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -155,6 +155,40 @@ class TestConfig(unittest.TestCase):
 		config = Config.parse()
 		self.assertEqual(config.dirs.queries, config.dirs.data / 'queries')
 
+	def test_workspace_routes_append_new_workspace(self):
+		"""Appending a route to a new workspace creates the list entry."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
+		self.assertIn('my_ws', config.workspace.routes)
+		self.assertEqual(config.workspace.routes['my_ws'], ['*vulnweb.com*'])
+
+	def test_workspace_routes_append_multiple_patterns(self):
+		"""Appending multiple patterns to same workspace accumulates them."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
+		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
+		self.assertEqual(config.workspace.routes['my_ws'], ['*vulnweb.com*', '*ocervell*'])
+
+	def test_workspace_routes_append_no_duplicates(self):
+		"""Appending a duplicate pattern is a no-op."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
+		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
+		self.assertEqual(config.workspace.routes['my_ws'], ['*vulnweb.com*'])
+
+	def test_workspace_routes_save_and_reload(self):
+		"""Workspace routes survive a save/reload cycle."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
+		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
+		config.save()
+		config2 = Config.parse(path=self.config_test)
+		self.assertEqual(config2.workspace.routes['my_ws'], ['*vulnweb.com*', '*ocervell*'])
+
 
 @mock.patch('sys.stderr', devnull)
 class TestConfigEnv(unittest.TestCase):

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -644,6 +644,95 @@ class TestCommandRunner(unittest.TestCase):
 				self.assertNotIn('doesnotexist', cmd.context.get('drivers', []))
 
 
+class TestWorkspaceRouting(unittest.TestCase):
+	"""Tests for automatic workspace routing based on input targets."""
+
+	def test_route_applied_when_input_matches_pattern(self):
+		"""Workspace route is applied when an input matches a configured pattern."""
+		routes = {'routed-ws': ['*host1*']}
+		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
+			patch('secator.config.CONFIG.workspace.default', new=''):
+			with mock_command(MyCommand, ['host1'], {}, []) as cmd:
+				self.assertEqual(cmd.workspace_name, 'routed-ws')
+				self.assertEqual(cmd.context.get('workspace_name'), 'routed-ws')
+				self.assertEqual(cmd.context.get('workspace_id'), 'routed-ws')
+
+	def test_route_not_applied_when_no_input_matches(self):
+		"""Workspace route is NOT applied when no input matches any pattern."""
+		routes = {'routed-ws': ['*vulnweb.com*']}
+		default = ''
+		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
+			patch('secator.config.CONFIG.workspace.default', new=default):
+			with mock_command(MyCommand, ['secator.cloud'], {}, []) as cmd:
+				self.assertEqual(cmd.workspace_name, 'default')
+
+	def test_route_not_applied_when_workspace_explicit(self):
+		"""Routes are NOT applied when user explicitly passes -ws, even when value equals the default."""
+		routes = {'routed-ws': ['*host1*']}
+		# Set default to 'my-default'; user explicitly passes the same value.
+		# Without workspace_explicit=True, routes would match and override — but with it, they should not.
+		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
+			patch('secator.config.CONFIG.workspace.default', new='my-default'):
+			opts = {'context': {'workspace_name': 'my-default', 'workspace_explicit': True}}
+			with mock_command(MyCommand, ['host1'], opts, []) as cmd:
+				self.assertEqual(cmd.workspace_name, 'my-default')
+
+	def test_route_overrides_default_workspace(self):
+		"""Workspace route overrides the configured default when no explicit -ws passed."""
+		routes = {'routed-ws': ['*host1*']}
+		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
+			patch('secator.config.CONFIG.workspace.default', new='my-default'):
+			with mock_command(MyCommand, ['host1'], {}, []) as cmd:
+				self.assertEqual(cmd.workspace_name, 'routed-ws')
+
+	def test_enforced_profile_overrides_route(self):
+		"""An enforced profile workspace overrides a route-matched workspace."""
+		from secator.template import TemplateLoader
+		routes = {'routed-ws': ['*host1*']}
+		profile = TemplateLoader(input={
+			'name': 'enforced_route_profile',
+			'type': 'profile',
+			'enforce': True,
+			'workspace': 'enforced-ws',
+		})
+		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
+			patch('secator.config.CONFIG.workspace.default', new=''):
+			opts = {'profiles': [profile]}
+			with mock_command(MyCommand, ['host1'], opts, []) as cmd:
+				self.assertEqual(cmd.workspace_name, 'enforced-ws')
+
+	def test_non_enforced_profile_overrides_route(self):
+		"""A non-enforced profile workspace takes precedence over a route match."""
+		from secator.template import TemplateLoader
+		routes = {'routed-ws': ['*host1*']}
+		profile = TemplateLoader(input={
+			'name': 'nonenforced_route_profile',
+			'type': 'profile',
+			'workspace': 'profile-ws',
+		})
+		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
+			patch('secator.config.CONFIG.workspace.default', new=''):
+			opts = {'profiles': [profile]}
+			with mock_command(MyCommand, ['host1'], opts, []) as cmd:
+				self.assertEqual(cmd.workspace_name, 'profile-ws')
+
+	def test_wildcard_pattern_matches_subdomain(self):
+		"""A wildcard pattern like *vulnweb.com* matches subdomains."""
+		routes = {'vulnweb-ws': ['*vulnweb.com*']}
+		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
+			patch('secator.config.CONFIG.workspace.default', new=''):
+			with mock_command(MyCommand, ['testphp.vulnweb.com'], {}, []) as cmd:
+				self.assertEqual(cmd.workspace_name, 'vulnweb-ws')
+
+	def test_first_matching_workspace_wins(self):
+		"""When multiple workspaces have patterns, the first matching workspace is used."""
+		routes = {'ws-a': ['*host1*'], 'ws-b': ['*host*']}
+		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
+			patch('secator.config.CONFIG.workspace.default', new=''):
+			with mock_command(MyCommand, ['host1'], {}, []) as cmd:
+				self.assertEqual(cmd.workspace_name, 'ws-a')
+
+
 class TestIsOwnSource(unittest.TestCase):
 	"""Verify _is_own_source correctly scopes errors to the owning runner."""
 

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -740,46 +740,73 @@ class TestCommandRunner(unittest.TestCase):
 class TestWorkspaceRouting(unittest.TestCase):
 	"""Tests for automatic workspace routing based on input targets."""
 
+	def setUp(self):
+		from secator.utils_test import clear_modules
+		clear_modules()
+		from secator.runners import Command
+		from secator.utils_test import mock_command
+
+		class LocalMyCommand(Command):
+			input_types = ['slug']
+			cmd = 'dummy'
+			input_flag = '-u'
+			file_flag = None
+
+		self.Cmd = LocalMyCommand
+		self.mock_command = mock_command
+
 	def test_route_applied_when_input_matches_pattern(self):
 		"""Workspace route is applied when an input matches a configured pattern."""
+		import unittest.mock
 		routes = {'routed-ws': ['*host1*']}
-		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
-			patch('secator.config.CONFIG.workspace.default', new=''):
-			with mock_command(MyCommand, ['host1'], {}, []) as cmd:
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
+			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.profiles.defaults', []):
+			with self.mock_command(self.Cmd, ['host1'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'routed-ws')
 				self.assertEqual(cmd.context.get('workspace_name'), 'routed-ws')
 				self.assertEqual(cmd.context.get('workspace_id'), 'routed-ws')
 
 	def test_route_not_applied_when_no_input_matches(self):
 		"""Workspace route is NOT applied when no input matches any pattern."""
+		import unittest.mock
 		routes = {'routed-ws': ['*vulnweb.com*']}
-		default = ''
-		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
-			patch('secator.config.CONFIG.workspace.default', new=default):
-			with mock_command(MyCommand, ['secator.cloud'], {}, []) as cmd:
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
+			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.profiles.defaults', []):
+			with self.mock_command(self.Cmd, ['secator.cloud'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'default')
 
 	def test_route_not_applied_when_workspace_explicit(self):
 		"""Routes are NOT applied when user explicitly passes -ws, even when value equals the default."""
+		import unittest.mock
 		routes = {'routed-ws': ['*host1*']}
 		# Set default to 'my-default'; user explicitly passes the same value.
 		# Without workspace_explicit=True, routes would match and override — but with it, they should not.
-		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
-			patch('secator.config.CONFIG.workspace.default', new='my-default'):
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
+			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspace.default', new='my-default'), \
+			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			opts = {'context': {'workspace_name': 'my-default', 'workspace_explicit': True}}
-			with mock_command(MyCommand, ['host1'], opts, []) as cmd:
+			with self.mock_command(self.Cmd, ['host1'], opts, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'my-default')
 
 	def test_route_overrides_default_workspace(self):
 		"""Workspace route overrides the configured default when no explicit -ws passed."""
+		import unittest.mock
 		routes = {'routed-ws': ['*host1*']}
-		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
-			patch('secator.config.CONFIG.workspace.default', new='my-default'):
-			with mock_command(MyCommand, ['host1'], {}, []) as cmd:
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
+			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspace.default', new='my-default'), \
+			patch('secator.runners._base.CONFIG.profiles.defaults', []):
+			with self.mock_command(self.Cmd, ['host1'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'routed-ws')
 
 	def test_enforced_profile_overrides_route(self):
 		"""An enforced profile workspace overrides a route-matched workspace."""
+		import unittest.mock
 		from secator.template import TemplateLoader
 		routes = {'routed-ws': ['*host1*']}
 		profile = TemplateLoader(input={
@@ -788,14 +815,17 @@ class TestWorkspaceRouting(unittest.TestCase):
 			'enforce': True,
 			'workspace': 'enforced-ws',
 		})
-		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
-			patch('secator.config.CONFIG.workspace.default', new=''):
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
+			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			opts = {'profiles': [profile]}
-			with mock_command(MyCommand, ['host1'], opts, []) as cmd:
+			with self.mock_command(self.Cmd, ['host1'], opts, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'enforced-ws')
 
 	def test_non_enforced_profile_overrides_route(self):
 		"""A non-enforced profile workspace takes precedence over a route match."""
+		import unittest.mock
 		from secator.template import TemplateLoader
 		routes = {'routed-ws': ['*host1*']}
 		profile = TemplateLoader(input={
@@ -803,26 +833,34 @@ class TestWorkspaceRouting(unittest.TestCase):
 			'type': 'profile',
 			'workspace': 'profile-ws',
 		})
-		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
-			patch('secator.config.CONFIG.workspace.default', new=''):
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
+			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			opts = {'profiles': [profile]}
-			with mock_command(MyCommand, ['host1'], opts, []) as cmd:
+			with self.mock_command(self.Cmd, ['host1'], opts, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'profile-ws')
 
 	def test_wildcard_pattern_matches_subdomain(self):
 		"""A wildcard pattern like *vulnweb.com* matches subdomains."""
+		import unittest.mock
 		routes = {'vulnweb-ws': ['*vulnweb.com*']}
-		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
-			patch('secator.config.CONFIG.workspace.default', new=''):
-			with mock_command(MyCommand, ['testphp.vulnweb.com'], {}, []) as cmd:
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
+			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.profiles.defaults', []):
+			with self.mock_command(self.Cmd, ['testphp.vulnweb.com'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'vulnweb-ws')
 
 	def test_first_matching_workspace_wins(self):
 		"""When multiple workspaces have patterns, the first matching workspace is used."""
+		import unittest.mock
 		routes = {'ws-a': ['*host1*'], 'ws-b': ['*host*']}
-		with patch('secator.config.CONFIG.workspace.routes', new=routes), \
-			patch('secator.config.CONFIG.workspace.default', new=''):
-			with mock_command(MyCommand, ['host1'], {}, []) as cmd:
+		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
+			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.profiles.defaults', []):
+			with self.mock_command(self.Cmd, ['host1'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'ws-a')
 
 


### PR DESCRIPTION
Closes #1157

Adds `workspace.routes` config for automatic workspace routing based on input patterns.

## Changes
- `secator/config.py`: Add `workspace.routes: Dict[str, List[str]]` to `Workspace` class; improve `_set_dict_key` to support `--append`/`--remove` for list values in nested dict fields
- `secator/runners/_base.py`: Add `_resolve_route_workspace()` using `fnmatch`; store `workspace_explicit` from context; apply routing in `resolve_profiles()` with correct priority
- `secator/cli_helper.py`: Track `workspace_explicit` via `ParameterSource.COMMANDLINE`
- Tests for both config and runner routing

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic workspace routing. Workspaces are now dynamically selected based on configured pattern rules that match against runner inputs, improving workspace management and selection efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->