### PR TITLE
feat(sqlite): add SQLite query driver + backend (mongodb parity)

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1822,6 +1822,7 @@ secator s host [blue]-yaml[/]                        [dim]# show config yaml (wo
 [dim]# Organize your results (workspace, database)[/]
 secator s host [blue]-ws[/] [bright_magenta]prod[/] example.com         [dim]# save results to 'prod' workspace[/]
 secator s host [blue]-driver[/] [bright_magenta]mongodb[/] example.com  [dim]# save results to mongodb database[/]
+secator s host [blue]-driver[/] [bright_magenta]sqlite[/] example.com  [dim]# save results to a local sqlite database[/]
 
 [dim]# Input types are flexible ...[/]
 secator s host [cyan]example.com[/]                  [dim]# single input[/]

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -823,7 +823,7 @@ def workspace_current():
 
 @workspace.command(name='rm', aliases=['remove', 'delete'])
 @click.argument('name')
-@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api', 'sqlite']), default='local', help='Query backend driver')  # noqa: E501
 @click.option('-y', '--yes', is_flag=True, default=False, help='Skip confirmation prompt')
 def workspace_delete(name, driver, yes):
 	"""Delete a workspace and all associated reports. NAME: workspace name."""
@@ -840,6 +840,9 @@ def workspace_delete(name, driver, yes):
 		actions.append(f'Delete all runners in MongoDB with workspace_id="{name}"')
 	elif driver == 'api':
 		actions.append(f'Send DELETE to API: {CONFIG.addons.api.workspace_delete_endpoint.format(workspace_id=name)}')
+	elif driver == 'sqlite':
+		actions.append(f'Delete all findings in SQLite with workspace_id="{name}"')
+		actions.append(f'Delete all runners in SQLite with workspace_id="{name}"')
 
 	console.print('[bold]The following actions will be performed:[/]')
 	for action in actions:
@@ -881,6 +884,22 @@ def workspace_delete(name, driver, yes):
 			console.print(Info(message=f'Deleted workspace "{name}" from API'))
 		except Exception as e:
 			console.print(Error(message=f'API deletion failed: {e}'))
+
+	# 4. SQLite backend
+	elif driver == 'sqlite':
+		try:
+			from secator.hooks.sqlite import get_sqlite_conn
+
+			conn = get_sqlite_conn()
+			findings_result = conn.execute("DELETE FROM findings WHERE workspace_id=?", (name,))
+			console.print(Info(message=f'Deleted {findings_result.rowcount} findings from SQLite'))
+			for collection in ['tasks', 'workflows', 'scans']:
+				result = conn.execute(f"DELETE FROM {collection} WHERE workspace_id=?", (name,))
+				if result.rowcount:
+					console.print(Info(message=f'Deleted {result.rowcount} {collection} from SQLite'))
+			conn.commit()
+		except Exception as e:
+			console.print(Error(message=f'SQLite deletion failed: {e}'))
 
 
 # ----------#
@@ -1174,7 +1193,7 @@ def _apply_format(results, fmt):
 @click.option('-q', '--query', type=str, default=None, help='Filter results (Python-like or MongoDB JSON)')
 @click.option('--format', '-f', 'fmt', type=str, default=None, help="Format string for results, e.g. '{tag.match}-{tag.name}' or '{port.host}:{port.port} || vulnerability.matched_at'")  # noqa: E501
 @click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
-@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api', 'sqlite']), default='local', help='Query backend driver')  # noqa: E501
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.pass_context
 def report_show(ctx, report_query, output, time_delta, query, fmt, workspace, driver, dedupe):
@@ -1443,7 +1462,7 @@ def report_info(runner_id, workspace, show_all):
 @report.command(name='delete', aliases=['rm', 'remove'])
 @click.argument('runner_id')
 @click.option('-ws', '-w', '--workspace', type=str, default=None, help='Workspace name')
-@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api', 'sqlite']), default='local', help='Query backend driver')  # noqa: E501
 @click.option('-y', '--yes', is_flag=True, default=False, help='Skip confirmation prompt')
 def report_delete(runner_id, workspace, driver, yes):
 	"""Delete a report. RUNNER_ID: runner path (e.g. tasks/24)."""
@@ -1500,6 +1519,12 @@ def report_delete(runner_id, workspace, driver, yes):
 			actions.append(f'Send DELETE to API: {endpoint_preview}')
 		else:
 			actions.append('[yellow]No API ID found in report — skipping API deletion[/]')
+	elif driver == 'sqlite':
+		if runner_db_id:
+			actions.append(f'Delete findings in SQLite for {runner_type_singular}_id="{runner_db_id}"')
+			actions.append(f'Delete {runner_type_singular} row in SQLite (id="{runner_db_id}")')
+		else:
+			actions.append('[yellow]No SQLite ID found in report — skipping SQLite deletion[/]')
 
 	console.print('[bold]The following actions will be performed:[/]')
 	for action in actions:
@@ -1544,6 +1569,24 @@ def report_delete(runner_id, workspace, driver, yes):
 			console.print(Info(message=f'Deleted {runner_type_singular} from API'))
 		except Exception as e:
 			console.print(Error(message=f'API deletion failed: {e}'))
+
+	# 4. SQLite backend
+	elif driver == 'sqlite' and runner_db_id:
+		try:
+			from secator.hooks.sqlite import get_sqlite_conn
+
+			conn = get_sqlite_conn()
+			findings_result = conn.execute(
+				f"DELETE FROM findings WHERE json_extract(data,'$._context.{runner_type_singular}_id')=?",
+				(runner_db_id,),
+			)
+			console.print(Info(message=f'Deleted {findings_result.rowcount} findings from SQLite'))
+			runner_result = conn.execute(f"DELETE FROM {runner_type_plural} WHERE id=?", (runner_db_id,))
+			if runner_result.rowcount:
+				console.print(Info(message=f'Deleted {runner_type_singular} row from SQLite'))
+			conn.commit()
+		except Exception as e:
+			console.print(Error(message=f'SQLite deletion failed: {e}'))
 
 
 # --------#

--- a/secator/config.py
+++ b/secator/config.py
@@ -201,6 +201,21 @@ class MongodbAddon(StrictModel):
 	]
 
 
+class SqliteAddon(StrictModel):
+	enabled: bool = False
+	path: str = ''
+	busy_timeout_ms: int = 5000
+	max_items: int = -1
+	duplicate_main_copy_fields: List[str] = [
+		'screenshot_path',
+		'stored_response_path',
+		'is_false_positive',
+		'is_acknowledged',
+		'verified',
+		'tags',
+	]
+
+
 class VulnersAddon(StrictModel):
 	enabled: bool = False
 	api_key: str = ''
@@ -288,6 +303,7 @@ class Addons(StrictModel):
 	gcs: GoogleCloudStorageAddon = GoogleCloudStorageAddon()
 	worker: WorkerAddon = WorkerAddon()
 	mongodb: MongodbAddon = MongodbAddon()
+	sqlite: SqliteAddon = SqliteAddon()
 	vulners: VulnersAddon = VulnersAddon()
 	discord: DiscordAddon = DiscordAddon()
 	api: ApiAddon = ApiAddon()

--- a/secator/definitions.py
+++ b/secator/definitions.py
@@ -55,7 +55,7 @@ LLM_SPINNER_MESSAGES = [
 ]
 
 # Available drivers and exporters
-AVAILABLE_DRIVERS = ['mongodb', 'gcs', 'api', 'discord']
+AVAILABLE_DRIVERS = ['mongodb', 'gcs', 'api', 'discord', 'sqlite']
 AVAILABLE_EXPORTERS = ['csv', 'gdrive', 'json', 'markdown', 'table', 'txt']
 
 # Vocab
@@ -190,7 +190,8 @@ for addon, module in [
 	('dev', 'flake8'),
 	('trace', 'memray'),
 	('build', 'hatch'),
-	('ai', 'litellm')
+	('ai', 'litellm'),
+	('sqlite', 'sqlite3'),
 ]:
 	ADDONS_ENABLED[addon] = is_importable(module)
 

--- a/secator/hooks/_dedup.py
+++ b/secator/hooks/_dedup.py
@@ -1,0 +1,5 @@
+# secator/hooks/_dedup.py
+
+
+def compute_duplicate_updates(workspace_findings, untagged_findings, copy_fields=None):
+	return {}

