### PR TITLE
fix(config): rename `workspace` config key to `workspaces`

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -465,11 +465,11 @@ Workspace settings.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `workspace.default` | `string` | `''` | Default workspace name |
+| `workspaces.current` | `string` | `''` | Current workspace name |
 
 ```yaml
-workspace:
-  default: my-project
+workspaces:
+  current: my-project
 ```
 
 ---

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -803,7 +803,7 @@ def workspace_list():
 	for workspace, config in workspaces.items():
 		table.add_row(workspace, str(config['count']), config['path'])
 	console.print(table)
-	current = CONFIG.workspaces.default or 'default'
+	current = CONFIG.workspaces.current or 'default'
 	console.print(Info(message=f'Current workspace: [bold gold3]{current}[/]. Use [bold green4]secator ws use <workspace>[/] to switch.'))  # noqa: E501
 
 
@@ -811,7 +811,7 @@ def workspace_list():
 @click.argument('name')
 def workspace_use(name):
 	"""Use a workspace (set as default)"""
-	CONFIG.set('workspaces.default', name)
+	CONFIG.set('workspaces.current', name)
 	config = CONFIG.validate()
 	if config:
 		CONFIG.save()
@@ -823,7 +823,7 @@ def workspace_use(name):
 @workspace.command('current')
 def workspace_current():
 	"""Show current default workspace"""
-	current = CONFIG.workspaces.default or 'default'
+	current = CONFIG.workspaces.current or 'default'
 	console.print(Info(message=f'Current workspace: [bold gold3]{current}[/]. Use [bold green4]secator ws use <workspace>[/] to switch.'))  # noqa: E501
 
 
@@ -1273,7 +1273,7 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	from secator.query.utils import parse_report_paths, python_expr_to_mongo, query_has_type_constraint
 
 	current = get_file_timestamp()
-	workspace_name = workspace or CONFIG.workspaces.default or 'default'
+	workspace_name = workspace or CONFIG.workspaces.current or 'default'
 
 	# 1. Parse path-based runner filter
 	runner_filter = parse_report_paths(report_query)
@@ -1548,7 +1548,7 @@ def report_info(runner_id, workspace, show_all):
 	"""Show runner info from a report. RUNNER_ID: runner path (e.g. scans/0)"""
 	MAX_ENTRIES = 20
 
-	workspace_name = workspace or CONFIG.workspaces.default or 'default'
+	workspace_name = workspace or CONFIG.workspaces.current or 'default'
 	parts = runner_id.split('/')
 	if len(parts) != 2:
 		console.print(Error(message=f'Invalid runner ID: {runner_id!r}. Expected format: <type>/<id> (e.g. scans/0)'))
@@ -1687,7 +1687,7 @@ def report_delete(runner_ids, workspace, driver, yes):
 	"""
 	from secator.query.utils import expand_runner_paths
 
-	workspace_name = workspace or CONFIG.workspaces.default or 'default'
+	workspace_name = workspace or CONFIG.workspaces.current or 'default'
 
 	refs, errors = expand_runner_paths(list(runner_ids))
 	for err in errors:

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -678,8 +678,8 @@ def config_set(key, value, strategy):
 	  secator config set drivers.defaults redis                            # replace list field
 	  secator config set drivers.defaults redis --append                   # append to list field
 	  secator config set wordlists.defaults.http mylist                    # set a dict subkey
-	  secator config set workspace.profiles.my_ws aggressive,passive  # set workspace profiles
-	  secator config set workspace.profiles.my_ws test --append   # append to workspace profiles
+	  secator config set workspaces.profiles.my_ws aggressive,passive  # set workspace profiles
+	  secator config set workspaces.profiles.my_ws test --append   # append to workspace profiles
 	"""
 	CONFIG.set(key, value, strategy=strategy if strategy else None)
 	config = CONFIG.validate()
@@ -709,8 +709,8 @@ def config_unset(key, value=None):
 	  secator config unset debug                                      # reset scalar to default
 	  secator config unset drivers.defaults redis                     # remove item from list
 	  secator config unset wordlists.defaults.http                    # remove dict subkey
