### PR TITLE
fix(query): validate output type fields and warn on unknown fields

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1305,6 +1305,9 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	debug('original query expr', sub='query', obj={'raw': query or ''})
 	mongo_query = python_expr_to_mongo(query) if query else {}
 	mongo_query, query_warnings = validate_query_fields(mongo_query)
+	if query and query_warnings and not mongo_query:
+		emit_query_warnings(query_warnings)
+		return
 	debug('converted mongo query', sub='query', obj=mongo_query)
 
 	# 3. Merge filters

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1264,7 +1264,7 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 
 	REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3).
 	"""
-	from secator.query.utils import parse_report_paths, python_expr_to_mongo
+	from secator.query.utils import parse_report_paths, python_expr_to_mongo, validate_query_fields
 
 	current = get_file_timestamp()
 	workspace_name = workspace or CONFIG.workspace.default or 'default'
@@ -1276,6 +1276,7 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	# 2. Translate -q expression to MongoDB style
 	debug('original query expr', sub='query', obj={'raw': query or ''})
 	mongo_query = python_expr_to_mongo(query) if query else {}
+	mongo_query = validate_query_fields(mongo_query)
 	debug('converted mongo query', sub='query', obj=mongo_query)
 
 	# 3. Merge filters

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1270,7 +1270,9 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 
 	REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3).
 	"""
-	from secator.query.utils import parse_report_paths, python_expr_to_mongo, validate_query_fields, query_has_type_constraint
+	from secator.query.utils import (
+		parse_report_paths, python_expr_to_mongo, validate_query_fields, query_has_type_constraint
+	)
 
 	current = get_file_timestamp()
 	workspace_name = workspace or CONFIG.workspace.default or 'default'

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1290,7 +1290,8 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3).
 	"""
 	from secator.query.utils import (
-		parse_report_paths, python_expr_to_mongo, validate_query_fields, query_has_type_constraint
+		parse_report_paths, python_expr_to_mongo, validate_query_fields,
+		emit_query_warnings, query_has_type_constraint
 	)
 
 	current = get_file_timestamp()
@@ -1303,7 +1304,7 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	# 2. Translate -q expression to MongoDB style
 	debug('original query expr', sub='query', obj={'raw': query or ''})
 	mongo_query = python_expr_to_mongo(query) if query else {}
-	mongo_query = validate_query_fields(mongo_query)
+	mongo_query, query_warnings = validate_query_fields(mongo_query)
 	debug('converted mongo query', sub='query', obj=mongo_query)
 
 	# 3. Merge filters
@@ -1372,6 +1373,7 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 		report.data['results'] = _apply_format(report.data['results'], fmt)
 	report.send()
 	total_results = sum(len(items) for items in report.data['results'].values())
+	emit_query_warnings(query_warnings)
 	info_msg = f'Found {total_results} results in workspace [bold gold3]{workspace_name}[/]'
 	if report_query:
 		searched = ', '.join(p.strip() for p in report_query.split(',') if p.strip())

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -381,12 +381,13 @@ def _build_type_map():
     }
 
 
-def _validate_fragment(fragment, type_map):
+def _validate_fragment(fragment, type_map, warnings):
     """Validate a single query fragment against known output type fields.
 
-    Returns None if all user-specified fields were invalid (signals the caller
-    to drop this fragment from an $or/$and list rather than keeping a bare
-    {'_type': 'x'} that would match every object of that type).
+    Appends (field_name, type_name, valid_fields) tuples to *warnings* for each
+    unknown field found.  Returns None if all user-specified fields were invalid
+    (signals the caller to drop this fragment from an $or/$and list rather than
+    keeping a bare {'_type': 'x'} that would match every object of that type).
     """
     if not isinstance(fragment, dict):
         return fragment
@@ -410,7 +411,7 @@ def _validate_fragment(fragment, type_map):
             result[k] = v
             user_fields_kept += 1
         else:
-            _warn_unknown_field(k, _type, valid_fields)
+            warnings.append((k, _type, valid_fields))
     # If the fragment had user-specified fields but ALL were invalid, signal
     # the caller to drop this fragment entirely rather than keeping a bare
     # {'_type': _type} that would match every object of that type.
@@ -419,11 +420,11 @@ def _validate_fragment(fragment, type_map):
     return result
 
 
-def _validate_query(q, type_map):
+def _validate_query(q, type_map, warnings):
     if not isinstance(q, dict):
         return q
     if '$or' in q:
-        parts = [_validate_query(sub, type_map) for sub in q['$or']]
+        parts = [_validate_query(sub, type_map, warnings) for sub in q['$or']]
         parts = [p for p in parts if p]
         if len(parts) == 0:
             return {}
@@ -431,14 +432,14 @@ def _validate_query(q, type_map):
             return parts[0]
         return {'$or': parts}
     if '$and' in q:
-        parts = [_validate_query(sub, type_map) for sub in q['$and']]
+        parts = [_validate_query(sub, type_map, warnings) for sub in q['$and']]
         parts = [p for p in parts if p]
         if len(parts) == 0:
             return {}
         if len(parts) == 1:
             return parts[0]
         return {'$and': parts}
-    result = _validate_fragment(q, type_map)
+    result = _validate_fragment(q, type_map, warnings)
     return result if result is not None else {}
 
 
@@ -447,14 +448,18 @@ def validate_query_fields(query):
 
     For each fragment referencing a known _type, checks that the queried fields
     exist on that type. Prints a warning (with available fields) for unknown fields
-    and removes them from the query.
+    and removes them from the query. Warnings are emitted after validation completes.
     Returns the (possibly modified) query dict.
     """
     if not query or not isinstance(query, dict):
         return query
 
     type_map = _build_type_map()
-    return _validate_query(query, type_map)
+    warnings = []
+    result = _validate_query(query, type_map, warnings)
+    for field_name, type_name, valid_fields in warnings:
+        _warn_unknown_field(field_name, type_name, valid_fields)
+    return result
 
 
 def query_has_type_constraint(query):

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -3,7 +3,7 @@
 import json
 import re
 