--- a/secator/hooks/_dedup.py
+++ b/secator/hooks/_dedup.py
@@ -2,4 +2,60 @@
 
 
 def compute_duplicate_updates(workspace_findings, untagged_findings, copy_fields=None):
-	return {}
+	"""Compute duplicate-tagging updates for a set of findings (backend-agnostic).
+
+	Args:
+		workspace_findings (list): Already-tagged, non-duplicate findings in the workspace
+			(loaded OutputType objects).
+		untagged_findings (list): Newly-seen / untagged findings to evaluate.
+		copy_fields (list): Field names to copy from a previous "main" finding onto the
+			new main finding when the new value is empty.
+
+	Returns:
+		dict: uuid -> update dict (fields to set), where each update may contain
+		'_related', '_context.workspace_duplicate', '_tagged' and copied fields.
+	"""
+	copy_fields = copy_fields or []
+	seen = []
+	db_updates = {}
+
+	for item in untagged_findings:
+		if item._uuid in seen:
+			continue
+
+		duplicate_ids = [_._uuid for _ in untagged_findings if _ == item and _._uuid != item._uuid]
+		seen.extend(duplicate_ids)
+
+		duplicate_ws = [_ for _ in workspace_findings if _ == item and _._uuid != item._uuid]
+
+		# Copy selected fields from the previous "main" finding when current value is empty.
+		copied_fields = {}
+		for previous_item in duplicate_ws:
+			for field in copy_fields:
+				if not hasattr(previous_item, field):
+					continue
+				value_prev = getattr(previous_item, field)
+				if not value_prev:
+					continue
+				value_curr = getattr(item, field, None)
+				if not value_curr and field not in copied_fields:
+					copied_fields[field] = value_prev
+
+		related_ids = []
+		if duplicate_ws:
+			duplicate_ids.extend([_._uuid for _ in duplicate_ws])
+			for related in duplicate_ws:
+				related_ids.extend(related._related)
+
+		db_updates[item._uuid] = {
+			**copied_fields,
+			'_related': duplicate_ids + related_ids,
+			'_context.workspace_duplicate': False,
+			'_tagged': True,
+		}
+		for uuid_ in duplicate_ids:
+			db_updates[uuid_] = {
+				'_context.workspace_duplicate': True,
+				'_tagged': True,
+			}
+	return db_updates

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -6,6 +6,7 @@ from bson.objectid import ObjectId
 from celery import shared_task
 
 from secator.config import CONFIG
+from secator.hooks._dedup import compute_duplicate_updates
 from secator.output_types import OUTPUT_TYPES
 from secator.runners import Scan, Task, Workflow
 from secator.utils import debug, escape_mongodb_url
@@ -192,87 +193,11 @@ def tag_duplicates(ws_id: str = None, full_scan: bool = False, exclude_types=[],
 		log_hook=log_hook
 	)
 	start_time = time.time()
-	seen = []
-	db_updates = {}
-
-	for item in untagged_findings:
-		if item._uuid in seen:
-			continue
-
-		debug(
-			f'Processing: {repr(item)} ({item._timestamp}) [{item._uuid}]',
-			sub='hooks.mongodb',
-			verbose=True,
-			log_hook=log_hook
-		)
-
-		duplicate_ids = [
-			_._uuid
-			for _ in untagged_findings
-			if _ == item and _._uuid != item._uuid
-		]
-		seen.extend(duplicate_ids)
-
-		debug(
-			f'Found {len(duplicate_ids)} duplicates for item',
-			sub='hooks.mongodb',
-			verbose=True,
-			log_hook=log_hook
-		)
-
-		duplicate_ws = [
-			_ for _ in workspace_findings
-			if _ == item and _._uuid != item._uuid
-		]
-		debug(f' --> Found {len(duplicate_ws)} workspace duplicates for item', sub='hooks.mongodb', verbose=True, log_hook=log_hook)  # noqa: E501
-
-		# Copy selected fields from the previous "main" finding (first workspace duplicate)
-		# into the new main finding, if configured.
-		copied_fields = {}
-		for previous_item in duplicate_ws:
-			copy_fields = CONFIG.addons.mongodb.duplicate_main_copy_fields
-			if copy_fields:
-				for field in copy_fields:
-					# Only copy if the attribute exists on the previous finding
-					if not hasattr(previous_item, field):
-						debug(f'{field} not found on {previous_item._uuid}', sub='hooks.mongodb', verbose=True, log_hook=log_hook)
-						continue
-					value_prev = getattr(previous_item, field)
-					debug(f'{field} is {value_prev} on {previous_item._uuid}', sub='hooks.mongodb', verbose=True, log_hook=log_hook)
-					# Skip empty values to avoid overwriting with "less useful" data
-					if not value_prev:
-						debug(f'{field} is empty on {previous_item._uuid}', sub='hooks.mongodb', verbose=True, log_hook=log_hook)
-						continue
-					# Only overwrite if current item field isn't set
-					value_curr = getattr(item, field)
-					debug(f'{field} is {value_curr} on {item._uuid}', sub='hooks.mongodb', verbose=True, log_hook=log_hook)
-					if not value_curr:
-						if field in copied_fields:
-							debug(f'{field} is already copied from previous item', sub='hooks.mongodb', verbose=True, log_hook=log_hook)
-							continue
-						debug(f'Using {field}={value_prev} from {previous_item._uuid} for {item._uuid}', sub='hooks.mongodb', verbose=True, log_hook=log_hook)  # noqa: E501
-						copied_fields[field] = value_prev
-
-		related_ids = []
-		if duplicate_ws:
-			duplicate_ws_ids = [_._uuid for _ in duplicate_ws]
-			duplicate_ids.extend(duplicate_ws_ids)
-			for related in duplicate_ws:
-				related_ids.extend(related._related)
-
-		debug(f' --> Found {len(duplicate_ids)} total duplicates for item', sub='hooks.mongodb', verbose=True, log_hook=log_hook)  # noqa: E501
-
-		db_updates[item._uuid] = {
-			**copied_fields,
-			'_related': duplicate_ids + related_ids,
-			'_context.workspace_duplicate': False,
-			'_tagged': True
-		}
-		for uuid in duplicate_ids:
-			db_updates[uuid] = {
-				'_context.workspace_duplicate': True,
-				'_tagged': True
-			}
+	db_updates = compute_duplicate_updates(
+		workspace_findings,
+		untagged_findings,
+		CONFIG.addons.mongodb.duplicate_main_copy_fields,
+	)
 	debug(f'Finished processing untagged findings in {time.time() - start_time}s', sub='hooks.mongodb', log_hook=log_hook)
 	start_time = time.time()
 

--- a/secator/hooks/sqlite.py
+++ b/secator/hooks/sqlite.py
@@ -1,16 +1,19 @@
 # secator/hooks/sqlite.py
 
+import json
 import re
 import sqlite3
 import threading
+import uuid
 from pathlib import Path
 
-from celery import shared_task  # noqa: F401
+from celery import shared_task
 
 from secator.config import CONFIG
-from secator.output_types import OUTPUT_TYPES  # noqa: F401
+from secator.output_types import OUTPUT_TYPES
+from secator.runners import Scan, Task, Workflow
 from secator.utils import debug
-from secator.hooks._dedup import compute_duplicate_updates  # noqa: F401
+from secator.hooks._dedup import compute_duplicate_updates
 
 _conns = {}
 _conn_lock = threading.Lock()
@@ -77,3 +80,166 @@ def get_sqlite_conn(db_path=None):
 					conn.close()
 					raise
 	return conn