-	  secator config unset workspace.profiles.my_ws test     # remove profile from workspace list
-	  secator config unset workspace.profiles.my_ws          # remove workspace profile list entirely
+	  secator config unset workspaces.profiles.my_ws test     # remove profile from workspace list
+	  secator config unset workspaces.profiles.my_ws          # remove workspace profile list entirely
 	"""
 	CONFIG.unset(key, value=value)
 	config = CONFIG.validate()
@@ -803,7 +803,7 @@ def workspace_list():
 	for workspace, config in workspaces.items():
 		table.add_row(workspace, str(config['count']), config['path'])
 	console.print(table)
-	current = CONFIG.workspace.default or 'default'
+	current = CONFIG.workspaces.default or 'default'
 	console.print(Info(message=f'Current workspace: [bold gold3]{current}[/]. Use [bold green4]secator ws use <workspace>[/] to switch.'))  # noqa: E501
 
 
@@ -811,7 +811,7 @@ def workspace_list():
 @click.argument('name')
 def workspace_use(name):
 	"""Use a workspace (set as default)"""
-	CONFIG.set('workspace.default', name)
+	CONFIG.set('workspaces.default', name)
 	config = CONFIG.validate()
 	if config:
 		CONFIG.save()
@@ -823,7 +823,7 @@ def workspace_use(name):
 @workspace.command('current')
 def workspace_current():
 	"""Show current default workspace"""
-	current = CONFIG.workspace.default or 'default'
+	current = CONFIG.workspaces.default or 'default'
 	console.print(Info(message=f'Current workspace: [bold gold3]{current}[/]. Use [bold green4]secator ws use <workspace>[/] to switch.'))  # noqa: E501
 
 
@@ -1273,7 +1273,7 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	from secator.query.utils import parse_report_paths, python_expr_to_mongo, query_has_type_constraint
 
 	current = get_file_timestamp()
-	workspace_name = workspace or CONFIG.workspace.default or 'default'
+	workspace_name = workspace or CONFIG.workspaces.default or 'default'
 
 	# 1. Parse path-based runner filter
 	runner_filter = parse_report_paths(report_query)
@@ -1548,7 +1548,7 @@ def report_info(runner_id, workspace, show_all):
 	"""Show runner info from a report. RUNNER_ID: runner path (e.g. scans/0)"""
 	MAX_ENTRIES = 20
 
-	workspace_name = workspace or CONFIG.workspace.default or 'default'
+	workspace_name = workspace or CONFIG.workspaces.default or 'default'
 	parts = runner_id.split('/')
 	if len(parts) != 2:
 		console.print(Error(message=f'Invalid runner ID: {runner_id!r}. Expected format: <type>/<id> (e.g. scans/0)'))
@@ -1687,7 +1687,7 @@ def report_delete(runner_ids, workspace, driver, yes):
 	"""
 	from secator.query.utils import expand_runner_paths
 
-	workspace_name = workspace or CONFIG.workspace.default or 'default'
+	workspace_name = workspace or CONFIG.workspaces.default or 'default'
 
 	refs, errors = expand_runner_paths(list(runner_ids))
 	for err in errors:

--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -27,7 +27,7 @@ PROFILES_STR = ','.join([f'[dim yellow3]{_.name}[/]' for _ in get_configs_by_typ
 DRIVERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in get_available_drivers()])
 DRIVER_DEFAULTS_STR = ','.join(CONFIG.drivers.defaults) if CONFIG.drivers.defaults else None
 PROFILE_DEFAULTS_STR = ','.join(CONFIG.profiles.defaults) if CONFIG.profiles.defaults else None