-from secator.output_types import Error
+from secator.output_types import Error, Warning
 from secator.rich import console
 from secator.utils import debug
 
@@ -284,3 +284,61 @@ def python_expr_to_mongo(query):
 
     debug('python_expr_to_mongo', sub='query', obj={'input': query, 'output': result})
     return result
+
+
+def validate_query_fields(query):
+    """Validate field names in a MongoDB-style query against known output types.
+
+    For each fragment referencing a known _type, checks that the queried fields
+    exist on that type. Prints a warning (with available fields) for unknown fields
+    and removes them from the query.
+    Returns the (possibly modified) query dict.
+    """
+    if not query or not isinstance(query, dict):
+        return query
+
+    from secator.output_types import OUTPUT_TYPES
+
+    type_map = {
+        cls.__dataclass_fields__['_type'].default: cls
+        for cls in OUTPUT_TYPES
+        if '_type' in getattr(cls, '__dataclass_fields__', {})
+        and isinstance(cls.__dataclass_fields__['_type'].default, str)
+    }
+
+    def _validate_fragment(fragment):
+        if not isinstance(fragment, dict):
+            return fragment
+        _type = fragment.get('_type')
+        if not _type:
+            return fragment
+        cls = type_map.get(_type)
+        if cls is None:
+            return fragment
+        valid_fields = set(cls.fields())
+        result = {}
+        for k, v in fragment.items():
+            if k.startswith('$') or k.startswith('_'):
+                result[k] = v
+                continue
+            top_field = k.split('.')[0]
+            if top_field in valid_fields:
+                result[k] = v
+            else:
+                public_fields = sorted(f for f in valid_fields if not f.startswith('_'))
+                console.print(Warning(
+                    message=f"Field '{k}' does not exist on type '{_type}'. "
+                            f"Available fields: {', '.join(public_fields)}"
+                ))
+        return result
+
+    def _validate(q):
+        if not isinstance(q, dict):
+            return q
+        if '$or' in q:
+            return {'$or': [_validate(sub) for sub in q['$or']]}
+        if '$and' in q:
+            return {'$and': [_validate(sub) for sub in q['$and']]}
+        return _validate_fragment(q)
+
+    return _validate(query)

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -307,6 +307,12 @@ def validate_query_fields(query):
     }
 
     def _validate_fragment(fragment):
+        """Validate a single query fragment against known output type fields.
+
+        Returns None if all user-specified fields were invalid (signals the caller
+        to drop this fragment from an $or/$and list rather than keeping a bare
+        {'_type': 'x'} that would match every object of that type).
+        """
         if not isinstance(fragment, dict):
             return fragment
         _type = fragment.get('_type')
@@ -317,28 +323,50 @@ def validate_query_fields(query):
             return fragment
         valid_fields = set(cls.fields())
         result = {}
+        user_fields_seen = 0
+        user_fields_kept = 0
         for k, v in fragment.items():
             if k.startswith('$') or k.startswith('_'):
                 result[k] = v
                 continue
+            user_fields_seen += 1
             top_field = k.split('.')[0]
             if top_field in valid_fields:
                 result[k] = v
+                user_fields_kept += 1
             else:
                 public_fields = sorted(f for f in valid_fields if not f.startswith('_'))
                 console.print(Warning(
                     message=f"Field '{k}' does not exist on type '{_type}'. "
                             f"Available fields: {', '.join(public_fields)}"
                 ))
+        # If the fragment had user-specified fields but ALL were invalid, signal
+        # the caller to drop this fragment entirely rather than keeping a bare
+        # {'_type': _type} that would match every object of that type.
+        if user_fields_seen > 0 and user_fields_kept == 0:
+            return None
         return result
 
     def _validate(q):
         if not isinstance(q, dict):
             return q
         if '$or' in q:
-            return {'$or': [_validate(sub) for sub in q['$or']]}
+            parts = [_validate(sub) for sub in q['$or']]
+            parts = [p for p in parts if p is not None]
+            if len(parts) == 0:
+                return {}
+            if len(parts) == 1:
+                return parts[0]
+            return {'$or': parts}
         if '$and' in q:
-            return {'$and': [_validate(sub) for sub in q['$and']]}
-        return _validate_fragment(q)
+            parts = [_validate(sub) for sub in q['$and']]
+            parts = [p for p in parts if p is not None]
+            if len(parts) == 0:
+                return {}
+            if len(parts) == 1:
+                return parts[0]
+            return {'$and': parts}
+        result = _validate_fragment(q)
+        return result if result is not None else {}
 
     return _validate(query)

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -361,6 +361,87 @@ def python_expr_to_mongo(query):
     return result
 
 