+
+
+def _apply_finding_update(conn, uuid_, update):
+	"""Apply a single dedup update dict to a findings row via json_set.
+
+	The JSON document patches are chained into a single nested ``json_set(...)``
+	expression because SQLite evaluates every assignment in an ``UPDATE`` against
+	the original row value, so repeated ``data = json_set(data, ...)`` clauses
+	would clobber one another.
+	"""
+	data_expr = "data"
+	data_params = []
+	extra_exprs = []
+	extra_params = []
+	for key, val in update.items():
+		data_expr = f"json_set({data_expr}, '$.{key}', json(?))"
+		data_params.append(json.dumps(val, default=str))
+		if key == '_tagged':
+			extra_exprs.append("_tagged = ?")
+			extra_params.append(int(bool(val)))
+		elif key == 'is_false_positive':
+			extra_exprs.append("is_false_positive = ?")
+			extra_params.append(int(bool(val)))
+	set_exprs = [f"data = {data_expr}"] + extra_exprs
+	params = data_params + extra_params + [uuid_]
+	conn.execute(f"UPDATE findings SET {', '.join(set_exprs)} WHERE uuid=?", params)
+
+
+def load_finding(obj, exclude_types=[]):
+	finding_type = obj.get('_type')
+	if finding_type in exclude_types:
+		return None
+	for otype in OUTPUT_TYPES:
+		if finding_type == otype.get_name():
+			item = otype.load(obj)
+			item._uuid = obj.get('_uuid', '')
+			return item
+	return None
+
+
+def load_findings(objs, exclude_types=[]):
+	findings = [load_finding(obj, exclude_types) for obj in objs]
+	return [f for f in findings if f is not None]
+
+
+def update_runner(self):
+	conn = get_sqlite_conn()
+	_type = self.config.type
+	table = f'{_type}s'
+	update = self.toDict()
+	chunk = update.get('chunk')
+	key = f'{_type}_chunk_id' if chunk else f'{_type}_id'
+	_id = self.context.get(key)
+	workspace_id = self.context.get('workspace_id')
+	payload = json.dumps(update, default=str)
+	if _id:
+		conn.execute(f"UPDATE {table} SET workspace_id=?, data=? WHERE id=?", (workspace_id, payload, _id))
+	else:
+		_id = str(uuid.uuid4())
+		conn.execute(f"INSERT INTO {table} (id, workspace_id, data) VALUES (?, ?, ?)", (_id, workspace_id, payload))
+		self.context[key] = _id
+	conn.commit()
+
+
+def update_finding(self, item):
+	if type(item) not in OUTPUT_TYPES:
+		return item
+	conn = get_sqlite_conn()
+	if not item._uuid:
+		item._uuid = str(uuid.uuid4())
+	data = item.toDict()
+	data['_uuid'] = item._uuid
+	ctx = data.get('_context') or {}
+	workspace_id = ctx.get('workspace_id')
+	payload = json.dumps(data, default=str)
+	conn.execute(
+		"INSERT INTO findings (uuid, type, workspace_id, is_false_positive, _tagged, data) "
+		"VALUES (?, ?, ?, ?, 0, ?) "
+		"ON CONFLICT(uuid) DO UPDATE SET "
+		"type=excluded.type, workspace_id=excluded.workspace_id, "
+		"is_false_positive=excluded.is_false_positive, data=excluded.data",
+		(item._uuid, item._type, workspace_id, int(bool(data.get('is_false_positive'))), payload),
+	)
+	conn.commit()
+	return item
+
+
+def find_duplicates(self):
+	from secator.definitions import IN_WORKER
+	ws_id = self.toDict().get('context', {}).get('workspace_id')
+	if not ws_id:
+		return
+	if not IN_WORKER:
+		tag_duplicates(ws_id)
+	else:
+		tag_duplicates.delay(ws_id)
+
+
+@shared_task
+def tag_duplicates(ws_id: str = None, full_scan: bool = False, exclude_types=[], max_items=None, log_hook=None):
+	"""Tag duplicate findings in a workspace (SQLite)."""
+	if max_items is None:
+		max_items = CONFIG.addons.sqlite.max_items
+	conn = get_sqlite_conn()
+	ws_rows = conn.execute(
+		"SELECT data FROM findings WHERE workspace_id=? AND _tagged=1 "
+		"AND json_extract(data,'$._context.workspace_duplicate')=0",
+		(str(ws_id),),
+	).fetchall()
+	workspace_findings = load_findings([json.loads(r[0]) for r in ws_rows], exclude_types)
+
+	if full_scan:
+		unt_rows = conn.execute("SELECT data FROM findings WHERE workspace_id=?", (str(ws_id),)).fetchall()
+	else:
+		unt_rows = conn.execute(
+			"SELECT data FROM findings WHERE workspace_id=? AND (_tagged IS NULL OR _tagged=0)",
+			(str(ws_id),),
+		).fetchall()
+	if max_items != -1:
+		unt_rows = unt_rows[:max_items]
+	untagged_findings = load_findings([json.loads(r[0]) for r in unt_rows], exclude_types)
+
+	debug(
+		f'Workspace non-duplicates: {len(workspace_findings)} Untagged: {len(untagged_findings)}',
+		sub='hooks.sqlite', log_hook=log_hook,
+	)
+
+	db_updates = compute_duplicate_updates(
+		workspace_findings, untagged_findings, CONFIG.addons.sqlite.duplicate_main_copy_fields,
+	)
+	if not db_updates:
+		debug('no db updates to execute', sub='hooks.sqlite', log_hook=log_hook)
+		return
+	for uuid_, update in db_updates.items():
+		_apply_finding_update(conn, uuid_, update)
+	conn.commit()
+	debug(f'Executed {len(db_updates)} database updates', sub='hooks.sqlite', log_hook=log_hook)
+
+
+HOOKS = {
+	Scan: {
+		'on_init': [update_runner],
+		'on_start': [update_runner],
+		'on_interval': [update_runner],
+		'on_duplicate': [update_finding],
+		'on_end': [update_runner],
+	},
+	Workflow: {
+		'on_init': [update_runner],
+		'on_start': [update_runner],
+		'on_interval': [update_runner],
+		'on_duplicate': [update_finding],
+		'on_end': [update_runner],
+	},
+	Task: {
+		'on_init': [update_runner],
+		'on_start': [update_runner],
+		'on_item': [update_finding],
+		'on_duplicate': [update_finding],
+		'on_interval': [update_runner],
+		'on_end': [update_runner],
+	},
+}

--- a/secator/hooks/sqlite.py
+++ b/secator/hooks/sqlite.py
@@ -1,0 +1,79 @@
+# secator/hooks/sqlite.py
+
+import re
+import sqlite3
+import threading
+from pathlib import Path
+
+from celery import shared_task  # noqa: F401
+
+from secator.config import CONFIG
+from secator.output_types import OUTPUT_TYPES  # noqa: F401
+from secator.utils import debug
+from secator.hooks._dedup import compute_duplicate_updates  # noqa: F401
+
+_conns = {}
+_conn_lock = threading.Lock()
+
+
+def _get_db_path():
+	path = CONFIG.addons.sqlite.path
+	if path:
+		return Path(path).expanduser()
+	return Path(CONFIG.dirs.data) / 'secator.db'
+
+
+def _regexp(pattern, value):
+	"""Custom REGEXP function: X REGEXP Y -> regexp(Y, X), so pattern=Y, value=X."""
+	if value is None or pattern is None:
+		return False
+	pattern = str(pattern).lstrip('*')
+	try:
+		return re.search(pattern, str(value)) is not None
+	except re.error as exc:
+		debug(f'REGEXP: invalid pattern {pattern!r}: {exc}', sub='hooks.sqlite')
+		return False
+
+
+SCHEMA = [
+	"""CREATE TABLE IF NOT EXISTS findings (
+		uuid TEXT PRIMARY KEY,
+		type TEXT,
+		workspace_id TEXT,
+		is_false_positive INTEGER DEFAULT 0,
+		_tagged INTEGER DEFAULT 0,
+		data TEXT
+	)""",
+	"CREATE INDEX IF NOT EXISTS idx_findings_ws ON findings(workspace_id)",
+	"CREATE INDEX IF NOT EXISTS idx_findings_ws_tag ON findings(workspace_id, _tagged)",
+	"CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)",
+	"CREATE TABLE IF NOT EXISTS workflows (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)",
+	"CREATE TABLE IF NOT EXISTS scans (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)",
+]
+
+
+def get_sqlite_conn(db_path=None):
+	"""Get or create a cached SQLite connection (one per db path) with schema + REGEXP."""
+	key = str(db_path) if db_path else str(_get_db_path())
+	conn = _conns.get(key)
+	if conn is None:
+		with _conn_lock:
+			conn = _conns.get(key)
+			if conn is None:
+				db_file = Path(key)
+				db_file.parent.mkdir(parents=True, exist_ok=True)
+				timeout = CONFIG.addons.sqlite.busy_timeout_ms / 1000
+				conn = sqlite3.connect(key, check_same_thread=False, timeout=timeout)
+				try:
+					conn.execute('PRAGMA journal_mode=WAL')
+					conn.execute(f'PRAGMA busy_timeout={CONFIG.addons.sqlite.busy_timeout_ms}')
+					conn.execute('PRAGMA synchronous=NORMAL')
+					conn.create_function('REGEXP', 2, _regexp)
+					for stmt in SCHEMA:
+						conn.execute(stmt)
+					conn.commit()
+					_conns[key] = conn
+				except Exception:
+					conn.close()
+					raise
+	return conn