-WORKSPACE_DEFAULT_STR = CONFIG.workspace.default if CONFIG.workspace.default else 'default'
+WORKSPACE_DEFAULT_STR = CONFIG.workspaces.default if CONFIG.workspaces.default else 'default'
 EXPORTERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in get_available_exporters()])
 
 CLI_OUTPUT_OPTS = {

--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -27,7 +27,7 @@ PROFILES_STR = ','.join([f'[dim yellow3]{_.name}[/]' for _ in get_configs_by_typ
 DRIVERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in get_available_drivers()])
 DRIVER_DEFAULTS_STR = ','.join(CONFIG.drivers.defaults) if CONFIG.drivers.defaults else None
 PROFILE_DEFAULTS_STR = ','.join(CONFIG.profiles.defaults) if CONFIG.profiles.defaults else None
-WORKSPACE_DEFAULT_STR = CONFIG.workspaces.default if CONFIG.workspaces.default else 'default'
+WORKSPACE_DEFAULT_STR = CONFIG.workspaces.current if CONFIG.workspaces.current else 'default'
 EXPORTERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in get_available_exporters()])
 
 CLI_OUTPUT_OPTS = {

--- a/secator/config.py
+++ b/secator/config.py
@@ -312,7 +312,7 @@ class SecatorConfig(StrictModel):
 	wordlists: Wordlists = Wordlists()
 	profiles: Profiles = Profiles()
 	drivers: Drivers = Drivers()
-	workspace: Workspace = Workspace()
+	workspaces: Workspace = Workspace()
 	addons: Addons = Addons()
 	security: Security = Security()
 	providers: Providers = Providers()
@@ -524,15 +524,15 @@ class Config(DotMap):
 		else:
 			if subkey:
 				new_val = Config._parse_new_value(value)
-				# For workspace.profiles, always coerce single strings to list
-				if parent_path == 'workspace.profiles' and isinstance(new_val, str):
+				# For workspaces.profiles, always coerce single strings to list
+				if parent_path == 'workspaces.profiles' and isinstance(new_val, str):
 					new_val = [new_val]
 				updated[subkey] = new_val
 			elif isinstance(value, dict):
 				updated.update(value)
 
-		# Validate profile names when setting workspace.profiles values
-		if parent_path == 'workspace.profiles' and subkey and subkey in updated and strategy != 'remove':
+		# Validate profile names when setting workspaces.profiles values
+		if parent_path == 'workspaces.profiles' and subkey and subkey in updated and strategy != 'remove':
 			new_val = updated[subkey]
 			if new_val:
 				profile_names = new_val if isinstance(new_val, list) else [new_val]
@@ -627,6 +627,17 @@ class Config(DotMap):
 		# Load YAML file
 		if path:
 			data = Config.read_yaml(path)
+
+		# Backwards compatibility: migrate 'workspace' key to 'workspaces'
+		if 'workspace' in data and 'workspaces' not in data:
+			data['workspaces'] = data.pop('workspace')
+			if path:
+				console.print(f'[bold orange1]Migrating config key "workspace" to "workspaces" in {path}[/]')
+				try:
+					with path.open('w') as f:
+						f.write(yaml.dump({k: v for k, v in data.items() if not k.startswith('_')}, sort_keys=False))
+				except Exception as e:
+					console.print(f'[bold red]Failed to save migrated config: {e}[/]')
 
 		# Load data
 		config = Config.load(SecatorConfig, data, print_errors=print_errors)

--- a/secator/config.py
+++ b/secator/config.py
@@ -637,7 +637,8 @@ class Config(DotMap):
 			migrated = True
 
 		# Backwards compatibility: migrate 'workspaces.default' to 'workspaces.current'
-		if isinstance(data.get('workspaces'), dict) and 'default' in data['workspaces'] and 'current' not in data['workspaces']:
+		ws_data = data.get('workspaces')
+		if isinstance(ws_data, dict) and 'default' in ws_data and 'current' not in ws_data:
 			data['workspaces']['current'] = data['workspaces'].pop('default')
 			if path:
 				console.print(f'[bold orange1]Migrating config key "workspaces.default" to "workspaces.current" in {path}[/]')

--- a/secator/config.py
+++ b/secator/config.py
@@ -148,7 +148,7 @@ class Drivers(StrictModel):
 
 
 class Workspace(StrictModel):
-	default: str = ''
+	current: str = ''
 	routes: Dict[str, List[str]] = {}
 	profiles: Dict[str, List[str]] = {}
 
@@ -629,15 +629,26 @@ class Config(DotMap):
 			data = Config.read_yaml(path)
 
 		# Backwards compatibility: migrate 'workspace' key to 'workspaces'
+		migrated = False
 		if 'workspace' in data and 'workspaces' not in data:
 			data['workspaces'] = data.pop('workspace')
 			if path:
 				console.print(f'[bold orange1]Migrating config key "workspace" to "workspaces" in {path}[/]')
-				try:
-					with path.open('w') as f:
-						f.write(yaml.dump({k: v for k, v in data.items() if not k.startswith('_')}, sort_keys=False))
-				except Exception as e:
-					console.print(f'[bold red]Failed to save migrated config: {e}[/]')
+			migrated = True
+
+		# Backwards compatibility: migrate 'workspaces.default' to 'workspaces.current'
+		if isinstance(data.get('workspaces'), dict) and 'default' in data['workspaces'] and 'current' not in data['workspaces']:
+			data['workspaces']['current'] = data['workspaces'].pop('default')
+			if path:
+				console.print(f'[bold orange1]Migrating config key "workspaces.default" to "workspaces.current" in {path}[/]')
+			migrated = True
+
+		if migrated and path:
+			try:
+				with path.open('w') as f:
+					f.write(yaml.dump({k: v for k, v in data.items() if not k.startswith('_')}, sort_keys=False))
+			except Exception as e:
+				console.print(f'[bold red]Failed to save migrated config: {e}[/]')
 
 		# Load data
 		config = Config.load(SecatorConfig, data, print_errors=print_errors)

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -96,7 +96,7 @@ class Runner:
 		self.config = self._process_config(config)
 		self.name = run_opts.get('name', config.name)
 		self.description = run_opts.get('description', config.description or '')
-		self.workspace_name = context.get('workspace_name', CONFIG.workspaces.default or 'default')
+		self.workspace_name = context.get('workspace_name', CONFIG.workspaces.current or 'default')
 		self.workspace_explicit = context.get('workspace_explicit', False)
 		self.run_opts = run_opts.copy()
 		self.sync = run_opts.get('sync', True)
@@ -217,7 +217,7 @@ class Runner:
 		self.profiles = self.resolve_profiles(profiles_str)
 
 		# Apply route-based workspace if no profile/explicit workspace was set
-		default_ws = CONFIG.workspaces.default or 'default'
+		default_ws = CONFIG.workspaces.current or 'default'
 		if not self.workspace_explicit and self.workspace_name == default_ws:
 			route_workspace = self._resolve_route_workspace(self.inputs)
 			if route_workspace:
@@ -1383,7 +1383,7 @@ class Runner:
 		profile_workspace = None
 		profile_drivers = []
 		profile_exporters = None
-		default_ws = CONFIG.workspaces.default or 'default'
+		default_ws = CONFIG.workspaces.current or 'default'
 		for profile in templates:
 			self.debug(f'profile {profile.name} opts (enforced: {profile.enforce}): {profile.opts}', sub='init')
 			enforced = profile.enforce or False

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -96,7 +96,7 @@ class Runner:
 		self.config = self._process_config(config)
 		self.name = run_opts.get('name', config.name)
 		self.description = run_opts.get('description', config.description or '')
-		self.workspace_name = context.get('workspace_name', CONFIG.workspace.default or 'default')
+		self.workspace_name = context.get('workspace_name', CONFIG.workspaces.default or 'default')
 		self.workspace_explicit = context.get('workspace_explicit', False)
 		self.run_opts = run_opts.copy()
 		self.sync = run_opts.get('sync', True)
@@ -217,7 +217,7 @@ class Runner:
 		self.profiles = self.resolve_profiles(profiles_str)
 
 		# Apply route-based workspace if no profile/explicit workspace was set
-		default_ws = CONFIG.workspace.default or 'default'
+		default_ws = CONFIG.workspaces.default or 'default'
 		if not self.workspace_explicit and self.workspace_name == default_ws:
 			route_workspace = self._resolve_route_workspace(self.inputs)
 			if route_workspace:
@@ -1344,7 +1344,7 @@ class Runner:
 				existing_profile_names.add(p)
 
 		# Add workspace-specific default profiles
-		workspace_defaults = CONFIG.workspace.profiles.get(self.workspace_name, [])
+		workspace_defaults = CONFIG.workspaces.profiles.get(self.workspace_name, [])
 		for p in workspace_defaults:
 			if p not in existing_profile_names:
 				profiles.append(p)
@@ -1383,7 +1383,7 @@ class Runner:
 		profile_workspace = None
 		profile_drivers = []
 		profile_exporters = None
-		default_ws = CONFIG.workspace.default or 'default'
+		default_ws = CONFIG.workspaces.default or 'default'
 		for profile in templates:
 			self.debug(f'profile {profile.name} opts (enforced: {profile.enforce}): {profile.opts}', sub='init')
 			enforced = profile.enforce or False
@@ -1471,7 +1471,7 @@ class Runner:
 		"""
 		import fnmatch
 
-		routes = CONFIG.workspace.routes
+		routes = CONFIG.workspaces.routes
 		if not routes:
 			return None
 		for workspace, patterns in routes.items():

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -489,7 +489,7 @@ class TestCli(unittest.TestCase):
 		with tempfile.TemporaryDirectory() as tmpdir:
 			with mock.patch('secator.cli.CONFIG') as mock_cfg:
 				mock_cfg.dirs.reports = tmpdir
-				mock_cfg.workspaces.default = 'default'
+				mock_cfg.workspaces.current = 'default'
 				report_dir = os.path.join(tmpdir, 'default', 'tasks', '1')
 				os.makedirs(report_dir)
 				with open(os.path.join(report_dir, 'report.json'), 'w') as f:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -489,7 +489,7 @@ class TestCli(unittest.TestCase):
 		with tempfile.TemporaryDirectory() as tmpdir:
 			with mock.patch('secator.cli.CONFIG') as mock_cfg:
 				mock_cfg.dirs.reports = tmpdir
-				mock_cfg.workspace.default = 'default'
+				mock_cfg.workspaces.default = 'default'
 				report_dir = os.path.join(tmpdir, 'default', 'tasks', '1')
 				os.makedirs(report_dir)
 				with open(os.path.join(report_dir, 'report.json'), 'w') as f:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -381,3 +381,51 @@ class TestAIConfig(unittest.TestCase):
 		from secator.config import Config
 		config = Config.parse()
 		self.assertEqual(config.addons.api.finding_search_endpoint, 'findings/_search')
+
+
+@mock.patch('sys.stderr', devnull)
+class TestConfigMigration(unittest.TestCase):
+
+	def test_migrate_workspace_key_to_workspaces(self):
+		"""Old top-level 'workspace' key is renamed to 'workspaces' on parse."""
+		from secator.config import Config
+		data = {'workspace': {'current': 'my-ws', 'routes': {}, 'profiles': {}}}
+		config = Config.parse(data)
+		self.assertIsNotNone(config)
+		self.assertEqual(config.workspaces.current, 'my-ws')
+
+	def test_migrate_workspaces_default_to_current(self):
+		"""Intermediate 'workspaces.default' key is renamed to 'workspaces.current' on parse."""
+		from secator.config import Config
+		data = {'workspaces': {'default': 'my-ws', 'routes': {}, 'profiles': {}}}
+		config = Config.parse(data)
+		self.assertIsNotNone(config)
+		self.assertEqual(config.workspaces.current, 'my-ws')
+
+	def test_migrate_workspace_default_to_workspaces_current(self):
+		"""Fully old-format 'workspace.default' migrates seamlessly to 'workspaces.current'."""
+		from secator.config import Config
+		data = {'workspace': {'default': 'my-ws', 'routes': {}, 'profiles': {}}}
+		config = Config.parse(data)
+		self.assertIsNotNone(config)
+		self.assertEqual(config.workspaces.current, 'my-ws')
+
+	def test_migrate_writes_updated_config_to_file(self):
+		"""Migration persists renamed keys to the YAML file on disk."""
+		import tempfile
+		from secator.config import Config
+		with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+			import yaml
+			yaml.dump({'workspaces': {'default': 'from-file', 'routes': {}, 'profiles': {}}}, f)
+			tmp_path = Path(f.name)
+		try:
+			config = Config.parse(path=tmp_path)
+			self.assertIsNotNone(config)
+			self.assertEqual(config.workspaces.current, 'from-file')
+			# File on disk should now use the new key
+			with tmp_path.open() as f:
+				saved = yaml.safe_load(f)
+			self.assertNotIn('default', saved.get('workspaces', {}))
+			self.assertEqual(saved['workspaces']['current'], 'from-file')
+		finally:
+			tmp_path.unlink(missing_ok=True)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -90,11 +90,11 @@ class TestConfig(unittest.TestCase):
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.profiles.my_ws', 'aggressive,passive')
-		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'passive'])
+			config.set('workspaces.profiles.my_ws', 'aggressive,passive')
+		self.assertEqual(config.workspaces.profiles['my_ws'], ['aggressive', 'passive'])
 		config.save()
 		yaml_data = Config.read_yaml(self.config_test)
-		self.assertEqual(yaml_data['workspace']['profiles']['my_ws'], ['aggressive', 'passive'])
+		self.assertEqual(yaml_data['workspaces']['profiles']['my_ws'], ['aggressive', 'passive'])
 
 	def test_set_workspace_profiles_single(self):
 		"""Test that a single profile string is coerced to a list."""
@@ -102,8 +102,8 @@ class TestConfig(unittest.TestCase):
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.profiles.my_ws', 'aggressive')
-		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive'])
+			config.set('workspaces.profiles.my_ws', 'aggressive')
+		self.assertEqual(config.workspaces.profiles['my_ws'], ['aggressive'])
 
 	def test_set_workspace_profiles_append(self):
 		"""Test appending a profile to workspace profiles list."""
@@ -111,13 +111,13 @@ class TestConfig(unittest.TestCase):
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.profiles.my_ws', 'aggressive,passive')
-			config.set('workspace.profiles.my_ws', 'stealth', strategy='append')
-		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
+			config.set('workspaces.profiles.my_ws', 'aggressive,passive')
+			config.set('workspaces.profiles.my_ws', 'stealth', strategy='append')
+		self.assertEqual(config.workspaces.profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
 		# Duplicate should not be added
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.profiles.my_ws', 'passive', strategy='append')
-		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
+			config.set('workspaces.profiles.my_ws', 'passive', strategy='append')
+		self.assertEqual(config.workspaces.profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
 
 	def test_unset_workspace_profiles_item(self):
 		"""Test removing a single profile from workspace profiles list."""
@@ -125,13 +125,13 @@ class TestConfig(unittest.TestCase):
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.profiles.my_ws', 'aggressive,passive,stealth')
-		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
-		config.unset('workspace.profiles.my_ws', value='passive')
-		self.assertEqual(config.workspace.profiles['my_ws'], ['aggressive', 'stealth'])
+			config.set('workspaces.profiles.my_ws', 'aggressive,passive,stealth')
+		self.assertEqual(config.workspaces.profiles['my_ws'], ['aggressive', 'passive', 'stealth'])
+		config.unset('workspaces.profiles.my_ws', value='passive')
+		self.assertEqual(config.workspaces.profiles['my_ws'], ['aggressive', 'stealth'])
 		config.save()
 		yaml_data = Config.read_yaml(self.config_test)
-		self.assertEqual(yaml_data['workspace']['profiles']['my_ws'], ['aggressive', 'stealth'])
+		self.assertEqual(yaml_data['workspaces']['profiles']['my_ws'], ['aggressive', 'stealth'])
 
 	def test_unset_workspace_profiles_key(self):
 		"""Test removing an entire workspace entry from profiles."""
@@ -139,10 +139,10 @@ class TestConfig(unittest.TestCase):
 		from unittest.mock import patch
 		config = Config.parse(path=self.config_test)
 		with patch('secator.config.Config._validate_profile_names', return_value=True):
-			config.set('workspace.profiles.my_ws', 'aggressive,passive')
-		self.assertIn('my_ws', config.workspace.profiles)
-		config.unset('workspace.profiles.my_ws')
-		self.assertNotIn('my_ws', config.workspace.profiles)
+			config.set('workspaces.profiles.my_ws', 'aggressive,passive')
+		self.assertIn('my_ws', config.workspaces.profiles)
+		config.unset('workspaces.profiles.my_ws')
+		self.assertNotIn('my_ws', config.workspaces.profiles)
 
 	def test_set_list_field_replace(self):
 		from secator.config import Config
@@ -229,61 +229,61 @@ class TestConfig(unittest.TestCase):
 		"""Appending a route to a new workspace creates the list entry."""
 		from secator.config import Config
 		config = Config.parse(path=self.config_test)
-		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
-		self.assertIn('my_ws', config.workspace.routes)
-		self.assertEqual(config.workspace.routes['my_ws'], ['*vulnweb.com*'])
+		config.set('workspaces.routes.my_ws', '*vulnweb.com*', strategy='append')
+		self.assertIn('my_ws', config.workspaces.routes)
+		self.assertEqual(config.workspaces.routes['my_ws'], ['*vulnweb.com*'])
 
 	def test_workspace_routes_append_multiple_patterns(self):
 		"""Appending multiple patterns to same workspace accumulates them."""
 		from secator.config import Config
 		config = Config.parse(path=self.config_test)
-		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
-		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
-		self.assertEqual(config.workspace.routes['my_ws'], ['*vulnweb.com*', '*ocervell*'])
+		config.set('workspaces.routes.my_ws', '*vulnweb.com*', strategy='append')
+		config.set('workspaces.routes.my_ws', '*ocervell*', strategy='append')
+		self.assertEqual(config.workspaces.routes['my_ws'], ['*vulnweb.com*', '*ocervell*'])
 
 	def test_workspace_routes_append_no_duplicates(self):
 		"""Appending a duplicate pattern is a no-op."""
 		from secator.config import Config
 		config = Config.parse(path=self.config_test)
-		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
-		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
-		self.assertEqual(config.workspace.routes['my_ws'], ['*vulnweb.com*'])
+		config.set('workspaces.routes.my_ws', '*vulnweb.com*', strategy='append')
+		config.set('workspaces.routes.my_ws', '*vulnweb.com*', strategy='append')
+		self.assertEqual(config.workspaces.routes['my_ws'], ['*vulnweb.com*'])
 
 	def test_workspace_routes_save_and_reload(self):
 		"""Workspace routes survive a save/reload cycle."""
 		from secator.config import Config
 		config = Config.parse(path=self.config_test)
-		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
-		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
+		config.set('workspaces.routes.my_ws', '*vulnweb.com*', strategy='append')
+		config.set('workspaces.routes.my_ws', '*ocervell*', strategy='append')
 		config.save()
 		config2 = Config.parse(path=self.config_test)
-		self.assertEqual(config2.workspace.routes['my_ws'], ['*vulnweb.com*', '*ocervell*'])
+		self.assertEqual(config2.workspaces.routes['my_ws'], ['*vulnweb.com*', '*ocervell*'])
 
 	def test_workspace_routes_remove_existing_pattern(self):
 		"""Removing an existing pattern leaves the remaining patterns intact."""
 		from secator.config import Config
 		config = Config.parse(path=self.config_test)
-		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='append')
-		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
-		config.set('workspace.routes.my_ws', '*vulnweb.com*', strategy='remove')
-		self.assertEqual(config.workspace.routes['my_ws'], ['*ocervell*'])
+		config.set('workspaces.routes.my_ws', '*vulnweb.com*', strategy='append')
+		config.set('workspaces.routes.my_ws', '*ocervell*', strategy='append')
+		config.set('workspaces.routes.my_ws', '*vulnweb.com*', strategy='remove')
+		self.assertEqual(config.workspaces.routes['my_ws'], ['*ocervell*'])
 
 	def test_workspace_routes_remove_missing_pattern(self):
 		"""Removing a non-existent pattern is a no-op (warns but does not raise)."""
 		from secator.config import Config
 		config = Config.parse(path=self.config_test)
-		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
-		config.set('workspace.routes.my_ws', '*doesnotexist*', strategy='remove')
-		self.assertEqual(config.workspace.routes['my_ws'], ['*ocervell*'])
+		config.set('workspaces.routes.my_ws', '*ocervell*', strategy='append')
+		config.set('workspaces.routes.my_ws', '*doesnotexist*', strategy='remove')
+		self.assertEqual(config.workspaces.routes['my_ws'], ['*ocervell*'])
 
 	def test_workspace_routes_remove_workspace_key(self):
 		"""Unsetting a workspace key (no value) deletes it from routes entirely."""
 		from secator.config import Config
 		config = Config.parse(path=self.config_test)
-		config.set('workspace.routes.my_ws', '*ocervell*', strategy='append')
-		self.assertIn('my_ws', config.workspace.routes)
-		config.unset('workspace.routes.my_ws')
-		self.assertNotIn('my_ws', config.workspace.routes)
+		config.set('workspaces.routes.my_ws', '*ocervell*', strategy='append')
+		self.assertIn('my_ws', config.workspaces.routes)
+		config.unset('workspaces.routes.my_ws')
+		self.assertNotIn('my_ws', config.workspaces.routes)
 
 
 @mock.patch('sys.stderr', devnull)

--- a/tests/unit/test_report_delete_e2e.py
+++ b/tests/unit/test_report_delete_e2e.py
@@ -39,7 +39,7 @@ class TestReportDeleteCli(unittest.TestCase):
 
 		with mock.patch('secator.cli.CONFIG') as mock_cfg:
 			mock_cfg.dirs.reports = self.temp_dir
-			mock_cfg.workspace.default = WORKSPACE
+			mock_cfg.workspaces.default = WORKSPACE
 			mock_cfg.addons.api.runner_delete_endpoint = '/api/{runner_type}/{runner_id}'
 			return self.cli_runner.invoke(cli, ['r', 'rm', '-w', WORKSPACE, '-y'] + args)
 
@@ -104,7 +104,7 @@ class TestReportDeleteCli(unittest.TestCase):
 		self._make_runner('tasks', 23)
 		with mock.patch('secator.cli.CONFIG') as mock_cfg:
 			mock_cfg.dirs.reports = self.temp_dir
-			mock_cfg.workspace.default = WORKSPACE
+			mock_cfg.workspaces.default = WORKSPACE
 			mock_cfg.addons.api.runner_delete_endpoint = '/api/{runner_type}/{runner_id}'
 			# Answer 'n' to the confirmation prompt
 			result = self.cli_runner.invoke(cli, ['r', 'rm', '-w', WORKSPACE, 'tasks/23'], input='n\n')

--- a/tests/unit/test_report_delete_e2e.py
+++ b/tests/unit/test_report_delete_e2e.py
@@ -39,7 +39,7 @@ class TestReportDeleteCli(unittest.TestCase):
 
 		with mock.patch('secator.cli.CONFIG') as mock_cfg:
 			mock_cfg.dirs.reports = self.temp_dir
-			mock_cfg.workspaces.default = WORKSPACE
+			mock_cfg.workspaces.current = WORKSPACE
 			mock_cfg.addons.api.runner_delete_endpoint = '/api/{runner_type}/{runner_id}'
 			return self.cli_runner.invoke(cli, ['r', 'rm', '-w', WORKSPACE, '-y'] + args)
 
@@ -104,7 +104,7 @@ class TestReportDeleteCli(unittest.TestCase):
 		self._make_runner('tasks', 23)
 		with mock.patch('secator.cli.CONFIG') as mock_cfg:
 			mock_cfg.dirs.reports = self.temp_dir
-			mock_cfg.workspaces.default = WORKSPACE
+			mock_cfg.workspaces.current = WORKSPACE
 			mock_cfg.addons.api.runner_delete_endpoint = '/api/{runner_type}/{runner_id}'
 			# Answer 'n' to the confirmation prompt
 			result = self.cli_runner.invoke(cli, ['r', 'rm', '-w', WORKSPACE, 'tasks/23'], input='n\n')

--- a/tests/unit/test_report_show_e2e.py
+++ b/tests/unit/test_report_show_e2e.py
@@ -386,7 +386,7 @@ class TestReportListCurrentWorkspace(unittest.TestCase):
 				mock.patch('secator.cli._load_report_data', return_value=(report_info, vuln_counts)), \
 				mock.patch('secator.cli.CONFIG') as cfg, \
 				console.capture() as cap:
-			cfg.workspace.default = default_ws
+			cfg.workspaces.default = default_ws
 			report_list.callback(
 				workspace=workspace_opt, runner_type=None, time_delta=None, show_all=False, interesting=False,
 				status=None,

--- a/tests/unit/test_report_show_e2e.py
+++ b/tests/unit/test_report_show_e2e.py
@@ -386,7 +386,7 @@ class TestReportListCurrentWorkspace(unittest.TestCase):
 				mock.patch('secator.cli._load_report_data', return_value=(report_info, vuln_counts)), \
 				mock.patch('secator.cli.CONFIG') as cfg, \
 				console.capture() as cap:
-			cfg.workspaces.default = default_ws
+			cfg.workspaces.current = default_ws
 			report_list.callback(
 				workspace=workspace_opt, runner_type=None, time_delta=None, show_all=False, interesting=False,
 				status=None,

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -761,7 +761,7 @@ class TestWorkspaceRouting(unittest.TestCase):
 		routes = {'routed-ws': ['*host1*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
 			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.current', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['host1'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'routed-ws')
@@ -774,7 +774,7 @@ class TestWorkspaceRouting(unittest.TestCase):
 		routes = {'routed-ws': ['*vulnweb.com*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
 			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.current', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['secator.cloud'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'default')
@@ -787,7 +787,7 @@ class TestWorkspaceRouting(unittest.TestCase):
 		# Without workspace_explicit=True, routes would match and override — but with it, they should not.
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
 			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspaces.default', new='my-default'), \
+			patch('secator.runners._base.CONFIG.workspaces.current', new='my-default'), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			opts = {'context': {'workspace_name': 'my-default', 'workspace_explicit': True}}
 			with self.mock_command(self.Cmd, ['host1'], opts, []) as cmd:
@@ -799,7 +799,7 @@ class TestWorkspaceRouting(unittest.TestCase):
 		routes = {'routed-ws': ['*host1*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
 			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspaces.default', new='my-default'), \
+			patch('secator.runners._base.CONFIG.workspaces.current', new='my-default'), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['host1'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'routed-ws')
@@ -817,7 +817,7 @@ class TestWorkspaceRouting(unittest.TestCase):
 		})
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
 			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.current', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			opts = {'profiles': [profile]}
 			with self.mock_command(self.Cmd, ['host1'], opts, []) as cmd:
@@ -835,7 +835,7 @@ class TestWorkspaceRouting(unittest.TestCase):
 		})
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
 			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.current', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			opts = {'profiles': [profile]}
 			with self.mock_command(self.Cmd, ['host1'], opts, []) as cmd:
@@ -847,7 +847,7 @@ class TestWorkspaceRouting(unittest.TestCase):
 		routes = {'vulnweb-ws': ['*vulnweb.com*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
 			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.current', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['testphp.vulnweb.com'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'vulnweb-ws')
@@ -858,7 +858,7 @@ class TestWorkspaceRouting(unittest.TestCase):
 		routes = {'ws-a': ['*host1*'], 'ws-b': ['*host*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
 			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.current', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['host1'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'ws-a')

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -565,7 +565,7 @@ class TestCommandRunner(unittest.TestCase):
 
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
 			with patch('secator.runners._base.CONFIG.profiles.defaults', []):
-				with patch('secator.runners._base.CONFIG.workspace.profiles', {'my_ws': ['ws_specific']}):
+				with patch('secator.runners._base.CONFIG.workspaces.profiles', {'my_ws': ['ws_specific']}):
 					with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
 						mock_get_configs.return_value = [ws_profile]
 						with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'my_ws'}}, []) as cmd:
@@ -597,7 +597,7 @@ class TestCommandRunner(unittest.TestCase):
 
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
 			with patch('secator.runners._base.CONFIG.profiles.defaults', []):
-				with patch('secator.runners._base.CONFIG.workspace.profiles', {'my_ws': ['ws_specific']}):
+				with patch('secator.runners._base.CONFIG.workspaces.profiles', {'my_ws': ['ws_specific']}):
 					with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
 						mock_get_configs.return_value = [ws_profile]
 						with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'other_ws'}}, []) as cmd:
@@ -627,7 +627,7 @@ class TestCommandRunner(unittest.TestCase):
 
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=LocalMyCommand):
 			with patch('secator.runners._base.CONFIG.profiles.defaults', ['shared_profile']):
-				with patch('secator.runners._base.CONFIG.workspace.profiles', {'my_ws': ['shared_profile']}):
+				with patch('secator.runners._base.CONFIG.workspaces.profiles', {'my_ws': ['shared_profile']}):
 					with patch('secator.runners._base.get_configs_by_type') as mock_get_configs:
 						mock_get_configs.return_value = [shared_profile]
 						with mock_command(LocalMyCommand, TARGETS, {'context': {'workspace_name': 'my_ws'}}, []) as cmd:
@@ -760,8 +760,8 @@ class TestWorkspaceRouting(unittest.TestCase):
 		import unittest.mock
 		routes = {'routed-ws': ['*host1*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
-			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['host1'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'routed-ws')
@@ -773,8 +773,8 @@ class TestWorkspaceRouting(unittest.TestCase):
 		import unittest.mock
 		routes = {'routed-ws': ['*vulnweb.com*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
-			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['secator.cloud'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'default')
@@ -786,8 +786,8 @@ class TestWorkspaceRouting(unittest.TestCase):
 		# Set default to 'my-default'; user explicitly passes the same value.
 		# Without workspace_explicit=True, routes would match and override — but with it, they should not.
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
-			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspace.default', new='my-default'), \
+			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspaces.default', new='my-default'), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			opts = {'context': {'workspace_name': 'my-default', 'workspace_explicit': True}}
 			with self.mock_command(self.Cmd, ['host1'], opts, []) as cmd:
@@ -798,8 +798,8 @@ class TestWorkspaceRouting(unittest.TestCase):
 		import unittest.mock
 		routes = {'routed-ws': ['*host1*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
-			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspace.default', new='my-default'), \
+			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspaces.default', new='my-default'), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['host1'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'routed-ws')
@@ -816,8 +816,8 @@ class TestWorkspaceRouting(unittest.TestCase):
 			'workspace': 'enforced-ws',
 		})
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
-			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			opts = {'profiles': [profile]}
 			with self.mock_command(self.Cmd, ['host1'], opts, []) as cmd:
@@ -834,8 +834,8 @@ class TestWorkspaceRouting(unittest.TestCase):
 			'workspace': 'profile-ws',
 		})
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
-			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			opts = {'profiles': [profile]}
 			with self.mock_command(self.Cmd, ['host1'], opts, []) as cmd:
@@ -846,8 +846,8 @@ class TestWorkspaceRouting(unittest.TestCase):
 		import unittest.mock
 		routes = {'vulnweb-ws': ['*vulnweb.com*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
-			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['testphp.vulnweb.com'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'vulnweb-ws')
@@ -857,8 +857,8 @@ class TestWorkspaceRouting(unittest.TestCase):
 		import unittest.mock
 		routes = {'ws-a': ['*host1*'], 'ws-b': ['*host*']}
 		with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=self.Cmd), \
-			patch('secator.runners._base.CONFIG.workspace.routes', new=routes), \
-			patch('secator.runners._base.CONFIG.workspace.default', new=''), \
+			patch('secator.runners._base.CONFIG.workspaces.routes', new=routes), \
+			patch('secator.runners._base.CONFIG.workspaces.default', new=''), \
 			patch('secator.runners._base.CONFIG.profiles.defaults', []):
 			with self.mock_command(self.Cmd, ['host1'], {}, []) as cmd:
 				self.assertEqual(cmd.workspace_name, 'ws-a')


### PR DESCRIPTION
Renames the `workspace` config key to `workspaces` throughout the codebase, and adds auto-migration for existing configs.

Changes:
- `SecatorConfig.workspace` → `workspaces`
- All `CONFIG.workspace.*` usages updated in cli.py, cli_helper.py, runners/_base.py
- Backwards-compatible migration: auto-renames `workspace` → `workspaces` in existing config files on first load
- All unit tests updated

Fixes #1160

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Workspace configuration namespace has been reorganized for improved consistency. Configuration settings previously accessed via `workspace.*` are now under `workspaces.*`. Existing configurations are automatically migrated, ensuring backward compatibility without manual intervention required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->