+def _warn_unknown_field(field_name, type_name, valid_fields):
+    """Emit a warning for an unknown field in a query fragment."""
+    from secator.output_types import Warning
+    public_fields = sorted(f for f in valid_fields if not f.startswith('_'))
+    console.print(Warning(
+        message=f"Field '{field_name}' does not exist on type '{type_name}'. "
+                f"Available fields: {', '.join(public_fields)}"
+    ))
+
+
+def _build_type_map():
+    from secator.output_types import OUTPUT_TYPES
+    return {
+        cls.__dataclass_fields__['_type'].default: cls
+        for cls in OUTPUT_TYPES
+        if '_type' in getattr(cls, '__dataclass_fields__', {})
+        and isinstance(cls.__dataclass_fields__['_type'].default, str)
+    }
+
+
+def _validate_fragment(fragment, type_map):
+    """Validate a single query fragment against known output type fields.
+
+    Returns None if all user-specified fields were invalid (signals the caller
+    to drop this fragment from an $or/$and list rather than keeping a bare
+    {'_type': 'x'} that would match every object of that type).
+    """
+    if not isinstance(fragment, dict):
+        return fragment
+    _type = fragment.get('_type')
+    if not _type:
+        return fragment
+    cls = type_map.get(_type)
+    if cls is None:
+        return fragment
+    valid_fields = set(cls.fields())
+    result = {}
+    user_fields_seen = 0
+    user_fields_kept = 0
+    for k, v in fragment.items():
+        if k.startswith('$') or k.startswith('_'):
+            result[k] = v
+            continue
+        user_fields_seen += 1
+        top_field = k.split('.')[0]
+        if top_field in valid_fields:
+            result[k] = v
+            user_fields_kept += 1
+        else:
+            _warn_unknown_field(k, _type, valid_fields)
+    # If the fragment had user-specified fields but ALL were invalid, signal
+    # the caller to drop this fragment entirely rather than keeping a bare
+    # {'_type': _type} that would match every object of that type.
+    if user_fields_seen > 0 and user_fields_kept == 0:
+        return None
+    return result
+
+
+def _validate_query(q, type_map):
+    if not isinstance(q, dict):
+        return q
+    if '$or' in q:
+        parts = [_validate_query(sub, type_map) for sub in q['$or']]
+        parts = [p for p in parts if p]
+        if len(parts) == 0:
+            return {}
+        if len(parts) == 1:
+            return parts[0]
+        return {'$or': parts}
+    if '$and' in q:
+        parts = [_validate_query(sub, type_map) for sub in q['$and']]
+        parts = [p for p in parts if p]
+        if len(parts) == 0:
+            return {}
+        if len(parts) == 1:
+            return parts[0]
+        return {'$and': parts}
+    result = _validate_fragment(q, type_map)
+    return result if result is not None else {}
+
+
 def validate_query_fields(query):
     """Validate field names in a MongoDB-style query against known output types.
 
@@ -372,80 +453,8 @@ def validate_query_fields(query):
     if not query or not isinstance(query, dict):
         return query
 
-    from secator.output_types import OUTPUT_TYPES
-
-    type_map = {
-        cls.__dataclass_fields__['_type'].default: cls
-        for cls in OUTPUT_TYPES
-        if '_type' in getattr(cls, '__dataclass_fields__', {})
-        and isinstance(cls.__dataclass_fields__['_type'].default, str)
-    }
-
-    def _validate_fragment(fragment):
-        """Validate a single query fragment against known output type fields.
-
-        Returns None if all user-specified fields were invalid (signals the caller
-        to drop this fragment from an $or/$and list rather than keeping a bare
-        {'_type': 'x'} that would match every object of that type).
-        """
-        if not isinstance(fragment, dict):
-            return fragment
-        _type = fragment.get('_type')
-        if not _type:
-            return fragment
-        cls = type_map.get(_type)
-        if cls is None:
-            return fragment
-        valid_fields = set(cls.fields())
-        result = {}
-        user_fields_seen = 0
-        user_fields_kept = 0
-        for k, v in fragment.items():
-            if k.startswith('$') or k.startswith('_'):
-                result[k] = v
-                continue
-            user_fields_seen += 1
-            top_field = k.split('.')[0]
-            if top_field in valid_fields:
-                result[k] = v
-                user_fields_kept += 1
-            else:
-                from secator.output_types import Warning
-                public_fields = sorted(f for f in valid_fields if not f.startswith('_'))
-                console.print(Warning(
-                    message=f"Field '{k}' does not exist on type '{_type}'. "
-                            f"Available fields: {', '.join(public_fields)}"
-                ))
-        # If the fragment had user-specified fields but ALL were invalid, signal
-        # the caller to drop this fragment entirely rather than keeping a bare
-        # {'_type': _type} that would match every object of that type.
-        if user_fields_seen > 0 and user_fields_kept == 0:
-            return None
-        return result
-
-    def _validate(q):
-        if not isinstance(q, dict):
-            return q
-        if '$or' in q:
-            parts = [_validate(sub) for sub in q['$or']]
-            parts = [p for p in parts if p]
-            if len(parts) == 0:
-                return {}
-            if len(parts) == 1:
-                return parts[0]
-            return {'$or': parts}
-        if '$and' in q:
-            parts = [_validate(sub) for sub in q['$and']]
-            parts = [p for p in parts if p]
-            if len(parts) == 0:
-                return {}
-            if len(parts) == 1:
-                return parts[0]
-            return {'$and': parts}
-        result = _validate_fragment(q)
-        return result if result is not None else {}
-
-    return _validate(query)
+    type_map = _build_type_map()
+    return _validate_query(query, type_map)
 
 
 def query_has_type_constraint(query):

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -447,19 +447,26 @@ def validate_query_fields(query):
     """Validate field names in a MongoDB-style query against known output types.
 
     For each fragment referencing a known _type, checks that the queried fields