--- a/secator/hooks/sqlite.py
+++ b/secator/hooks/sqlite.py
@@ -157,11 +157,12 @@ def update_finding(self, item):
 	payload = json.dumps(data, default=str)
 	conn.execute(
 		"INSERT INTO findings (uuid, type, workspace_id, is_false_positive, _tagged, data) "
-		"VALUES (?, ?, ?, ?, 0, ?) "
+		"VALUES (?, ?, ?, ?, ?, ?) "
 		"ON CONFLICT(uuid) DO UPDATE SET "
 		"type=excluded.type, workspace_id=excluded.workspace_id, "
-		"is_false_positive=excluded.is_false_positive, data=excluded.data",
-		(item._uuid, item._type, workspace_id, int(bool(data.get('is_false_positive'))), payload),
+		"is_false_positive=excluded.is_false_positive, _tagged=excluded._tagged, data=excluded.data",
+		(item._uuid, item._type, workspace_id,
+			int(bool(data.get('is_false_positive'))), int(bool(data.get('_tagged'))), payload),
 	)
 	conn.commit()
 	return item

--- a/secator/query/__init__.py
+++ b/secator/query/__init__.py
@@ -6,9 +6,10 @@ from secator.query._base import QueryBackend
 from secator.query.api import ApiBackend
 from secator.query.mongodb import MongoDBBackend
 from secator.query.json import JsonBackend
+from secator.query.sqlite import SqliteBackend
 
 
-__all__ = ['QueryEngine', 'QueryBackend', 'ApiBackend', 'MongoDBBackend', 'JsonBackend']
+__all__ = ['QueryEngine', 'QueryBackend', 'ApiBackend', 'MongoDBBackend', 'JsonBackend', 'SqliteBackend']
 
 
 class QueryEngine:
@@ -17,6 +18,7 @@ class QueryEngine:
     BACKENDS = {
         'api': ApiBackend,
         'mongodb': MongoDBBackend,
+        'sqlite': SqliteBackend,
         'json': JsonBackend,
     }
 
@@ -32,6 +34,8 @@ class QueryEngine:
             return MongoDBBackend(self.workspace_id, context=self.context)
         elif 'api' in drivers:
             return ApiBackend(self.workspace_id, context=self.context)
+        elif 'sqlite' in drivers:
+            return SqliteBackend(self.workspace_id, context=self.context)
         else:
             # For JSON backend, use workspace_name for directory (reports are saved by name)
             workspace_name = self.context.get('workspace_name', self.workspace_id)

--- a/secator/query/sqlite.py
+++ b/secator/query/sqlite.py
@@ -1,12 +1,12 @@
 # secator/query/sqlite.py
 
-import json  # noqa: F401
+import json
 import re
-from typing import List, Dict, Any, Optional  # noqa: F401
+from typing import List, Dict, Any
 
-from secator.output_types import Warning  # noqa: F401
-from secator.query._base import QueryBackend  # noqa: F401
-from secator.rich import console  # noqa: F401
+from secator.output_types import Warning
+from secator.query._base import QueryBackend
+from secator.rich import console
 
 # Query fields that map to real indexed columns instead of json_extract.
 MIRRORED_COLUMNS = {
@@ -93,3 +93,66 @@ def _build_where(query: dict):
 			clauses.append(f'{expr} = ?')
 			params.append(condition)
 	return ' AND '.join(clauses), params
+
+
+class SqliteBackend(QueryBackend):
+	"""Query backend for SQLite (JSON-blob rows + SQL translation)."""
+
+	name = 'sqlite'
+
+	def _get_conn(self):
+		from secator.hooks.sqlite import get_sqlite_conn
+		return get_sqlite_conn(self.config.get('db_path'))
+
+	def _execute_search(self, query: dict, limit: int = 0, exclude_fields: list = None) -> List[Dict[str, Any]]:
+		try:
+			conn = self._get_conn()
+			where, params = _build_where(query)
+			sql = f"SELECT data FROM findings WHERE {where or '1=1'}"
+			if limit:  # limit=0 means unlimited (matches ABC contract and JsonBackend)
+				sql += " LIMIT ?"
+				params.append(limit)
+			results = []
+			for (data,) in conn.execute(sql, params).fetchall():
+				finding = json.loads(data)
+				if exclude_fields:
+					finding = {k: v for k, v in finding.items() if k not in exclude_fields}
+				results.append(finding)
+			return results
+		except Exception as e:
+			console.print(Warning(message=f'SQLite search failed: {e}'))
+			return []
+
+	def _execute_count(self, query: dict) -> int:
+		try:
+			conn = self._get_conn()
+			where, params = _build_where(query)
+			sql = f"SELECT COUNT(*) FROM findings WHERE {where or '1=1'}"
+			return conn.execute(sql, params).fetchone()[0]
+		except Exception as e:
+			console.print(Warning(message=f'SQLite count failed: {e}'))
+			return 0
+
+	def _execute_update(self, query: dict, update: dict) -> int:
+		set_fields = update.get('$set', {})
+		if not set_fields:
+			return 0
+		conn = self._get_conn()
+		where, where_params = _build_where(query)
+		set_exprs = []
+		set_params = []
+		for field, val in set_fields.items():
+			_col_expr(field)  # validate field name (raises ValueError on SQL metacharacters)
+			set_exprs.append(f"data = json_set(data, '$.{field}', json(?))")
+			set_params.append(json.dumps(val, default=str))
+			if field == '_tagged':
+				set_exprs.append("_tagged = ?")
+				set_params.append(int(bool(val)))
+			elif field == 'is_false_positive':
+				set_exprs.append("is_false_positive = ?")
+				set_params.append(int(bool(val)))
+		sql = f"UPDATE findings SET {', '.join(set_exprs)} WHERE {where or '1=1'}"
+		cur = conn.execute(sql, set_params + where_params)
+		# Connection is shared; commit flushes pending writes (best-effort single-host semantics, per design).
+		conn.commit()
+		return cur.rowcount

--- a/secator/query/sqlite.py
+++ b/secator/query/sqlite.py
@@ -1,0 +1,95 @@
+# secator/query/sqlite.py
+
+import json  # noqa: F401
+import re
+from typing import List, Dict, Any, Optional  # noqa: F401
+
+from secator.output_types import Warning  # noqa: F401
+from secator.query._base import QueryBackend  # noqa: F401
+from secator.rich import console  # noqa: F401
+
+# Query fields that map to real indexed columns instead of json_extract.
+MIRRORED_COLUMNS = {
+	'_context.workspace_id': 'workspace_id',
+	'is_false_positive': 'is_false_positive',
+	'_tagged': '_tagged',
+	'_type': 'type',
+}
+
+COMPARISON_OPS = {
+	'$ne': '!=',
+	'$gt': '>',
+	'$gte': '>=',
+	'$lt': '<',
+	'$lte': '<=',
+}
+
+
+_FIELD_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_.]*$')
+
+
+def _col_expr(field: str) -> str:
+	"""Return the SQL expression for a query field (mirrored column or json_extract path).
+
+	Field names are interpolated into the SQL text (json1 paths cannot be parameterized),
+	so they are validated against a strict allowlist to prevent SQL injection.
+	"""
+	if field in MIRRORED_COLUMNS:
+		return MIRRORED_COLUMNS[field]
+	if not _FIELD_RE.match(field):
+		raise ValueError(f'Invalid query field name: {field!r}')
+	return f"json_extract(data, '$.{field}')"
+
+
+def _build_where(query: dict):
+	"""Translate a MongoDB-style query dict into a parameterized SQL WHERE fragment.
+
+	Returns (sql_fragment, params). An empty query yields ('', []).
+	"""
+	clauses = []
+	params = []
+	for key, condition in query.items():
+		if key == '$and':
+			sub = [_build_where(q) for q in condition]
+			if not sub:
+				clauses.append('1=1')
+				continue
+			joined = ' AND '.join(s if s else '1=1' for s, _ in sub)
+			clauses.append(f'({joined})')
+			for _, p in sub:
+				params.extend(p)
+			continue
+		if key == '$or':
+			sub = [_build_where(q) for q in condition]
+			if not sub:
+				clauses.append('0')
+				continue
+			joined = ' OR '.join(s if s else '0' for s, _ in sub)
+			clauses.append(f'({joined})')
+			for _, p in sub:
+				params.extend(p)
+			continue
+		expr = _col_expr(key)
+		if isinstance(condition, dict):
+			for op, val in condition.items():
+				if op in COMPARISON_OPS:
+					clauses.append(f'{expr} {COMPARISON_OPS[op]} ?')
+					params.append(val)
+				elif op == '$in':
+					if not val:
+						clauses.append('0')
+						continue
+					placeholders = ', '.join('?' for _ in val)
+					clauses.append(f'{expr} IN ({placeholders})')
+					params.extend(val)
+				elif op == '$contains':
+					clauses.append(f"{expr} LIKE '%' || ? || '%'")
+					params.append(val)
+				elif op == '$regex':
+					clauses.append(f'{expr} REGEXP ?')
+					params.append(str(val))
+				# unknown operators are ignored, matching the json backend
+		else:
+			clauses.append(f'{expr} = ?')
+			params.append(condition)
+	return ' AND '.join(clauses), params

--- a/secator/query/sqlite.py
+++ b/secator/query/sqlite.py
@@ -139,20 +139,23 @@ class SqliteBackend(QueryBackend):
 			return 0
 		conn = self._get_conn()
 		where, where_params = _build_where(query)
-		set_exprs = []
-		set_params = []
+		data_expr = "data"
+		data_params = []
+		extra_exprs = []
+		extra_params = []
 		for field, val in set_fields.items():
 			_col_expr(field)  # validate field name (raises ValueError on SQL metacharacters)
-			set_exprs.append(f"data = json_set(data, '$.{field}', json(?))")
-			set_params.append(json.dumps(val, default=str))
+			data_expr = f"json_set({data_expr}, '$.{field}', json(?))"
+			data_params.append(json.dumps(val, default=str))
 			if field == '_tagged':
-				set_exprs.append("_tagged = ?")
-				set_params.append(int(bool(val)))
+				extra_exprs.append("_tagged = ?")
+				extra_params.append(int(bool(val)))
 			elif field == 'is_false_positive':
-				set_exprs.append("is_false_positive = ?")
-				set_params.append(int(bool(val)))
-		sql = f"UPDATE findings SET {', '.join(set_exprs)} WHERE {where or '1=1'}"
-		cur = conn.execute(sql, set_params + where_params)
+				extra_exprs.append("is_false_positive = ?")
+				extra_params.append(int(bool(val)))
+		set_clause = ', '.join([f"data = {data_expr}"] + extra_exprs)
+		sql = f"UPDATE findings SET {set_clause} WHERE {where or '1=1'}"
+		cur = conn.execute(sql, data_params + extra_params + where_params)
 		# Connection is shared; commit flushes pending writes (best-effort single-host semantics, per design).
 		conn.commit()
 		return cur.rowcount

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -538,6 +538,7 @@ class TestCli(unittest.TestCase):
 				assert result.exit_code == 0
 				assert 'already installed' in result.output
 
+
 class TestSqliteCliDriver(unittest.TestCase):
 	def test_report_show_accepts_sqlite_driver(self):
 		from click.testing import CliRunner

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -538,5 +538,24 @@ class TestCli(unittest.TestCase):
 				assert result.exit_code == 0
 				assert 'already installed' in result.output
 
+class TestSqliteCliDriver(unittest.TestCase):
+	def test_report_show_accepts_sqlite_driver(self):
+		from click.testing import CliRunner
+		from secator.cli import cli
+		runner = CliRunner()
+		# Use a wide terminal so the choice list does not wrap mid-word in the help table
+		result = runner.invoke(cli, ['report', 'show', '--help'], env={'COLUMNS': '200'})
+		self.assertEqual(result.exit_code, 0)
+		self.assertIn('sqlite', result.output)
+
+	def test_workspace_delete_accepts_sqlite_driver(self):
+		from click.testing import CliRunner
+		from secator.cli import cli
+		runner = CliRunner()
+		result = runner.invoke(cli, ['workspace', 'delete', '--help'])
+		self.assertEqual(result.exit_code, 0)
+		self.assertIn('sqlite', result.output)
+
+
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -426,3 +426,21 @@ class TestQueryEngineUpdate(unittest.TestCase):
 		engine.backend.update.assert_called_once_with(
 			{'_type': 'ai'}, {'$set': {'status': 'done'}}
 		)
+
+
+class TestSqliteWiring(unittest.TestCase):
+	def test_sqlite_in_available_drivers(self):
+		from secator.loader import get_available_drivers
+		self.assertIn('sqlite', get_available_drivers())
+
+	def test_sqlite_addon_always_enabled(self):
+		from secator.definitions import ADDONS_ENABLED
+		self.assertIn('sqlite', ADDONS_ENABLED)
+		self.assertTrue(ADDONS_ENABLED['sqlite'])
+
+	def test_sqlite_addon_config_exists(self):
+		from secator.config import CONFIG
+		self.assertFalse(CONFIG.addons.sqlite.enabled)
+		self.assertEqual(CONFIG.addons.sqlite.busy_timeout_ms, 5000)
+		self.assertEqual(CONFIG.addons.sqlite.max_items, -1)
+		self.assertIsInstance(CONFIG.addons.sqlite.duplicate_main_copy_fields, list)

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -444,3 +444,84 @@ class TestSqliteWiring(unittest.TestCase):
 		self.assertEqual(CONFIG.addons.sqlite.busy_timeout_ms, 5000)
 		self.assertEqual(CONFIG.addons.sqlite.max_items, -1)
 		self.assertIsInstance(CONFIG.addons.sqlite.duplicate_main_copy_fields, list)
+
+
+class TestSqliteTranslator(unittest.TestCase):
+	def _where(self, query):
+		from secator.query.sqlite import _build_where
+		return _build_where(query)
+
+	def test_equality(self):
+		sql, params = self._where({'_type': 'url'})
+		self.assertEqual(sql, "type = ?")
+		self.assertEqual(params, ['url'])
+
+	def test_plain_field_uses_json_extract(self):
+		sql, params = self._where({'name': 'foo'})
+		self.assertEqual(sql, "json_extract(data, '$.name') = ?")
+		self.assertEqual(params, ['foo'])
+
+	def test_mirrored_workspace_id(self):
+		sql, params = self._where({'_context.workspace_id': 'ws1'})
+		self.assertEqual(sql, "workspace_id = ?")
+		self.assertEqual(params, ['ws1'])
+
+	def test_comparison_ops(self):
+		sql, params = self._where({'cvss_score': {'$gte': 9.0}})
+		self.assertEqual(sql, "json_extract(data, '$.cvss_score') >= ?")
+		self.assertEqual(params, [9.0])
+
+	def test_in_op(self):
+		sql, params = self._where({'severity': {'$in': ['critical', 'high']}})
+		self.assertEqual(sql, "json_extract(data, '$.severity') IN (?, ?)")
+		self.assertEqual(params, ['critical', 'high'])
+
+	def test_contains_op(self):
+		sql, params = self._where({'url': {'$contains': 'login'}})
+		self.assertEqual(sql, "json_extract(data, '$.url') LIKE '%' || ? || '%'")
+		self.assertEqual(params, ['login'])
+
+	def test_regex_op(self):
+		sql, params = self._where({'url': {'$regex': r'example\.com'}})
+		self.assertEqual(sql, "json_extract(data, '$.url') REGEXP ?")
+		self.assertEqual(params, [r'example\.com'])
+
+	def test_and(self):
+		sql, params = self._where({'$and': [{'_type': 'url'}, {'name': 'x'}]})
+		self.assertEqual(sql, "(type = ? AND json_extract(data, '$.name') = ?)")
+		self.assertEqual(params, ['url', 'x'])
+
+	def test_or(self):
+		sql, params = self._where({'$or': [{'_type': 'url'}, {'_type': 'port'}]})
+		self.assertEqual(sql, "(type = ? OR type = ?)")
+		self.assertEqual(params, ['url', 'port'])
+
+	def test_empty(self):
+		sql, params = self._where({})
+		self.assertEqual(sql, "")
+		self.assertEqual(params, [])
+
+	def test_in_empty_list(self):
+		sql, params = self._where({'severity': {'$in': []}})
+		self.assertEqual(sql, "0")
+		self.assertEqual(params, [])
+
+	def test_or_empty_list(self):
+		sql, params = self._where({'$or': []})
+		self.assertEqual(sql, "0")
+		self.assertEqual(params, [])
+
+	def test_and_empty_list(self):
+		sql, params = self._where({'$and': []})
+		self.assertEqual(sql, "1=1")
+		self.assertEqual(params, [])
+
+	def test_dotted_field_allowed(self):
+		sql, params = self._where({'foo.bar': 'baz'})
+		self.assertEqual(sql, "json_extract(data, '$.foo.bar') = ?")
+		self.assertEqual(params, ['baz'])
+
+	def test_invalid_field_name_rejected(self):
+		from secator.query.sqlite import _build_where
+		with self.assertRaises(ValueError):
+			_build_where({"x') UNION SELECT 1 --": 'v'})

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -388,6 +388,20 @@ class TestQueryEngine(unittest.TestCase):
 		results = engine.search({}, dedupe=False)
 		assert len(results) == 2
 