-    exist on that type. Prints a warning (with available fields) for unknown fields
-    and removes them from the query. Warnings are emitted after validation completes.
-    Returns the (possibly modified) query dict.
+    exist on that type. Invalid fields are removed from the query.
+
+    Returns:
+        tuple[dict, list]: (filtered_query, warnings) where warnings is a list of
+        (field_name, type_name, valid_fields) tuples for unknown fields found.
+        Callers are responsible for emitting the warnings at the appropriate time.
     """
     if not query or not isinstance(query, dict):
-        return query
+        return query, []
 
     type_map = _build_type_map()
     warnings = []
     result = _validate_query(query, type_map, warnings)
+    return result, warnings
+
+
+def emit_query_warnings(warnings):
+    """Emit warning messages for unknown query fields collected by validate_query_fields."""
     for field_name, type_name, valid_fields in warnings:
         _warn_unknown_field(field_name, type_name, valid_fields)
-    return result
 
 
 def query_has_type_constraint(query):

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -3,7 +3,7 @@
 import json
 import re
 
-from secator.output_types import Error, Warning
+from secator.output_types import Error
 from secator.rich import console
 from secator.utils import debug
 
@@ -410,6 +410,7 @@ def validate_query_fields(query):
                 result[k] = v
                 user_fields_kept += 1
             else:
+                from secator.output_types import Warning
                 public_fields = sorted(f for f in valid_fields if not f.startswith('_'))
                 console.print(Warning(
                     message=f"Field '{k}' does not exist on type '{_type}'. "
@@ -427,7 +428,7 @@ def validate_query_fields(query):
             return q
         if '$or' in q:
             parts = [_validate(sub) for sub in q['$or']]
-            parts = [p for p in parts if p is not None]
+            parts = [p for p in parts if p]
             if len(parts) == 0:
                 return {}
             if len(parts) == 1:
@@ -435,7 +436,7 @@ def validate_query_fields(query):
             return {'$or': parts}
         if '$and' in q:
             parts = [_validate(sub) for sub in q['$and']]
-            parts = [p for p in parts if p is not None]
+            parts = [p for p in parts if p]
             if len(parts) == 0:
                 return {}
             if len(parts) == 1:

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,5 +1,3 @@
-import re
-
 from secator.query.utils import (
     expand_runner_paths,
     parse_report_paths,
@@ -7,10 +5,6 @@ from secator.query.utils import (
     validate_query_fields,
     query_has_type_constraint,
 )
-
-
-def _strip_ansi(text):
-    return re.sub(r'\x1b\[[0-9;]*m', '', text)
 
 
 class TestParseReportPaths:
@@ -294,27 +288,34 @@ class TestExpandRunnerPaths:
 class TestValidateQueryFields:
 
     def test_none_returns_none(self):
-        assert validate_query_fields(None) is None
+        result, warnings = validate_query_fields(None)
+        assert result is None
+        assert warnings == []
 
     def test_empty_dict_returns_empty(self):
-        assert validate_query_fields({}) == {}
+        result, warnings = validate_query_fields({})
+        assert result == {}
+        assert warnings == []
 
     def test_valid_field_passes_through(self):
         q = {'_type': 'vulnerability', 'severity': {'$regex': 'high'}}
-        assert validate_query_fields(q) == q
+        result, warnings = validate_query_fields(q)
+        assert result == q
+        assert warnings == []
 
-    def test_invalid_field_removed_with_warning(self, capfd):
+    def test_invalid_field_removed_with_warning(self):
         # When ALL user-specified fields are invalid, the fragment is dropped entirely
         # (returning {} rather than {'_type': 'technology'} which would match everything).
         q = {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}}
-        result = validate_query_fields(q)
+        result, warnings = validate_query_fields(q)
         assert result == {}
-        captured = capfd.readouterr()
-        err = _strip_ansi(captured.err)
-        assert "Field 'name' does not exist on type 'technology'" in err
-        assert 'product' in err  # one of the available fields
+        assert len(warnings) == 1
+        field_name, type_name, valid_fields = warnings[0]
+        assert field_name == 'name'
+        assert type_name == 'technology'
+        assert 'product' in valid_fields  # one of the available fields
 
-    def test_or_validates_each_fragment(self, capfd):
+    def test_or_validates_each_fragment(self):
         # The technology fragment has no valid user fields, so it is dropped from $or.
         # The $or collapses to a single item, which is unwrapped.
         q = {
@@ -323,12 +324,13 @@ class TestValidateQueryFields:
                 {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}},
             ]
         }
-        result = validate_query_fields(q)
+        result, warnings = validate_query_fields(q)
         assert result == {'_type': 'url', 'status_code': {'$ne': 200}}
-        captured = capfd.readouterr()
-        assert "Field 'name' does not exist on type 'technology'" in _strip_ansi(captured.err)
+        assert len(warnings) == 1
+        assert warnings[0][0] == 'name'
+        assert warnings[0][1] == 'technology'
 
-    def test_or_with_partial_invalid_fields(self, capfd):
+    def test_or_with_partial_invalid_fields(self):
         # When one fragment has some valid and some invalid fields, only the invalid
         # field is removed; the fragment itself is kept.
         q = {
@@ -337,17 +339,18 @@ class TestValidateQueryFields:
                 {'_type': 'technology', 'product': 'nginx', 'name': 'bogus'},
             ]
         }
-        result = validate_query_fields(q)
+        result, warnings = validate_query_fields(q)
         assert result == {
             '$or': [
                 {'_type': 'url', 'status_code': {'$ne': 200}},
                 {'_type': 'technology', 'product': 'nginx'},
             ]
         }
-        captured = capfd.readouterr()
-        assert "Field 'name' does not exist on type 'technology'" in _strip_ansi(captured.err)
+        assert len(warnings) == 1
+        assert warnings[0][0] == 'name'
+        assert warnings[0][1] == 'technology'
 
-    def test_and_validates_each_fragment(self, capfd):
+    def test_and_validates_each_fragment(self):
         # The technology fragment (all user fields invalid) is dropped from $and.
         # The $and collapses to a single item, which is unwrapped.
         q = {
@@ -356,42 +359,55 @@ class TestValidateQueryFields:
                 {'_type': 'technology', 'name': {'$regex': 'php'}},
             ]
         }
-        result = validate_query_fields(q)
+        result, warnings = validate_query_fields(q)
         assert result == {'_context.scan_id': '5'}
-        captured = capfd.readouterr()
-        assert "Field 'name' does not exist on type 'technology'" in _strip_ansi(captured.err)
+        assert len(warnings) == 1
+        assert warnings[0][0] == 'name'
+        assert warnings[0][1] == 'technology'
 
     def test_unknown_type_passes_through(self):
         q = {'_type': 'unknown_type', 'foo': 'bar'}
-        assert validate_query_fields(q) == q
+        result, warnings = validate_query_fields(q)
+        assert result == q
+        assert warnings == []
 
     def test_no_type_passes_through(self):
         q = {'_context.scan_id': '5'}
-        assert validate_query_fields(q) == q
+        result, warnings = validate_query_fields(q)
+        assert result == q
+        assert warnings == []
 
     def test_internal_fields_pass_through(self):
         q = {'_type': 'url', '_context': {'scan_id': '5'}, '_timestamp': {'$gte': 0}}
-        assert validate_query_fields(q) == q
+        result, warnings = validate_query_fields(q)
+        assert result == q
+        assert warnings == []
 
     def test_nested_extra_data_field_passes_through(self):
         q = {'_type': 'url', 'extra_data.custom': 'value'}
-        assert validate_query_fields(q) == q
+        result, warnings = validate_query_fields(q)
+        assert result == q
+        assert warnings == []
 
-    def test_multiple_invalid_fields_all_warned(self, capfd):
+    def test_multiple_invalid_fields_all_warned(self):
         # All user fields invalid → fragment dropped entirely, returning {}
         q = {'_type': 'technology', 'name': 'php', 'bogus': 'x'}
-        result = validate_query_fields(q)
+        result, warnings = validate_query_fields(q)
         assert result == {}
-        captured = capfd.readouterr()
-        err = _strip_ansi(captured.err)
-        assert "Field 'name' does not exist on type 'technology'" in err
-        assert "Field 'bogus' does not exist on type 'technology'" in err
+        assert len(warnings) == 2
+        warned_fields = {w[0] for w in warnings}
+        assert 'name' in warned_fields
+        assert 'bogus' in warned_fields
 
     def test_valid_url_status_code(self):
         q = {'_type': 'url', 'status_code': {'$ne': 200}}
-        assert validate_query_fields(q) == q
+        result, warnings = validate_query_fields(q)
+        assert result == q
+        assert warnings == []
 
     def test_valid_vulnerability_cvss_score(self):
         q = {'_type': 'vulnerability', 'cvss_score': {'$gt': 7}}
-        assert validate_query_fields(q) == q
+        result, warnings = validate_query_fields(q)
+        assert result == q
+        assert warnings == []
 

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,3 +1,5 @@
+import re
+
 from secator.query.utils import (
     expand_runner_paths,
     parse_report_paths,
@@ -5,6 +7,10 @@ from secator.query.utils import (
     validate_query_fields,
     query_has_type_constraint,
 )
+
+
+def _strip_ansi(text):
+    return re.sub(r'\x1b\[[0-9;]*m', '', text)
 
 
 class TestParseReportPaths:
@@ -304,8 +310,9 @@ class TestValidateQueryFields:
         result = validate_query_fields(q)
         assert result == {}
         captured = capfd.readouterr()
-        assert "Field 'name' does not exist on type 'technology'" in captured.err
-        assert 'product' in captured.err  # one of the available fields
+        err = _strip_ansi(captured.err)
+        assert "Field 'name' does not exist on type 'technology'" in err
+        assert 'product' in err  # one of the available fields
 
     def test_or_validates_each_fragment(self, capfd):
         # The technology fragment has no valid user fields, so it is dropped from $or.
@@ -319,7 +326,7 @@ class TestValidateQueryFields:
         result = validate_query_fields(q)
         assert result == {'_type': 'url', 'status_code': {'$ne': 200}}
         captured = capfd.readouterr()
-        assert "Field 'name' does not exist on type 'technology'" in captured.err
+        assert "Field 'name' does not exist on type 'technology'" in _strip_ansi(captured.err)
 
     def test_or_with_partial_invalid_fields(self, capfd):
         # When one fragment has some valid and some invalid fields, only the invalid
@@ -338,7 +345,7 @@ class TestValidateQueryFields:
             ]
         }
         captured = capfd.readouterr()
-        assert "Field 'name' does not exist on type 'technology'" in captured.err
+        assert "Field 'name' does not exist on type 'technology'" in _strip_ansi(captured.err)
 
     def test_and_validates_each_fragment(self, capfd):
         # The technology fragment (all user fields invalid) is dropped from $and.
@@ -352,7 +359,7 @@ class TestValidateQueryFields:
         result = validate_query_fields(q)
         assert result == {'_context.scan_id': '5'}
         captured = capfd.readouterr()
-        assert "Field 'name' does not exist on type 'technology'" in captured.err
+        assert "Field 'name' does not exist on type 'technology'" in _strip_ansi(captured.err)
 
     def test_unknown_type_passes_through(self):
         q = {'_type': 'unknown_type', 'foo': 'bar'}
@@ -376,8 +383,9 @@ class TestValidateQueryFields:
         result = validate_query_fields(q)
         assert result == {}
         captured = capfd.readouterr()
-        assert "Field 'name' does not exist on type 'technology'" in captured.err
-        assert "Field 'bogus' does not exist on type 'technology'" in captured.err
+        err = _strip_ansi(captured.err)
+        assert "Field 'name' does not exist on type 'technology'" in err
+        assert "Field 'bogus' does not exist on type 'technology'" in err
 
     def test_valid_url_status_code(self):
         q = {'_type': 'url', 'status_code': {'$ne': 200}}

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,4 +1,6 @@
-from secator.query.utils import parse_report_paths, python_expr_to_mongo
+from unittest.mock import patch
+
+from secator.query.utils import parse_report_paths, python_expr_to_mongo, validate_query_fields
 
 
 class TestParseReportPaths:
@@ -157,4 +159,93 @@ class TestPythonExprToMongo:
     def test_in_operator_floats(self):
         result = python_expr_to_mongo("item.score in [1.5, 2.5, 3.0]")
         assert result == {'_type': 'item', 'score': {'$in': [1.5, 2.5, 3.0]}}
+
+
+class TestValidateQueryFields:
+
+    def test_none_returns_none(self):
+        assert validate_query_fields(None) is None
+
+    def test_empty_dict_returns_empty(self):
+        assert validate_query_fields({}) == {}
+
+    def test_valid_field_passes_through(self):
+        q = {'_type': 'vulnerability', 'severity': {'$regex': 'high'}}
+        assert validate_query_fields(q) == q
+
+    def test_invalid_field_removed_with_warning(self):
+        q = {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}}
+        with patch('secator.query.utils.console') as mock_console:
+            result = validate_query_fields(q)
+        assert result == {'_type': 'technology'}
+        mock_console.print.assert_called_once()
+        warning_obj = mock_console.print.call_args[0][0]
+        assert 'name' in warning_obj.message
+        assert 'technology' in warning_obj.message
+        assert 'product' in warning_obj.message  # one of the available fields
+
+    def test_or_validates_each_fragment(self):
+        q = {
+            '$or': [
+                {'_type': 'url', 'status_code': {'$ne': 200}},
+                {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}},
+            ]
+        }
+        with patch('secator.query.utils.console') as mock_console:
+            result = validate_query_fields(q)
+        assert result == {
+            '$or': [
+                {'_type': 'url', 'status_code': {'$ne': 200}},
+                {'_type': 'technology'},
+            ]
+        }
+        mock_console.print.assert_called_once()
+
+    def test_and_validates_each_fragment(self):
+        q = {
+            '$and': [
+                {'_context.scan_id': '5'},
+                {'_type': 'technology', 'name': {'$regex': 'php'}},
+            ]
+        }
+        with patch('secator.query.utils.console') as mock_console:
+            result = validate_query_fields(q)
+        assert result == {
+            '$and': [
+                {'_context.scan_id': '5'},
+                {'_type': 'technology'},
+            ]
+        }
+        mock_console.print.assert_called_once()
+
+    def test_unknown_type_passes_through(self):
+        q = {'_type': 'unknown_type', 'foo': 'bar'}
+        assert validate_query_fields(q) == q
+
+    def test_no_type_passes_through(self):
+        q = {'_context.scan_id': '5'}
+        assert validate_query_fields(q) == q
+
+    def test_internal_fields_pass_through(self):
+        q = {'_type': 'url', '_context': {'scan_id': '5'}, '_timestamp': {'$gte': 0}}
+        assert validate_query_fields(q) == q
+
+    def test_nested_extra_data_field_passes_through(self):
+        q = {'_type': 'url', 'extra_data.custom': 'value'}
+        assert validate_query_fields(q) == q
+
+    def test_multiple_invalid_fields_all_warned(self):
+        q = {'_type': 'technology', 'name': 'php', 'bogus': 'x'}
+        with patch('secator.query.utils.console') as mock_console:
+            result = validate_query_fields(q)
+        assert result == {'_type': 'technology'}
+        assert mock_console.print.call_count == 2
+
+    def test_valid_url_status_code(self):
+        q = {'_type': 'url', 'status_code': {'$ne': 200}}
+        assert validate_query_fields(q) == q
+
+    def test_valid_vulnerability_cvss_score(self):
+        q = {'_type': 'vulnerability', 'cvss_score': {'$gt': 7}}
+        assert validate_query_fields(q) == q
 

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -5,6 +5,7 @@ from secator.query.utils import (
     python_expr_to_mongo,
     validate_query_fields,
     query_has_type_constraint,
+    _warn_unknown_field,
 )
 
 
@@ -302,14 +303,14 @@ class TestValidateQueryFields:
         # When ALL user-specified fields are invalid, the fragment is dropped entirely
         # (returning {} rather than {'_type': 'technology'} which would match everything).
         q = {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}}
-        with patch('secator.query.utils.console') as mock_console:
+        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
             result = validate_query_fields(q)
         assert result == {}
-        mock_console.print.assert_called_once()
-        warning_obj = mock_console.print.call_args[0][0]
-        assert 'name' in warning_obj.message
-        assert 'technology' in warning_obj.message
-        assert 'product' in warning_obj.message  # one of the available fields
+        mock_warn.assert_called_once()
+        field_name, type_name, valid_fields = mock_warn.call_args[0]
+        assert field_name == 'name'
+        assert type_name == 'technology'
+        assert 'product' in valid_fields  # one of the available fields
 
     def test_or_validates_each_fragment(self):
         # The technology fragment has no valid user fields, so it is dropped from $or.
@@ -320,10 +321,10 @@ class TestValidateQueryFields:
                 {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}},
             ]
         }
-        with patch('secator.query.utils.console') as mock_console:
+        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
             result = validate_query_fields(q)
         assert result == {'_type': 'url', 'status_code': {'$ne': 200}}
-        mock_console.print.assert_called_once()
+        mock_warn.assert_called_once()
 
     def test_or_with_partial_invalid_fields(self):
         # When one fragment has some valid and some invalid fields, only the invalid
@@ -334,7 +335,7 @@ class TestValidateQueryFields:
                 {'_type': 'technology', 'product': 'nginx', 'name': 'bogus'},
             ]
         }
-        with patch('secator.query.utils.console') as mock_console:
+        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
             result = validate_query_fields(q)
         assert result == {
             '$or': [
@@ -342,7 +343,7 @@ class TestValidateQueryFields:
                 {'_type': 'technology', 'product': 'nginx'},
             ]
         }
-        mock_console.print.assert_called_once()
+        mock_warn.assert_called_once()
 
     def test_and_validates_each_fragment(self):
         # The technology fragment (all user fields invalid) is dropped from $and.
@@ -353,10 +354,10 @@ class TestValidateQueryFields:
                 {'_type': 'technology', 'name': {'$regex': 'php'}},
             ]
         }
-        with patch('secator.query.utils.console') as mock_console:
+        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
             result = validate_query_fields(q)
         assert result == {'_context.scan_id': '5'}
-        mock_console.print.assert_called_once()
+        mock_warn.assert_called_once()
 
     def test_unknown_type_passes_through(self):
         q = {'_type': 'unknown_type', 'foo': 'bar'}
@@ -377,10 +378,10 @@ class TestValidateQueryFields:
     def test_multiple_invalid_fields_all_warned(self):
         # All user fields invalid → fragment dropped entirely, returning {}
         q = {'_type': 'technology', 'name': 'php', 'bogus': 'x'}
-        with patch('secator.query.utils.console') as mock_console:
+        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
             result = validate_query_fields(q)
         assert result == {}
-        assert mock_console.print.call_count == 2
+        assert mock_warn.call_count == 2
 
     def test_valid_url_status_code(self):
         q = {'_type': 'url', 'status_code': {'$ne': 200}}

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -297,23 +297,19 @@ class TestValidateQueryFields:
         q = {'_type': 'vulnerability', 'severity': {'$regex': 'high'}}
         assert validate_query_fields(q) == q
 
-    def test_invalid_field_removed_with_warning(self):
+    def test_invalid_field_removed_with_warning(self, capfd):
         # When ALL user-specified fields are invalid, the fragment is dropped entirely
         # (returning {} rather than {'_type': 'technology'} which would match everything).
-        from secator.rich import console
-        console.export_text(clear=True)
         q = {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}}
         result = validate_query_fields(q)
         assert result == {}
-        recorded = console.export_text()
-        assert "Field 'name' does not exist on type 'technology'" in recorded
-        assert 'product' in recorded  # one of the available fields
+        captured = capfd.readouterr()
+        assert "Field 'name' does not exist on type 'technology'" in captured.err
+        assert 'product' in captured.err  # one of the available fields
 
-    def test_or_validates_each_fragment(self):
+    def test_or_validates_each_fragment(self, capfd):
         # The technology fragment has no valid user fields, so it is dropped from $or.
         # The $or collapses to a single item, which is unwrapped.
-        from secator.rich import console
-        console.export_text(clear=True)
         q = {
             '$or': [
                 {'_type': 'url', 'status_code': {'$ne': 200}},
@@ -322,14 +318,12 @@ class TestValidateQueryFields:
         }
         result = validate_query_fields(q)
         assert result == {'_type': 'url', 'status_code': {'$ne': 200}}
-        recorded = console.export_text()
-        assert "Field 'name' does not exist on type 'technology'" in recorded
+        captured = capfd.readouterr()
+        assert "Field 'name' does not exist on type 'technology'" in captured.err
 
-    def test_or_with_partial_invalid_fields(self):
+    def test_or_with_partial_invalid_fields(self, capfd):
         # When one fragment has some valid and some invalid fields, only the invalid
         # field is removed; the fragment itself is kept.
-        from secator.rich import console
-        console.export_text(clear=True)
         q = {
             '$or': [
                 {'_type': 'url', 'status_code': {'$ne': 200}},
@@ -343,14 +337,12 @@ class TestValidateQueryFields:
                 {'_type': 'technology', 'product': 'nginx'},
             ]
         }
-        recorded = console.export_text()
-        assert "Field 'name' does not exist on type 'technology'" in recorded
+        captured = capfd.readouterr()
+        assert "Field 'name' does not exist on type 'technology'" in captured.err
 
-    def test_and_validates_each_fragment(self):
+    def test_and_validates_each_fragment(self, capfd):
         # The technology fragment (all user fields invalid) is dropped from $and.
         # The $and collapses to a single item, which is unwrapped.
-        from secator.rich import console
-        console.export_text(clear=True)
         q = {
             '$and': [
                 {'_context.scan_id': '5'},
@@ -359,8 +351,8 @@ class TestValidateQueryFields:
         }
         result = validate_query_fields(q)
         assert result == {'_context.scan_id': '5'}
-        recorded = console.export_text()
-        assert "Field 'name' does not exist on type 'technology'" in recorded
+        captured = capfd.readouterr()
+        assert "Field 'name' does not exist on type 'technology'" in captured.err
 
     def test_unknown_type_passes_through(self):
         q = {'_type': 'unknown_type', 'foo': 'bar'}
@@ -378,16 +370,14 @@ class TestValidateQueryFields:
         q = {'_type': 'url', 'extra_data.custom': 'value'}
         assert validate_query_fields(q) == q
 
-    def test_multiple_invalid_fields_all_warned(self):
+    def test_multiple_invalid_fields_all_warned(self, capfd):
         # All user fields invalid → fragment dropped entirely, returning {}
-        from secator.rich import console
-        console.export_text(clear=True)
         q = {'_type': 'technology', 'name': 'php', 'bogus': 'x'}
         result = validate_query_fields(q)
         assert result == {}
-        recorded = console.export_text()
-        assert "Field 'name' does not exist on type 'technology'" in recorded
-        assert "Field 'bogus' does not exist on type 'technology'" in recorded
+        captured = capfd.readouterr()
+        assert "Field 'name' does not exist on type 'technology'" in captured.err
+        assert "Field 'bogus' does not exist on type 'technology'" in captured.err
 
     def test_valid_url_status_code(self):
         q = {'_type': 'url', 'status_code': {'$ne': 200}}

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,11 +1,9 @@
-from unittest.mock import patch
 from secator.query.utils import (
     expand_runner_paths,
     parse_report_paths,
     python_expr_to_mongo,
     validate_query_fields,
     query_has_type_constraint,
-    _warn_unknown_field,
 )
 
 
@@ -302,62 +300,67 @@ class TestValidateQueryFields:
     def test_invalid_field_removed_with_warning(self):
         # When ALL user-specified fields are invalid, the fragment is dropped entirely
         # (returning {} rather than {'_type': 'technology'} which would match everything).
+        from secator.rich import console
+        console.export_text(clear=True)
         q = {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}}
-        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
-            result = validate_query_fields(q)
+        result = validate_query_fields(q)
         assert result == {}
-        mock_warn.assert_called_once()
-        field_name, type_name, valid_fields = mock_warn.call_args[0]
-        assert field_name == 'name'
-        assert type_name == 'technology'
-        assert 'product' in valid_fields  # one of the available fields
+        recorded = console.export_text()
+        assert "Field 'name' does not exist on type 'technology'" in recorded
+        assert 'product' in recorded  # one of the available fields
 
     def test_or_validates_each_fragment(self):
         # The technology fragment has no valid user fields, so it is dropped from $or.
         # The $or collapses to a single item, which is unwrapped.
+        from secator.rich import console
+        console.export_text(clear=True)
         q = {
             '$or': [
                 {'_type': 'url', 'status_code': {'$ne': 200}},
                 {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}},
             ]
         }
-        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
-            result = validate_query_fields(q)
+        result = validate_query_fields(q)
         assert result == {'_type': 'url', 'status_code': {'$ne': 200}}
-        mock_warn.assert_called_once()
+        recorded = console.export_text()
+        assert "Field 'name' does not exist on type 'technology'" in recorded
 
     def test_or_with_partial_invalid_fields(self):
         # When one fragment has some valid and some invalid fields, only the invalid
         # field is removed; the fragment itself is kept.
+        from secator.rich import console
+        console.export_text(clear=True)
         q = {
             '$or': [
                 {'_type': 'url', 'status_code': {'$ne': 200}},
                 {'_type': 'technology', 'product': 'nginx', 'name': 'bogus'},
             ]
         }
-        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
-            result = validate_query_fields(q)
+        result = validate_query_fields(q)
         assert result == {
             '$or': [
                 {'_type': 'url', 'status_code': {'$ne': 200}},
                 {'_type': 'technology', 'product': 'nginx'},
             ]
         }
-        mock_warn.assert_called_once()
+        recorded = console.export_text()
+        assert "Field 'name' does not exist on type 'technology'" in recorded
 
     def test_and_validates_each_fragment(self):
         # The technology fragment (all user fields invalid) is dropped from $and.
         # The $and collapses to a single item, which is unwrapped.
+        from secator.rich import console
+        console.export_text(clear=True)
         q = {
             '$and': [
                 {'_context.scan_id': '5'},
                 {'_type': 'technology', 'name': {'$regex': 'php'}},
             ]
         }
-        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
-            result = validate_query_fields(q)
+        result = validate_query_fields(q)
         assert result == {'_context.scan_id': '5'}
-        mock_warn.assert_called_once()
+        recorded = console.export_text()
+        assert "Field 'name' does not exist on type 'technology'" in recorded
 
     def test_unknown_type_passes_through(self):
         q = {'_type': 'unknown_type', 'foo': 'bar'}
@@ -377,11 +380,14 @@ class TestValidateQueryFields:
 
     def test_multiple_invalid_fields_all_warned(self):
         # All user fields invalid → fragment dropped entirely, returning {}
+        from secator.rich import console
+        console.export_text(clear=True)
         q = {'_type': 'technology', 'name': 'php', 'bogus': 'x'}
-        with patch('secator.query.utils._warn_unknown_field') as mock_warn:
-            result = validate_query_fields(q)
+        result = validate_query_fields(q)
         assert result == {}
-        assert mock_warn.call_count == 2
+        recorded = console.export_text()
+        assert "Field 'name' does not exist on type 'technology'" in recorded
+        assert "Field 'bogus' does not exist on type 'technology'" in recorded
 
     def test_valid_url_status_code(self):
         q = {'_type': 'url', 'status_code': {'$ne': 200}}

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -174,10 +174,12 @@ class TestValidateQueryFields:
         assert validate_query_fields(q) == q
 
     def test_invalid_field_removed_with_warning(self):
+        # When ALL user-specified fields are invalid, the fragment is dropped entirely
+        # (returning {} rather than {'_type': 'technology'} which would match everything).
         q = {'_type': 'technology', 'name': {'$regex': '(HSTS|php)'}}
         with patch('secator.query.utils.console') as mock_console:
             result = validate_query_fields(q)
-        assert result == {'_type': 'technology'}
+        assert result == {}
         mock_console.print.assert_called_once()
         warning_obj = mock_console.print.call_args[0][0]
         assert 'name' in warning_obj.message
@@ -185,6 +187,8 @@ class TestValidateQueryFields:
         assert 'product' in warning_obj.message  # one of the available fields
 
     def test_or_validates_each_fragment(self):
+        # The technology fragment has no valid user fields, so it is dropped from $or.
+        # The $or collapses to a single item, which is unwrapped.
         q = {
             '$or': [
                 {'_type': 'url', 'status_code': {'$ne': 200}},
@@ -193,15 +197,31 @@ class TestValidateQueryFields:
         }
         with patch('secator.query.utils.console') as mock_console:
             result = validate_query_fields(q)
+        assert result == {'_type': 'url', 'status_code': {'$ne': 200}}
+        mock_console.print.assert_called_once()
+
+    def test_or_with_partial_invalid_fields(self):
+        # When one fragment has some valid and some invalid fields, only the invalid
+        # field is removed; the fragment itself is kept.
+        q = {
+            '$or': [
+                {'_type': 'url', 'status_code': {'$ne': 200}},
+                {'_type': 'technology', 'product': 'nginx', 'name': 'bogus'},
+            ]
+        }
+        with patch('secator.query.utils.console') as mock_console:
+            result = validate_query_fields(q)
         assert result == {
             '$or': [
                 {'_type': 'url', 'status_code': {'$ne': 200}},
-                {'_type': 'technology'},
+                {'_type': 'technology', 'product': 'nginx'},
             ]
         }
         mock_console.print.assert_called_once()
 
     def test_and_validates_each_fragment(self):
+        # The technology fragment (all user fields invalid) is dropped from $and.
+        # The $and collapses to a single item, which is unwrapped.
         q = {
             '$and': [
                 {'_context.scan_id': '5'},
@@ -210,12 +230,7 @@ class TestValidateQueryFields:
         }
         with patch('secator.query.utils.console') as mock_console:
             result = validate_query_fields(q)
-        assert result == {
-            '$and': [
-                {'_context.scan_id': '5'},
-                {'_type': 'technology'},
-            ]
-        }
+        assert result == {'_context.scan_id': '5'}
         mock_console.print.assert_called_once()
 
     def test_unknown_type_passes_through(self):
@@ -235,10 +250,11 @@ class TestValidateQueryFields:
         assert validate_query_fields(q) == q
 
     def test_multiple_invalid_fields_all_warned(self):
+        # All user fields invalid → fragment dropped entirely, returning {}
         q = {'_type': 'technology', 'name': 'php', 'bogus': 'x'}
         with patch('secator.query.utils.console') as mock_console:
             result = validate_query_fields(q)
-        assert result == {'_type': 'technology'}
+        assert result == {}
         assert mock_console.print.call_count == 2
 
     def test_valid_url_status_code(self):


### PR DESCRIPTION
When making a query like `secator query "url.status_code != 200 || technology.name ~= '(HSTS|php)'"`, if a field does not exist on the referenced output type, a warning is now printed with the list of available fields, and the invalid filter is removed so the query still runs cleanly.

Closes #1154

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added query validation for reports to ensure queries match known output types.
  * Unknown query fields now trigger warning notifications for better query clarity.
  * Invalid fields are automatically filtered from queries during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->