+	def test_query_engine_selects_sqlite(self):
+		from secator.query import QueryEngine
+		from secator.query.sqlite import SqliteBackend
+
+		engine = QueryEngine(workspace_id='ws123', context={'drivers': ['sqlite']})
+		self.assertIsInstance(engine.backend, SqliteBackend)
+
+	def test_query_engine_mongodb_priority_over_sqlite(self):
+		from secator.query import QueryEngine
+		from secator.query.mongodb import MongoDBBackend
+
+		engine = QueryEngine(workspace_id='ws123', context={'drivers': ['sqlite', 'mongodb']})
+		self.assertIsInstance(engine.backend, MongoDBBackend)
+
 
 class TestQueryEngineUpdate(unittest.TestCase):
 	"""Tests for QueryEngine.update method."""

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -516,6 +516,14 @@ class TestSqliteBackend(unittest.TestCase):
 		results = backend.search({'_type': 'url'})
 		self.assertEqual(results[0]['status_code'], 404)
 
+	def test_update_multiple_fields(self):
+		backend = self._backend()
+		n = backend.update({'_type': 'url'}, {'$set': {'status_code': 200, 'title': 'Home'}})
+		self.assertEqual(n, 1)
+		results = backend.search({'_type': 'url'})
+		self.assertEqual(results[0]['status_code'], 200)
+		self.assertEqual(results[0]['title'], 'Home')
+
 	def test_update_rejects_malicious_field_name(self):
 		backend = self._backend()
 		with self.assertRaises(ValueError):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -428,6 +428,103 @@ class TestQueryEngineUpdate(unittest.TestCase):
 		)
 
 
+class TestSqliteBackend(unittest.TestCase):
+	def setUp(self):
+		import tempfile
+		import json
+		from pathlib import Path
+		import secator.hooks.sqlite as sqlite_mod
+		from secator.config import CONFIG
+
+		self.sqlite_mod = sqlite_mod
+		self.temp_dir = tempfile.mkdtemp()
+		self.db_path = str(Path(self.temp_dir) / 'test.db')
+		self._orig_path = CONFIG.addons.sqlite.path
+		CONFIG.addons.sqlite.path = self.db_path
+		sqlite_mod._conns.clear()
+		self.ws = 'ws1'
+		conn = sqlite_mod.get_sqlite_conn()
+		rows = [
+			('u1', 'vulnerability', self.ws, 0, {'_type': 'vulnerability', 'name': 'SQLi',
+				'severity': 'critical', 'matched_at': 'http://x/login', 'is_false_positive': False,
+				'_context': {'workspace_id': self.ws, 'workspace_duplicate': False}}),
+			('u2', 'vulnerability', self.ws, 0, {'_type': 'vulnerability', 'name': 'XSS',
+				'severity': 'medium', 'matched_at': 'http://x/search', 'is_false_positive': False,
+				'_context': {'workspace_id': self.ws, 'workspace_duplicate': False}}),
+			('u3', 'url', self.ws, 0, {'_type': 'url', 'url': 'http://x/login',
+				'is_false_positive': False, '_context': {'workspace_id': self.ws, 'workspace_duplicate': False}}),
+		]
+		for uuid_, type_, ws, fp, data in rows:
+			conn.execute(
+				"INSERT INTO findings (uuid, type, workspace_id, is_false_positive, _tagged, data) "
+				"VALUES (?, ?, ?, ?, 0, ?)",
+				(uuid_, type_, ws, fp, json.dumps(data)))
+		conn.commit()
+
+	def tearDown(self):
+		import shutil
+		from secator.config import CONFIG
+		for conn in self.sqlite_mod._conns.values():
+			conn.close()
+		self.sqlite_mod._conns.clear()
+		CONFIG.addons.sqlite.path = self._orig_path
+		shutil.rmtree(self.temp_dir)
+
+	def _backend(self):
+		from secator.query.sqlite import SqliteBackend
+		return SqliteBackend(workspace_id=self.ws)
+
+	def test_search_by_type(self):
+		results = self._backend().search({'_type': 'vulnerability'})
+		self.assertEqual(len(results), 2)
+		self.assertTrue(all(r['_type'] == 'vulnerability' for r in results))
+
+	def test_search_with_in_operator(self):
+		results = self._backend().search({'_type': 'vulnerability', 'severity': {'$in': ['critical', 'high']}})
+		self.assertEqual(len(results), 1)
+		self.assertEqual(results[0]['name'], 'SQLi')
+
+	def test_search_contains(self):
+		results = self._backend().search({'matched_at': {'$contains': 'login'}})
+		self.assertEqual(len(results), 1)
+		self.assertEqual(results[0]['name'], 'SQLi')
+
+	def test_search_regex(self):
+		results = self._backend().search({'matched_at': {'$regex': r'/search'}})
+		self.assertEqual(len(results), 1)
+		self.assertEqual(results[0]['name'], 'XSS')
+
+	def test_count(self):
+		self.assertEqual(self._backend().count({'_type': 'vulnerability'}), 2)
+
+	def test_base_query_enforces_workspace(self):
+		results = self._backend().search({})
+		self.assertTrue(all(r['_context']['workspace_id'] == self.ws for r in results))
+
+	def test_limit(self):
+		results = self._backend().search({}, limit=1)
+		self.assertEqual(len(results), 1)
+
+	def test_exclude_fields(self):
+		results = self._backend().search({'_type': 'url'}, exclude_fields=['url'])
+		self.assertNotIn('url', results[0])
+
+	def test_update(self):
+		backend = self._backend()
+		n = backend.update({'_type': 'url'}, {'$set': {'status_code': 404}})
+		self.assertEqual(n, 1)
+		results = backend.search({'_type': 'url'})
+		self.assertEqual(results[0]['status_code'], 404)
+
+	def test_update_rejects_malicious_field_name(self):
+		backend = self._backend()
+		with self.assertRaises(ValueError):
+			backend.update({'_type': 'url'}, {'$set': {"x', type = 'pwned' --": 1}})
+		# Confirm no row was corrupted: the url row still has type 'url'.
+		results = backend.search({'_type': 'url'})
+		self.assertEqual(len(results), 1)
+
+
 class TestSqliteWiring(unittest.TestCase):
 	def test_sqlite_in_available_drivers(self):
 		from secator.loader import get_available_drivers

--- a/tests/unit/test_sqlite_driver.py
+++ b/tests/unit/test_sqlite_driver.py
@@ -61,3 +61,64 @@ class TestSqliteConnection(SqliteTestBase):
 
 	def test_regexp_leading_wildcard_stripped(self):
 		self.assertTrue(self.sqlite_mod._regexp('*CVE', 'a-CVE-2026'))
+
+
+class TestComputeDuplicateUpdates(unittest.TestCase):
+	def _finding(self, uuid_, url, fp=False, related=None):
+		from secator.output_types import Url
+		item = Url(url=url, _context={'workspace_id': 'ws1', 'workspace_duplicate': False})
+		item._uuid = uuid_
+		item._related = related or []
+		item.is_false_positive = fp
+		return item
+
+	def test_marks_duplicates(self):
+		from secator.hooks._dedup import compute_duplicate_updates
+		a = self._finding('u1', 'http://x/a')
+		b = self._finding('u2', 'http://x/a')  # duplicate of a
+		c = self._finding('u3', 'http://x/c')  # unique
+		updates = compute_duplicate_updates([], [a, b, c], copy_fields=[])
+		# The first item keeps workspace_duplicate False and lists its duplicates
+		self.assertFalse(updates['u1']['_context.workspace_duplicate'])
+		self.assertIn('u2', updates['u1']['_related'])
+		self.assertTrue(updates['u1']['_tagged'])
+		# The duplicate is flagged
+		self.assertTrue(updates['u2']['_context.workspace_duplicate'])
+		self.assertTrue(updates['u2']['_tagged'])
+		# Unique item is not a duplicate
+		self.assertFalse(updates['u3']['_context.workspace_duplicate'])
+
+	def test_no_duplicates(self):
+		from secator.hooks._dedup import compute_duplicate_updates
+		a = self._finding('u1', 'http://x/a')
+		b = self._finding('u2', 'http://x/b')
+		updates = compute_duplicate_updates([], [a, b], copy_fields=[])
+		self.assertFalse(updates['u1']['_context.workspace_duplicate'])
+		self.assertFalse(updates['u2']['_context.workspace_duplicate'])
+
+	def test_workspace_duplicate_path(self):
+		from secator.hooks._dedup import compute_duplicate_updates
+		# An already-tagged workspace finding 'w1' matches a new untagged item 'u1' (same url).
+		# w1 carries its own _related history ['old'].
+		ws_finding = self._finding('w1', 'http://x/a', related=['old'])
+		new_item = self._finding('u1', 'http://x/a')
+		updates = compute_duplicate_updates([ws_finding], [new_item], copy_fields=[])
+		# The new item is the main, not a duplicate, and is tagged.
+		self.assertFalse(updates['u1']['_context.workspace_duplicate'])
+		self.assertTrue(updates['u1']['_tagged'])
+		# It relates to the matching workspace finding and inherits its _related history.
+		self.assertIn('w1', updates['u1']['_related'])
+		self.assertIn('old', updates['u1']['_related'])
+		# The matching workspace finding is flagged as a duplicate.
+		self.assertTrue(updates['w1']['_context.workspace_duplicate'])
+		self.assertTrue(updates['w1']['_tagged'])
+
+	def test_copy_fields_from_previous_main(self):
+		from secator.hooks._dedup import compute_duplicate_updates
+		# Previous main (workspace) finding has a non-empty field; new item lacks it -> copied.
+		ws_finding = self._finding('w1', 'http://x/a')
+		ws_finding.host = 'example.com'  # non-empty on previous main
+		new_item = self._finding('u1', 'http://x/a')
+		new_item.host = ''  # empty on new item -> should be filled from previous
+		updates = compute_duplicate_updates([ws_finding], [new_item], copy_fields=['host'])
+		self.assertEqual(updates['u1'].get('host'), 'example.com')

--- a/tests/unit/test_sqlite_driver.py
+++ b/tests/unit/test_sqlite_driver.py
@@ -1,0 +1,63 @@
+# tests/unit/test_sqlite_driver.py
+
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class SqliteTestBase(unittest.TestCase):
+	"""Points the sqlite driver at a temp DB and resets the connection cache."""
+
+	def setUp(self):
+		import secator.hooks.sqlite as sqlite_mod
+		from secator.config import CONFIG
+		self.sqlite_mod = sqlite_mod
+		self.temp_dir = tempfile.mkdtemp()
+		self.db_path = str(Path(self.temp_dir) / 'test.db')
+		self._orig_path = CONFIG.addons.sqlite.path
+		CONFIG.addons.sqlite.path = self.db_path
+		sqlite_mod._conns.clear()
+
+	def tearDown(self):
+		import shutil
+		from secator.config import CONFIG
+		for conn in self.sqlite_mod._conns.values():
+			conn.close()
+		self.sqlite_mod._conns.clear()
+		CONFIG.addons.sqlite.path = self._orig_path
+		shutil.rmtree(self.temp_dir)
+
+
+class TestSqliteConnection(SqliteTestBase):
+	def test_schema_created(self):
+		conn = self.sqlite_mod.get_sqlite_conn()
+		tables = {
+			r[0] for r in conn.execute(
+				"SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+		}
+		self.assertEqual({'findings', 'tasks', 'workflows', 'scans'}, tables & {'findings', 'tasks', 'workflows', 'scans'})
+
+	def test_wal_mode(self):
+		conn = self.sqlite_mod.get_sqlite_conn()
+		mode = conn.execute('PRAGMA journal_mode').fetchone()[0]
+		self.assertEqual(mode.lower(), 'wal')
+
+	def test_regexp_function_registered(self):
+		conn = self.sqlite_mod.get_sqlite_conn()
+		row = conn.execute("SELECT 'CVE-2026-1' REGEXP 'CVE-2026'").fetchone()
+		self.assertEqual(row[0], 1)
+		row = conn.execute("SELECT 'foo' REGEXP 'CVE'").fetchone()
+		self.assertEqual(row[0], 0)
+
+	def test_regexp_none_value(self):
+		self.assertFalse(self.sqlite_mod._regexp('CVE', None))
+
+	def test_regexp_none_pattern(self):
+		self.assertFalse(self.sqlite_mod._regexp(None, 'CVE-2026'))
+
+	def test_regexp_invalid_pattern_returns_false(self):
+		# An unbalanced group is an invalid regex; should be swallowed (return False), not raise.
+		self.assertFalse(self.sqlite_mod._regexp('(unclosed', 'anything'))
+
+	def test_regexp_leading_wildcard_stripped(self):
+		self.assertTrue(self.sqlite_mod._regexp('*CVE', 'a-CVE-2026'))

--- a/tests/unit/test_sqlite_driver.py
+++ b/tests/unit/test_sqlite_driver.py
@@ -179,7 +179,6 @@ class TestSqliteHooks(SqliteTestBase):
 
 	def test_tag_duplicates(self):
 		from secator.hooks import sqlite as mod
-		from secator.query.sqlite import SqliteBackend
 
 		class FakeRunner:
 			def __init__(self):
@@ -191,9 +190,14 @@ class TestSqliteHooks(SqliteTestBase):
 		mod.update_finding(runner, self._make_finding('http://x/a'))  # duplicate
 		mod.update_finding(runner, self._make_finding('http://x/b'))
 
+		# tag_duplicates is a Celery @shared_task: the registry caches the task whose
+		# function globals may bind a *stale* CONFIG object after another test calls
+		# clear_modules() (which drops secator.config from sys.modules). Point that exact
+		# CONFIG at our temp DB so the task reads/writes the same database this test set up.
+		mod.tag_duplicates.run.__globals__['CONFIG'].addons.sqlite.path = self.db_path
 		mod.tag_duplicates('ws1')
 
-		conn = mod.get_sqlite_conn()
+		conn = mod.get_sqlite_conn(self.db_path)
 		dup_count = conn.execute(
 			"SELECT COUNT(*) FROM findings WHERE json_extract(data,'$._context.workspace_duplicate')=1"
 		).fetchone()[0]

--- a/tests/unit/test_sqlite_driver.py
+++ b/tests/unit/test_sqlite_driver.py
@@ -201,6 +201,31 @@ class TestSqliteHooks(SqliteTestBase):
 		tagged = conn.execute("SELECT COUNT(*) FROM findings WHERE _tagged=1").fetchone()[0]
 		self.assertEqual(tagged, 3)
 
+	def test_reinsert_keeps_column_and_json_consistent(self):
+		from secator.hooks import sqlite as mod
+
+		class FakeRunner:
+			def __init__(self):
+				self.config = type('C', (), {'name': 'httpx'})()
+				self.context = {'workspace_id': 'ws1'}
+
+		runner = FakeRunner()
+		item = self._make_finding('http://x/a')
+		mod.update_finding(runner, item)
+		# Simulate tagging: mark it tagged + duplicate via the dedup apply path.
+		conn = mod.get_sqlite_conn()
+		mod._apply_finding_update(conn, item._uuid, {
+			'_tagged': True, '_context.workspace_duplicate': True,
+		})
+		conn.commit()
+		# Re-save the SAME finding (same uuid) with a fresh/stale in-memory item.
+		mod.update_finding(runner, item)
+		# Column and JSON must agree (no drift): both reflect the re-saved payload.
+		row = conn.execute(
+			"SELECT _tagged, json_extract(data, '$._tagged') FROM findings WHERE uuid=?",
+			(item._uuid,)).fetchone()
+		self.assertEqual(int(bool(row[0])), int(bool(row[1])))
+
 	def test_hooks_structure(self):
 		from secator.hooks import sqlite as mod
 		from secator.runners import Scan, Task, Workflow

--- a/tests/unit/test_sqlite_driver.py
+++ b/tests/unit/test_sqlite_driver.py
@@ -122,3 +122,89 @@ class TestComputeDuplicateUpdates(unittest.TestCase):
 		new_item.host = ''  # empty on new item -> should be filled from previous
 		updates = compute_duplicate_updates([ws_finding], [new_item], copy_fields=['host'])
 		self.assertEqual(updates['u1'].get('host'), 'example.com')
+
+
+class TestSqliteHooks(SqliteTestBase):
+	def _make_finding(self, url):
+		from secator.output_types import Url
+		return Url(url=url, _context={'workspace_id': 'ws1', 'workspace_duplicate': False})
+
+	def test_update_finding_inserts_and_assigns_uuid(self):
+		from secator.hooks import sqlite as mod
+		from secator.query.sqlite import SqliteBackend
+
+		class FakeRunner:
+			def __init__(self):
+				self.config = type('C', (), {'name': 'httpx'})()
+				self.context = {'workspace_id': 'ws1'}
+
+		runner = FakeRunner()
+		item = self._make_finding('http://x/a')
+		self.assertEqual(item._uuid, '')
+		returned = mod.update_finding(runner, item)
+		self.assertTrue(returned._uuid)  # uuid assigned
+
+		results = SqliteBackend(workspace_id='ws1').search({'_type': 'url'})
+		self.assertEqual(len(results), 1)
+		self.assertEqual(results[0]['url'], 'http://x/a')
+
+	def test_update_runner_inserts_and_stores_id(self):
+		from secator.hooks import sqlite as mod
+
+		class FakeRunner:
+			def __init__(self):
+				self.config = type('C', (), {'type': 'task', 'name': 'httpx'})()
+				self.context = {'workspace_id': 'ws1'}
+				self.status = 'RUNNING'
+
+			def toDict(self):
+				return {'name': 'httpx', 'status': self.status, 'chunk': None}
+
+		runner = FakeRunner()
+		mod.update_runner(runner)
+		self.assertIn('task_id', runner.context)
+		task_id = runner.context['task_id']
+
+		conn = mod.get_sqlite_conn()
+		row = conn.execute("SELECT workspace_id FROM tasks WHERE id=?", (task_id,)).fetchone()
+		self.assertIsNotNone(row)
+		self.assertEqual(row[0], 'ws1')
+
+		# Second call updates the same row (no new id)
+		runner.status = 'SUCCESS'
+		mod.update_runner(runner)
+		self.assertEqual(runner.context['task_id'], task_id)
+		count = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+		self.assertEqual(count, 1)
+
+	def test_tag_duplicates(self):
+		from secator.hooks import sqlite as mod
+		from secator.query.sqlite import SqliteBackend
+
+		class FakeRunner:
+			def __init__(self):
+				self.config = type('C', (), {'name': 'httpx'})()
+				self.context = {'workspace_id': 'ws1'}
+
+		runner = FakeRunner()
+		mod.update_finding(runner, self._make_finding('http://x/a'))
+		mod.update_finding(runner, self._make_finding('http://x/a'))  # duplicate
+		mod.update_finding(runner, self._make_finding('http://x/b'))
+
+		mod.tag_duplicates('ws1')
+
+		conn = mod.get_sqlite_conn()
+		dup_count = conn.execute(
+			"SELECT COUNT(*) FROM findings WHERE json_extract(data,'$._context.workspace_duplicate')=1"
+		).fetchone()[0]
+		self.assertEqual(dup_count, 1)
+		tagged = conn.execute("SELECT COUNT(*) FROM findings WHERE _tagged=1").fetchone()[0]
+		self.assertEqual(tagged, 3)
+
+	def test_hooks_structure(self):
+		from secator.hooks import sqlite as mod
+		from secator.runners import Scan, Task, Workflow
+		self.assertIn(Task, mod.HOOKS)
+		self.assertIn(Workflow, mod.HOOKS)
+		self.assertIn(Scan, mod.HOOKS)
+		self.assertIn('on_item', mod.HOOKS[Task])


### PR DESCRIPTION
## Summary

Adds a self-contained, server-less **`sqlite`** driver to secator with full parity to the `mongodb` driver:

- **Write side** (`secator/hooks/sqlite.py`): WAL connection + schema bootstrap, runner/finding persistence hooks (`update_runner`, `update_finding`), and workspace duplicate tagging (`tag_duplicates`). Findings/runners are stored as JSON blobs with `workspace_id`/`is_false_positive`/`_tagged`/`type` mirrored into indexed columns.
- **Read side** (`secator/query/sqlite.py`): `SqliteBackend(QueryBackend)` plus a `_build_where` translator that compiles MongoDB-style query dicts (`$ne/$gt/$gte/$lt/$lte/$in/$contains/$regex/$and/$or`) to parameterized SQL via `json_extract` + a custom `REGEXP` function.
- **Shared dedup** (`secator/hooks/_dedup.py`): `compute_duplicate_updates` extracted as a backend-agnostic helper; `mongodb` refactored to use it (behavior unchanged).
- **Wiring**: `SqliteAddon` config, `AVAILABLE_DRIVERS`/`ADDONS_ENABLED`, `QueryEngine` backend selection (priority `mongodb > api > sqlite > json`), and CLI `--driver sqlite` support including `workspace delete` / `report delete` branches.

Storage: single DB file with a `workspace_id` column on every row; WAL mode + `busy_timeout` for best-effort single-host concurrency.

### Security
Field names are interpolated into `json_extract` paths (json1 paths can't be parameterized), so both the query translator and `_execute_update` validate every field name against a strict allowlist (`^[A-Za-z_][A-Za-z0-9_.]*$`) before interpolation. All values are bound parameters; CLI table names come from a fixed allowlist. This closes a SQL-injection vector reachable via the CLI `-q` JSON escape hatch.

## Test Plan
- [x] `secator test unit` — 747/747 passing
- [x] `secator test lint` — clean
- [x] Translator unit tests (operators, `$in []`/`$or []` edge cases, field-name rejection)
- [x] `SqliteBackend` search/count/update (incl. multi-field `$set`, exclude_fields, workspace isolation)
- [x] Write hooks round-trip + duplicate tagging + re-insert column/JSON consistency
- [x] Shared `compute_duplicate_updates` (workspace + copy_fields branches) and mongodb-refactor regression
- [x] CLI `--driver sqlite` choice + delete branches
- [x] Manual smoke: `secator x httpx <target> -driver sqlite` then `secator report show -driver sqlite`

## Known follow-ups (out of scope)
- `SqliteAddon.enabled` is defined for config-shape parity but not yet wired into the worker uuid-passing memory optimization that mongodb's `enabled` gates (sqlite always ships full result objects).
- `tag_duplicates` (sqlite) is a `@shared_task` but not yet added to Celery autodiscovery/routing — latent only, since `find_duplicates` is not wired into HOOKS for either driver (cross-run dedup is not auto-triggered today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQLite as a backend driver option for storing and querying scan results locally
  * Extended CLI commands (`workspace delete`, `reports show`, `reports delete`) with SQLite driver support
  * Implemented duplicate finding detection and management for SQLite-stored data
  * Added SQLite configuration options for database path, timeout, and field management

* **Tests**
  * Added comprehensive test coverage for SQLite backend, CLI integration, and deduplication functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->