### PR TITLE
feat(driver): proper support for all backends in CLI commands (`r list`, `r info`, `query`, ...)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -418,6 +418,10 @@ def _handle_query(action: Dict, ctx: ActionContext) -> Generator:
 			if isinstance(result, OutputType):
 				result = result.toDict()
 			result["_context"].update(context)
+			# Query results are existing workspace findings surfaced for the AI's
+			# observation only — mark them so the runner doesn't re-yield/re-report
+			# them (which would duplicate them back into the workspace).
+			result.setdefault("_context", {})["ai_query_result"] = True
 			yield result
 
 	except Exception as e:

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -5,6 +5,8 @@ import shutil
 import subprocess
 import sys
 
+import yaml
+
 from pathlib import Path
 from stat import S_ISFIFO
 
@@ -786,12 +788,18 @@ def workspace_list(driver):
 
 	if effective_driver in ('mongodb', 'api'):
 		workspaces = engine.list_workspaces()
-		table.add_column('Workspace name', style='bold gold3')
+		table.add_column('Name', style='bold gold3')
+		table.add_column('Id', style='dim cyan')
+		table.add_column('Description', style='dim cyan')
+		table.add_column('Run count', overflow='fold')
 		table.add_column('Findings count', overflow='fold')
 		for ws in workspaces:
-			ws_name = ws.get('workspace_id') or ws.get('workspace_name', '')
-			count = str(ws.get('count', ''))
-			table.add_row(ws_name, count)
+			ws_name = ws.get('name', '') or ws.get('_id', '')
+			ws_id = ws.get('_id', '')
+			ws_description = ws.get('description')
+			runners_count = str(ws.get('runners_count', '?'))
+			findings_count = str(ws.get('findings_count', '?'))
+			table.add_row(ws_name, ws_id, ws_description, runners_count, findings_count)
 	else:
 		workspaces_dict = {}
 		reports_dir = Path(CONFIG.dirs.reports)
@@ -811,7 +819,7 @@ def workspace_list(driver):
 			if ws not in workspaces_dict:
 				workspaces_dict[ws] = {'count': 0, 'path': '/'.join(str(path).split('/')[:-3])}
 			workspaces_dict[ws]['count'] += 1
-		table.add_column('Workspace name', style='bold gold3')
+		table.add_column('Name', style='bold gold3')
 		table.add_column('Run count', overflow='fold')
 		table.add_column('Path')
 		for workspace, config in workspaces_dict.items():
@@ -1473,12 +1481,18 @@ def _format_vuln_counts(counts):
 @click.option('--show-all', is_flag=True, default=False, help='Show all columns including report path')
 @click.option('--interesting', '-i', is_flag=True, default=False, help='Only show reports that have vulnerabilities')
 @click.option('--status', type=str, default=None, help="Filter by runner status (case-insensitive regex, e.g. SUCCESS, FAIL, '(RUNNING|FAILURE)')")  # noqa: E501
+@click.option('--show-children', is_flag=True, default=False, help='Include nested sub-tasks / sub-workflows (by default only outermost runners are shown)')  # noqa: E501
 @click.pass_context
-def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, interesting, status):
+def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, interesting, status, show_children):
 	"""List all secator reports."""
 	from secator.query import QueryEngine
 
 	effective_driver = driver or CONFIG.backends.current
+
+	# --show-children only applies to the mongodb/api backends, which persist nested
+	# runners. Local JSON reports don't store sub-tasks/sub-workflows separately.
+	if show_children and effective_driver not in ('mongodb', 'api'):
+		console.print(Warning(message='--show-children has no effect with the local driver: sub-tasks/sub-workflows are not stored in local reports.'))  # noqa: E501
 
 	# --status is matched as a case-insensitive regex (e.g. 'FAIL' -> FAILURE, '(RUNNING|FAILURE)')
 	status_pattern = None
@@ -1492,18 +1506,18 @@ def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, inter
 	# Build table. overflow='fold' wraps long values onto multiple lines instead of
 	# truncating with an ellipsis, so important fields stay readable on small screens.
 	table = Table()
-	table.add_column("Workspace", style="bold gold3", overflow="fold")
-	table.add_column("Name", overflow="fold")
-	table.add_column("Id", overflow="fold")
-	table.add_column("Target", overflow="fold")
-	table.add_column("Profiles", overflow="fold")
-	table.add_column("Start Date", overflow="fold")
-	table.add_column("End Date", overflow="fold")
-	table.add_column("Elapsed", overflow="fold")
-	table.add_column("Status", style="green", overflow="fold")
-	table.add_column("Vulnerabilities", overflow="fold")
+	table.add_column('Workspace', style='bold gold3', overflow='fold')
+	table.add_column('Name', overflow='fold')
+	table.add_column('Id', overflow='fold')
+	table.add_column('Target', overflow='fold')
+	table.add_column('Profiles', overflow='fold')
+	table.add_column('Start Date', overflow='fold')
+	table.add_column('End Date', overflow='fold')
+	table.add_column('Elapsed', overflow='fold')
+	table.add_column('Status', style='green', overflow='fold')
+	table.add_column('Vulnerabilities', overflow='fold')
 	if show_all:
-		table.add_column('Path', overflow="fold")
+		table.add_column('Path', overflow='fold')
 
 	shown = 0
 
@@ -1511,7 +1525,10 @@ def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, inter
 		# Use QueryEngine backend to list runners
 		context = {'drivers': [effective_driver]}
 		engine = QueryEngine(workspace_id=workspace or '', context=context)
-		runners = engine.list_runners(workspace_id=workspace, runner_type=runner_type)
+		# By default only list outermost runners (has_parent=False). --show-children
+		# drops the filter so nested sub-tasks/sub-workflows are shown too.
+		has_parent = None if show_children else False
+		runners = engine.list_runners(workspace_id=workspace, runner_type=runner_type, has_parent=has_parent)
 		for runner_info in runners:
 			runner_status = runner_info.get('status', '')
 			status_color = STATE_COLORS.get(runner_status, 'white')
@@ -1524,9 +1541,17 @@ def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, inter
 			profiles = runner_info.get('run_opts', {}).get('profiles', [])
 			if isinstance(profiles, str):
 				profiles = [p.strip() for p in profiles.split(',') if p.strip()]
+			profiles = [p for p in profiles if p]
 			profiles_str = ', '.join(profiles) if profiles else ''
-			runner_id = runner_info.get('_id_str', runner_info.get('_type', ''))
-			ws_name = runner_info.get('_workspace', workspace or '')
+			# Show the id as {runner_type}/{runner_id} so it can be passed to `secator r info`.
+			runner_id = runner_info.get('_id_str')
+			if not runner_id:
+				rtype = runner_info.get('_type') or runner_info.get('config', {}).get('type', '')
+				if rtype and not rtype.endswith('s'):
+					rtype += 's'
+				raw_id = runner_info.get('_id', '')
+				runner_id = f'{rtype}/{raw_id}' if rtype and raw_id else (raw_id or rtype)
+			ws_name = runner_info.get('context', {}).get('workspace_name') or runner_info.get('_workspace', workspace or '')
 			row = [
 				ws_name,
 				f'[bold blue]{runner_info.get("name", "")}[/]',
@@ -1536,7 +1561,7 @@ def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, inter
 				humanize_date(runner_info.get('start_time')),
 				humanize_date(runner_info.get('end_time')),
 				runner_info.get('elapsed_human', ''),
-				f"[{status_color}]{runner_status}[/]",
+				f'[{status_color}]{runner_status}[/]',
 				'-',
 			]
 			if show_all:
@@ -1575,7 +1600,7 @@ def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, inter
 					humanize_date(report_info.get('start_time')),
 					humanize_date(report_info.get('end_time')),
 					report_info.get('elapsed_human', ''),
-					f"[{status_color}]{runner_status}[/]",
+					f'[{status_color}]{runner_status}[/]',
 					_format_vuln_counts(vuln_counts),
 				]
 				if show_all:
@@ -1599,11 +1624,13 @@ def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, inter
 @report.command('info')
 @click.argument('runner_id', type=str)
 @click.option('-ws', '-w', '--workspace', type=str, default=None, help='Workspace name')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default=None, help='Query backend driver')
 @click.option('--show-all', is_flag=True, default=False, help='Show all entries (do not truncate lists/dicts or errors)')  # noqa: E501
-def report_info(runner_id, workspace, show_all):
+def report_info(runner_id, workspace, driver, show_all):
 	"""Show runner info from a report. RUNNER_ID: runner path (e.g. scans/0)"""
 	MAX_ENTRIES = 20
 
+	effective_driver = driver or CONFIG.backends.current
 	workspace_name = workspace or CONFIG.workspace.default or 'default'
 	parts = runner_id.split('/')
 	if len(parts) != 2:
@@ -1612,21 +1639,49 @@ def report_info(runner_id, workspace, show_all):
 	runner_type, runner_number = parts[0], parts[1]
 	if not runner_type.endswith('s'):
 		runner_type += 's'
+	runner_type_singular = runner_type.rstrip('s')
 
-	report_path = Path(CONFIG.dirs.reports) / sanitize_folder_name(workspace_name) / runner_type / runner_number / 'report.json'  # noqa: E501
-	if not report_path.exists():
-		console.print(Error(message=f'Report not found: {report_path}'))
-		return
+	if effective_driver in ('mongodb', 'api'):
+		# Fetch the runner from the remote/db backend (e.g. /runner/<id>?type=<type>)
+		from secator.query import QueryEngine
 
-	with open(report_path, 'r') as f:
-		content = json.loads(f.read())
+		context = {'drivers': [effective_driver]}
+		engine = QueryEngine(workspace_id=workspace or '', context=context)
+		runner_info = engine.get_runner(runner_number, runner_type=runner_type_singular)
+		if not runner_info:
+			console.print(Error(message=f'Runner not found: {runner_id} (driver: {effective_driver})'))
+			return
+		info = dict(runner_info)
+		info.pop('_id', None)
+		source_label, source_value = '_source', f'{effective_driver}:{runner_type}/{runner_number}'
+	else:
+		report_path = Path(CONFIG.dirs.reports) / sanitize_folder_name(workspace_name) / runner_type / runner_number / 'report.json'  # noqa: E501
+		if not report_path.exists():
+			console.print(Error(message=f'Report not found: {report_path}'))
+			return
 
-	info = dict(content.get('info', {}))
+		with open(report_path, 'r') as f:
+			content = json.loads(f.read())
+
+		info = dict(content.get('info', {}))
+		source_label, source_value = '_path', str(report_path)
+
 	errors_raw = info.pop('errors', [])
+	warnings_raw = info.pop('warnings', [])
+
+	# These fields are verbose and only shown with --show-all.
+	SHOW_ALL_ONLY_KEYS = ('config', 'output')
 
 	table = Table(title=f'Info: {runner_id}', show_header=False, box=None, padding=(0, 1))
 	table.add_column('Key', style='bold gold3', no_wrap=True)
 	table.add_column('Value')
+
+	from rich.syntax import Syntax
+
+	def _render_yaml(data):
+		"""Render a dict as syntax-highlighted YAML for readability."""
+		yaml_str = yaml.dump(data, sort_keys=False, default_flow_style=False).rstrip()
+		return Syntax(yaml_str, 'yaml', theme='ansi-dark', padding=0, background_color='default')
 
 	def _format_value(value):
 		if isinstance(value, list):
@@ -1637,19 +1692,20 @@ def report_info(runner_id, workspace, show_all):
 				items = value
 				tail = ''
 			return '\n'.join(str(v) for v in items) + tail
-		if isinstance(value, dict):
-			if not show_all and len(value) > MAX_ENTRIES:
-				pairs = list(value.items())[:MAX_ENTRIES]
-				tail = f'\n[dim]... and {len(value) - MAX_ENTRIES} more (use --show-all to see all)[/]'
-			else:
-				pairs = list(value.items())
-				tail = ''
-			return '\n'.join(f'[bold]{k}[/]: {v}' for k, v in pairs) + tail
 		return str(value) if value is not None else ''
 
-	table.add_row('_path', str(report_path))
+	table.add_row(source_label, source_value)
 	for key, value in info.items():
-		table.add_row(key, _format_value(value))
+		if key in SHOW_ALL_ONLY_KEYS and not show_all:
+			continue
+		# Render any dict value as syntax-highlighted YAML. For config, drop the
+		# verbose 'opts' key (full option schema) first.
+		if isinstance(value, dict):
+			data = {k: v for k, v in value.items() if k != 'opts'} if key == 'config' else value
+			rendered = _render_yaml(data)
+		else:
+			rendered = _format_value(value)
+		table.add_row(key, rendered)
 
 	console.print(table)
 
@@ -1671,6 +1727,22 @@ def report_info(runner_id, workspace, show_all):
 	else:
 		console.print()
 		console.print('[dim]No errors.[/]')
+
+	# Display warnings as Warning output types
+	if warnings_raw:
+		warnings_to_show = warnings_raw if show_all else warnings_raw[-1:]
+		console.print()
+		extra = ', showing last 1' if not show_all and len(warnings_raw) > 1 else ''
+		console.print(f'[bold]Warnings[/] ({len(warnings_raw)} total{extra}):')
+		for warn_data in warnings_to_show:
+			if isinstance(warn_data, dict):
+				try:
+					warn = Warning.load(warn_data)
+				except (KeyError, TypeError, ValueError):
+					warn = Warning(message=str(warn_data))
+			else:
+				warn = Warning(message=str(warn_data))
+			console.print(warn)
 
 
 def _resolve_runner_db_id(report_folder, runner_type_singular):
@@ -1788,7 +1860,12 @@ def report_delete(runner_ids, workspace, driver, yes):
 
 	for runner_type_plural, runner_type_singular, runner_number, runner_db_id in resolved:
 		_delete_one_report(
-			workspace_name, runner_type_plural, runner_type_singular, runner_number, runner_db_id, driver,
+			workspace_name,
+			runner_type_plural,
+			runner_type_singular,
+			runner_number,
+			runner_db_id,
+			driver,
 		)
 
 
@@ -2404,6 +2481,7 @@ def _load_external_addon_commands():
 			@click.command(name, help=f'Install {name} addon.')
 			def _cmd():
 				_install_external_addon(name, config)
+
 			return _cmd
 
 		addons.add_command(_make_cmd(addon_name, addon_config))

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1333,8 +1333,10 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	drivers = [driver] if driver and driver != 'local' else []
 	# Resolve the workspace name to its id for the API backend (findings are filtered
 	# by the real workspace id; the local/mongodb backends key findings by name).
+	# Mirror QueryEngine._select_backend: an explicit mongodb/api driver wins,
+	# otherwise (None/'local') the configured default backend is used.
 	workspace_id = workspace_name
-	effective_driver = driver or CONFIG.backends.current
+	effective_driver = driver if driver in ('mongodb', 'api') else CONFIG.backends.current
 	if effective_driver == 'api':
 		try:
 			from secator.hooks.api import resolve_workspace

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -778,8 +778,6 @@ def workspace():
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default=None, help='Query backend driver')
 def workspace_list(driver):
 	"""List workspaces"""
-	from secator.query import QueryEngine
-
 	effective_driver = QueryEngine.resolve_backend(driver)
 	context = {'drivers': [effective_driver] if effective_driver and effective_driver != 'local' else []}
 	engine = QueryEngine(workspace_id='', context=context)
@@ -1510,8 +1508,6 @@ def _format_vuln_counts(counts):
 @click.pass_context
 def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, interesting, status, show_children):
 	"""List all secator reports."""
-	from secator.query import QueryEngine
-
 	effective_driver = QueryEngine.resolve_backend(driver)
 
 	# --show-children only applies to the mongodb/api backends, which persist nested
@@ -1668,8 +1664,6 @@ def report_info(runner_id, workspace, driver, show_all):
 
 	if effective_driver in ('mongodb', 'api'):
 		# Fetch the runner from the remote/db backend (e.g. /runner/<id>?type=<type>)
-		from secator.query import QueryEngine
-
 		context = {'drivers': [effective_driver]}
 		engine = QueryEngine(workspace_id=workspace or '', context=context)
 		runner_info = engine.get_runner(runner_number, runner_type=runner_type_singular)

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1547,6 +1547,10 @@ def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, inter
 	shown = 0
 
 	if effective_driver in ('mongodb', 'api'):
+		# --interesting and --time-delta are only supported by the local driver.
+		unsupported = [opt for opt, val in (('--interesting', interesting), ('--time-delta', time_delta)) if val]
+		if unsupported:
+			console.print(Warning(message=f'{", ".join(unsupported)} {"is" if len(unsupported) == 1 else "are"} only supported with the local driver and will be ignored for the {effective_driver} driver.'))  # noqa: E501
 		# Use QueryEngine backend to list runners
 		context = {'drivers': [effective_driver]}
 		engine = QueryEngine(workspace_id=workspace or '', context=context)

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -851,11 +851,23 @@ def workspace_current():
 
 @workspace.command(name='rm', aliases=['remove', 'delete'])
 @click.argument('name')
-@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default=None, help='Query backend driver')
 @click.option('-y', '--yes', is_flag=True, default=False, help='Skip confirmation prompt')
 def workspace_delete(name, driver, yes):
 	"""Delete a workspace and all associated reports. NAME: workspace name"""
+	driver = driver or CONFIG.backends.current
 	workspace_folder = Path(CONFIG.dirs.reports) / sanitize_folder_name(name)
+
+	# The API keys workspaces by id, so resolve the name to its id for the api driver.
+	api_workspace_id = name
+	if driver == 'api':
+		try:
+			from secator.hooks.api import resolve_workspace
+
+			api_workspace_id, _ = resolve_workspace(name)
+		except Exception as e:
+			console.print(Error(message=f'Error resolving workspace from API: {e}'))
+			return
 
 	actions = []
 	if workspace_folder.exists():
@@ -867,7 +879,7 @@ def workspace_delete(name, driver, yes):
 		actions.append(f'Delete all findings in MongoDB with workspace_id="{name}"')
 		actions.append(f'Delete all runners in MongoDB with workspace_id="{name}"')
 	elif driver == 'api':
-		actions.append(f'Send DELETE to API: {CONFIG.addons.api.workspace_delete_endpoint.format(workspace_id=name)}')
+		actions.append(f'Send DELETE to API: {CONFIG.addons.api.workspace_delete_endpoint.format(workspace_id=api_workspace_id)}')  # noqa: E501
 
 	console.print('[bold]The following actions will be performed:[/]')
 	for action in actions:
@@ -904,7 +916,7 @@ def workspace_delete(name, driver, yes):
 		try:
 			from secator.hooks.api import _make_request
 
-			endpoint = CONFIG.addons.api.workspace_delete_endpoint.format(workspace_id=name)
+			endpoint = CONFIG.addons.api.workspace_delete_endpoint.format(workspace_id=api_workspace_id)
 			_make_request('DELETE', endpoint)
 			console.print(Info(message=f'Deleted workspace "{name}" from API'))
 		except Exception as e:
@@ -1816,7 +1828,7 @@ def _delete_one_report(workspace_name, runner_type_plural, runner_type_singular,
 @report.command(name='delete', aliases=['rm', 'remove'])
 @click.argument('runner_ids', nargs=-1, required=True)
 @click.option('-ws', '-w', '--workspace', type=str, default=None, help='Workspace name')
-@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default=None, help='Query backend driver')
 @click.option('-y', '--yes', is_flag=True, default=False, help='Skip confirmation prompt')
 def report_delete(runner_ids, workspace, driver, yes):
 	"""Delete one or more reports.
@@ -1827,6 +1839,7 @@ def report_delete(runner_ids, workspace, driver, yes):
 	"""
 	from secator.query.utils import expand_runner_paths
 
+	driver = driver or CONFIG.backends.current
 	workspace_name = workspace or CONFIG.workspace.default or 'default'
 
 	refs, errors = expand_runner_paths(list(runner_ids))

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1331,6 +1331,18 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 
 	# 5. Build runner context for QueryEngine backend selection
 	drivers = [driver] if driver and driver != 'local' else []
+	# Resolve the workspace name to its id for the API backend (findings are filtered
+	# by the real workspace id; the local/mongodb backends key findings by name).
+	workspace_id = workspace_name
+	effective_driver = driver or CONFIG.backends.current
+	if effective_driver == 'api':
+		try:
+			from secator.hooks.api import resolve_workspace
+
+			workspace_id, workspace_name = resolve_workspace(workspace_name)
+		except Exception as e:
+			console.print(Error(message=f'Error resolving workspace from API: {e}'))
+			return
 	runner = DotMap(
 		{
 			'config': DotMap({'name': f'consolidated_report_{current}', 'type': 'consolidated'}),
@@ -1338,7 +1350,7 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 			'workspace_name': workspace_name,
 			'errors': [],
 			'context': {
-				'workspace_id': workspace_name,
+				'workspace_id': workspace_id,
 				'workspace_name': workspace_name,
 				'drivers': drivers,
 			},

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1115,7 +1115,9 @@ def report():
 
 # Operators / tokens that mark a string as a filter expression rather than natural language.
 _QUERY_EXPR_OPERATORS = ('==', '!=', '<=', '>=', '~=', '<', '>', '&&', '||')
-_QUERY_EXPR_WORD_OPERATORS = (' and ', ' or ', ' in ')
+# 'field in [...]' list-membership operator. Require the bracket so plain English
+# "in" (e.g. "what's in my workspace?") is not mistaken for a query expression.
+_QUERY_EXPR_IN_RE = re.compile(r'\bin\s*\[')
 
 
 def _looks_like_query_expr(value):
@@ -1123,15 +1125,19 @@ def _looks_like_query_expr(value):
 
 	Heuristics (any match => expression):
 	  - contains a comparison/logical operator (==, !=, <, >, <=, >=, ~=, &&, ||)
-	  - contains a word operator surrounded by spaces ( and / or / in )
+	  - contains the 'in [' list-membership operator (e.g. tags in [x, y])
 	  - matches a bare dotted field-access path like 'word.word' (e.g. extra_data.published)
 	  - is a bare known output type name (url, vulnerability, domain, etc.)
+
+	Note: the word operators 'and' / 'or' are intentionally not matched on their own —
+	they always connect comparison clauses, which are already caught above, so matching
+	them standalone would misclassify natural-language prompts (e.g. "subdomains and ips").
 	"""
 	if not value:
 		return False
 	if any(op in value for op in _QUERY_EXPR_OPERATORS):
 		return True
-	if any(op in value for op in _QUERY_EXPR_WORD_OPERATORS):
+	if _QUERY_EXPR_IN_RE.search(value):
 		return True
 	if re.fullmatch(r'\w+(?:\.\w+)+', value.strip()):
 		return True

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1855,7 +1855,12 @@ def report_delete(runner_ids, workspace, driver, yes):
 	console.print('[bold]The following actions will be performed:[/]')
 	for runner_type_plural, runner_type_singular, runner_number in refs:
 		report_folder = Path(CONFIG.dirs.reports) / sanitize_folder_name(workspace_name) / runner_type_plural / runner_number
-		runner_db_id = _resolve_runner_db_id(report_folder, runner_type_singular)
+		if runner_number.isdigit():
+			# Local report: resolve the backend id from the report's context.
+			runner_db_id = _resolve_runner_db_id(report_folder, runner_type_singular)
+		else:
+			# Backend id passed directly (e.g. an ObjectId from `r list --driver api`).
+			runner_db_id = runner_number
 		resolved.append((runner_type_plural, runner_type_singular, runner_number, runner_db_id))
 
 		if report_folder.exists():

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1787,12 +1787,13 @@ def _delete_one_report(workspace_name, runner_type_plural, runner_type_singular,
 	"""Perform the actual deletion for a single runner reference."""
 	report_folder = Path(CONFIG.dirs.reports) / sanitize_folder_name(workspace_name) / runner_type_plural / runner_number
 
-	# 1. Remove report folder
-	if report_folder.exists():
-		shutil.rmtree(report_folder)
-		console.print(Info(message=f'Removed report folder: {report_folder}'))
-	else:
-		console.print(Warning(message=f'Report folder not found: {report_folder}'))
+	# 1. Remove report folder (local driver only; api/mongodb delete from the backend)
+	if driver == 'local':
+		if report_folder.exists():
+			shutil.rmtree(report_folder)
+			console.print(Info(message=f'Removed report folder: {report_folder}'))
+		else:
+			console.print(Warning(message=f'Report folder not found: {report_folder}'))
 
 	# 2. MongoDB backend
 	if driver == 'mongodb' and runner_db_id:
@@ -1863,10 +1864,11 @@ def report_delete(runner_ids, workspace, driver, yes):
 			runner_db_id = runner_number
 		resolved.append((runner_type_plural, runner_type_singular, runner_number, runner_db_id))
 
-		if report_folder.exists():
-			console.print(f'  [dim]-[/] Remove report folder: {report_folder}')
-		else:
-			console.print(f'  [dim]-[/] [dim]Report folder not found (will skip): {report_folder}[/]')
+		if driver == 'local':
+			if report_folder.exists():
+				console.print(f'  [dim]-[/] Remove report folder: {report_folder}')
+			else:
+				console.print(f'  [dim]-[/] [dim]Report folder not found (will skip): {report_folder}[/]')
 
 		if driver == 'mongodb':
 			if runner_db_id:

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -25,6 +25,7 @@ from secator.cli_helper import register_runner
 from secator.definitions import ADDONS_ENABLED, ASCII, DEV_PACKAGE, VERSION, STATE_COLORS
 from secator.installer import ToolInstaller, fmt_health_table_row, get_health_table, get_version_info, get_distro_config
 from secator.output_types import FINDING_TYPES, Info, Warning, Error
+from secator.query import QueryEngine
 from secator.report import Report
 from secator.rich import console
 from secator.runners import Command, Runner
@@ -779,7 +780,7 @@ def workspace_list(driver):
 	"""List workspaces"""
 	from secator.query import QueryEngine
 
-	effective_driver = driver or CONFIG.backends.current
+	effective_driver = QueryEngine.resolve_backend(driver)
 	context = {'drivers': [effective_driver] if effective_driver and effective_driver != 'local' else []}
 	engine = QueryEngine(workspace_id='', context=context)
 
@@ -855,7 +856,7 @@ def workspace_current():
 @click.option('-y', '--yes', is_flag=True, default=False, help='Skip confirmation prompt')
 def workspace_delete(name, driver, yes):
 	"""Delete a workspace and all associated reports. NAME: workspace name"""
-	driver = driver or CONFIG.backends.current
+	driver = QueryEngine.resolve_backend(driver)
 	workspace_folder = Path(CONFIG.dirs.reports) / sanitize_folder_name(name)
 
 	# The API keys workspaces by id, so resolve the name to its id for the api driver.
@@ -1346,7 +1347,7 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	# Resolve the workspace name to its id for the API backend (findings are filtered
 	# by the real workspace id; the local/mongodb backends key findings by name).
 	workspace_id = workspace_name
-	effective_driver = driver or CONFIG.backends.current
+	effective_driver = QueryEngine.resolve_backend(driver)
 	if effective_driver == 'api':
 		try:
 			from secator.hooks.api import resolve_workspace
@@ -1511,7 +1512,7 @@ def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, inter
 	"""List all secator reports."""
 	from secator.query import QueryEngine
 
-	effective_driver = driver or CONFIG.backends.current
+	effective_driver = QueryEngine.resolve_backend(driver)
 
 	# --show-children only applies to the mongodb/api backends, which persist nested
 	# runners. Local JSON reports don't store sub-tasks/sub-workflows separately.
@@ -1654,7 +1655,7 @@ def report_info(runner_id, workspace, driver, show_all):
 	"""Show runner info from a report. RUNNER_ID: runner path (e.g. scans/0)"""
 	MAX_ENTRIES = 20
 
-	effective_driver = driver or CONFIG.backends.current
+	effective_driver = QueryEngine.resolve_backend(driver)
 	workspace_name = workspace or CONFIG.workspace.default or 'default'
 	parts = runner_id.split('/')
 	if len(parts) != 2:
@@ -1840,7 +1841,7 @@ def report_delete(runner_ids, workspace, driver, yes):
 	"""
 	from secator.query.utils import expand_runner_paths
 
-	driver = driver or CONFIG.backends.current
+	driver = QueryEngine.resolve_backend(driver)
 	workspace_name = workspace or CONFIG.workspace.default or 'default'
 
 	refs, errors = expand_runner_paths(list(runner_ids))

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -772,38 +772,52 @@ def workspace():
 
 
 @workspace.command('list')
-def workspace_list():
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default=None, help='Query backend driver')
+def workspace_list(driver):
 	"""List workspaces"""
-	workspaces = {}
-	reports_dir = Path(CONFIG.dirs.reports)
-	# Discover all workspace directories (including empty ones)
-	if reports_dir.exists():
-		for child in sorted(reports_dir.iterdir()):
-			if child.is_dir():
-				workspaces[child.name] = {'count': 0, 'path': str(child)}
-	# Count reports per workspace
-	json_reports = []
-	for root, _, files in os.walk(CONFIG.dirs.reports):
-		for file in files:
-			if file.endswith('report.json'):
-				path = Path(root) / file
-				json_reports.append(path)
-	json_reports = sorted(json_reports, key=lambda x: x.stat().st_mtime, reverse=False)
-	for path in json_reports:
-		ws, runner_type, number = str(path).split('/')[-4:-1]
-		if ws not in workspaces:
-			workspaces[ws] = {'count': 0, 'path': '/'.join(str(path).split('/')[:-3])}
-		workspaces[ws]['count'] += 1
+	from secator.query import QueryEngine
 
-	# Build table
+	effective_driver = driver or CONFIG.backends.current
+	context = {'drivers': [effective_driver] if effective_driver and effective_driver != 'local' else []}
+	engine = QueryEngine(workspace_id='', context=context)
+
 	table = Table()
-	table.add_column('Workspace name', style='bold gold3')
-	table.add_column('Run count', overflow='fold')
-	table.add_column('Path')
-	for workspace, config in workspaces.items():
-		table.add_row(workspace, str(config['count']), config['path'])
-	console.print(table)
 	current = CONFIG.workspace.default or 'default'
+
+	if effective_driver in ('mongodb', 'api'):
+		workspaces = engine.list_workspaces()
+		table.add_column('Workspace name', style='bold gold3')
+		table.add_column('Findings count', overflow='fold')
+		for ws in workspaces:
+			ws_name = ws.get('workspace_id') or ws.get('workspace_name', '')
+			count = str(ws.get('count', ''))
+			table.add_row(ws_name, count)
+	else:
+		workspaces_dict = {}
+		reports_dir = Path(CONFIG.dirs.reports)
+		if reports_dir.exists():
+			for child in sorted(reports_dir.iterdir()):
+				if child.is_dir():
+					workspaces_dict[child.name] = {'count': 0, 'path': str(child)}
+		json_reports = []
+		for root, _, files in os.walk(CONFIG.dirs.reports):
+			for file in files:
+				if file.endswith('report.json'):
+					path = Path(root) / file
+					json_reports.append(path)
+		json_reports = sorted(json_reports, key=lambda x: x.stat().st_mtime, reverse=False)
+		for path in json_reports:
+			ws, runner_type, number = str(path).split('/')[-4:-1]
+			if ws not in workspaces_dict:
+				workspaces_dict[ws] = {'count': 0, 'path': '/'.join(str(path).split('/')[:-3])}
+			workspaces_dict[ws]['count'] += 1
+		table.add_column('Workspace name', style='bold gold3')
+		table.add_column('Run count', overflow='fold')
+		table.add_column('Path')
+		for workspace, config in workspaces_dict.items():
+			table.add_row(workspace, str(config['count']), config['path'])
+
+	console.print(table)
 	console.print(Info(message=f'Current workspace: [bold gold3]{current}[/]. Use [bold green4]secator ws use <workspace>[/] to switch.'))  # noqa: E501
 
 
@@ -1455,14 +1469,16 @@ def _format_vuln_counts(counts):
 @click.option('-ws', '-w', '--workspace', type=str)
 @click.option('-r', '--runner-type', type=str, default=None, help='Filter by runner type. Choices: task, workflow, scan')  # noqa: E501
 @click.option('-d', '--time-delta', type=str, default=None, help='Keep results newer than time delta. E.g: 26m, 1d, 1y')  # noqa: E501
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default=None, help='Query backend driver')
 @click.option('--show-all', is_flag=True, default=False, help='Show all columns including report path')
 @click.option('--interesting', '-i', is_flag=True, default=False, help='Only show reports that have vulnerabilities')
 @click.option('--status', type=str, default=None, help="Filter by runner status (case-insensitive regex, e.g. SUCCESS, FAIL, '(RUNNING|FAILURE)')")  # noqa: E501
 @click.pass_context
-def report_list(ctx, workspace, runner_type, time_delta, show_all, interesting, status):
+def report_list(ctx, workspace, runner_type, time_delta, driver, show_all, interesting, status):
 	"""List all secator reports."""
-	paths = list_reports(workspace=workspace, type=runner_type, timedelta=human_to_timedelta(time_delta))
-	paths = sorted(paths, key=lambda x: x.stat().st_mtime, reverse=False)
+	from secator.query import QueryEngine
+
+	effective_driver = driver or CONFIG.backends.current
 
 	# --status is matched as a case-insensitive regex (e.g. 'FAIL' -> FAILURE, '(RUNNING|FAILURE)')
 	status_pattern = None
@@ -1489,45 +1505,85 @@ def report_list(ctx, workspace, runner_type, time_delta, show_all, interesting, 
 	if show_all:
 		table.add_column('Path', overflow="fold")
 
-	# Load each report
 	shown = 0
-	for path in paths:
-		try:
-			path_info = get_info_from_report_path(path)
-			report_info, vuln_counts = _load_report_data(path)
-			if not _report_passes_filters(report_info, vuln_counts, interesting, status_pattern):
+
+	if effective_driver in ('mongodb', 'api'):
+		# Use QueryEngine backend to list runners
+		context = {'drivers': [effective_driver]}
+		engine = QueryEngine(workspace_id=workspace or '', context=context)
+		runners = engine.list_runners(workspace_id=workspace, runner_type=runner_type)
+		for runner_info in runners:
+			runner_status = runner_info.get('status', '')
+			status_color = STATE_COLORS.get(runner_status, 'white')
+			if status_pattern and not status_pattern.search(str(runner_status)):
 				continue
-			runner_id = path_info['type'] + '/' + path_info['id']
-			targets = report_info.get('targets', [])
+			targets = runner_info.get('targets', [])
 			first_target = str(targets[0]) if targets else ''
 			if len(targets) > 1:
 				first_target += f' (+{len(targets) - 1})'
-			profiles = report_info.get('run_opts', {}).get('profiles', [])
+			profiles = runner_info.get('run_opts', {}).get('profiles', [])
 			if isinstance(profiles, str):
 				profiles = [p.strip() for p in profiles.split(',') if p.strip()]
 			profiles_str = ', '.join(profiles) if profiles else ''
-			runner_status = report_info.get('status', '')
-			status_color = STATE_COLORS[runner_status] if runner_status in STATE_COLORS else 'white'
-
-			# Update table
+			runner_id = runner_info.get('_id_str', runner_info.get('_type', ''))
+			ws_name = runner_info.get('_workspace', workspace or '')
 			row = [
-				path_info['workspace'],
-				f'[bold blue]{report_info.get("name", "")}[/]',
-				f'[link={Path(path).as_uri()}]{runner_id}[/link]',
+				ws_name,
+				f'[bold blue]{runner_info.get("name", "")}[/]',
+				runner_id,
 				first_target,
 				profiles_str,
-				humanize_date(report_info.get('start_time')),
-				humanize_date(report_info.get('end_time')),
-				report_info.get('elapsed_human', ''),
+				humanize_date(runner_info.get('start_time')),
+				humanize_date(runner_info.get('end_time')),
+				runner_info.get('elapsed_human', ''),
 				f"[{status_color}]{runner_status}[/]",
-				_format_vuln_counts(vuln_counts),
+				'-',
 			]
 			if show_all:
-				row.append(str(path))
+				row.append('')
 			table.add_row(*row)
 			shown += 1
-		except Exception as e:
-			console.print(Error(message=f'Could not load {path}: {str(e)}'))
+	else:
+		# Local filesystem listing
+		paths = list_reports(workspace=workspace, type=runner_type, timedelta=human_to_timedelta(time_delta))
+		paths = sorted(paths, key=lambda x: x.stat().st_mtime, reverse=False)
+
+		for path in paths:
+			try:
+				path_info = get_info_from_report_path(path)
+				report_info, vuln_counts = _load_report_data(path)
+				if not _report_passes_filters(report_info, vuln_counts, interesting, status_pattern):
+					continue
+				runner_id = path_info['type'] + '/' + path_info['id']
+				targets = report_info.get('targets', [])
+				first_target = str(targets[0]) if targets else ''
+				if len(targets) > 1:
+					first_target += f' (+{len(targets) - 1})'
+				profiles = report_info.get('run_opts', {}).get('profiles', [])
+				if isinstance(profiles, str):
+					profiles = [p.strip() for p in profiles.split(',') if p.strip()]
+				profiles_str = ', '.join(profiles) if profiles else ''
+				runner_status = report_info.get('status', '')
+				status_color = STATE_COLORS[runner_status] if runner_status in STATE_COLORS else 'white'
+
+				row = [
+					path_info['workspace'],
+					f'[bold blue]{report_info.get("name", "")}[/]',
+					f'[link={Path(path).as_uri()}]{runner_id}[/link]',
+					first_target,
+					profiles_str,
+					humanize_date(report_info.get('start_time')),
+					humanize_date(report_info.get('end_time')),
+					report_info.get('elapsed_human', ''),
+					f"[{status_color}]{runner_status}[/]",
+					_format_vuln_counts(vuln_counts),
+				]
+				if show_all:
+					row.append(str(path))
+				table.add_row(*row)
+				shown += 1
+			except Exception as e:
+				console.print(Error(message=f'Could not load {path}: {str(e)}'))
 
 	if shown > 0:
 		console.print(table)

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1064,7 +1064,7 @@ def list_aliases(silent):
 @click.option('-d', '--time-delta', type=str, default=None, help='Keep results newer than time delta. E.g: 26m, 1d, 1y')  # noqa: E501
 @click.option('--format', '-f', 'fmt', type=str, default=None, help="Format string for results, e.g. '{vulnerability.matched_at}'")  # noqa: E501
 @click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
-@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default=None, help='Query backend driver')
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.option('-l', '--limit', type=int, default=0, help='Limit number of results (0 = no limit)')
 @click.pass_context
@@ -1333,10 +1333,8 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	drivers = [driver] if driver and driver != 'local' else []
 	# Resolve the workspace name to its id for the API backend (findings are filtered
 	# by the real workspace id; the local/mongodb backends key findings by name).
-	# Mirror QueryEngine._select_backend: an explicit mongodb/api driver wins,
-	# otherwise (None/'local') the configured default backend is used.
 	workspace_id = workspace_name
-	effective_driver = driver if driver in ('mongodb', 'api') else CONFIG.backends.current
+	effective_driver = driver or CONFIG.backends.current
 	if effective_driver == 'api':
 		try:
 			from secator.hooks.api import resolve_workspace
@@ -1414,7 +1412,7 @@ def run_ai_chat(ctx, prompt, workspace):
 @click.option('-q', '--query', type=str, default=None, help='Filter results (Python-like or MongoDB JSON)')
 @click.option('--format', '-f', 'fmt', type=str, default=None, help="Format string for results, e.g. '{tag.match}-{tag.name}' or '{port.host}:{port.port} || vulnerability.matched_at'")  # noqa: E501
 @click.option('-w', '-ws', '--workspace', type=str, default=None, help='Filter by workspace name')
-@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default='local', help='Query backend driver')
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api']), default=None, help='Query backend driver')
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.option('-l', '--limit', type=int, default=0, help='Limit number of results (0 = no limit)')
 @click.pass_context

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -814,9 +814,13 @@ def workspace_list(driver):
 					json_reports.append(path)
 		json_reports = sorted(json_reports, key=lambda x: x.stat().st_mtime, reverse=False)
 		for path in json_reports:
-			ws, runner_type, number = str(path).split('/')[-4:-1]
+			# Layout: <reports>/<ws>/<runner_type>/<number>/report.json — use the path
+			# helper / Path parts instead of a manual POSIX split.
+			ws = get_info_from_report_path(path).get('workspace')
+			if not ws:
+				continue
 			if ws not in workspaces_dict:
-				workspaces_dict[ws] = {'count': 0, 'path': '/'.join(str(path).split('/')[:-3])}
+				workspaces_dict[ws] = {'count': 0, 'path': str(path.parents[2])}
 			workspaces_dict[ws]['count'] += 1
 		table.add_column('Name', style='bold gold3')
 		table.add_column('Run count', overflow='fold')

--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -24,7 +24,7 @@ from secator.completion import complete_profiles, complete_workspaces, complete_
 WORKSPACES = next(os.walk(CONFIG.dirs.reports))[1]
 WORKSPACES_STR = '|'.join([f'[dim yellow3]{_}[/]' for _ in WORKSPACES])
 PROFILES_STR = ','.join([f'[dim yellow3]{_.name}[/]' for _ in get_configs_by_type('profile')])
-DRIVERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in get_available_drivers()])
+DRIVERS_STR = ','.join([f'[dim yellow3]{_}[/]' for _ in ['local'] + get_available_drivers()])
 DRIVER_DEFAULTS_STR = ','.join(CONFIG.drivers.defaults) if CONFIG.drivers.defaults else None
 PROFILE_DEFAULTS_STR = ','.join(CONFIG.profiles.defaults) if CONFIG.profiles.defaults else None
 WORKSPACE_DEFAULT_STR = CONFIG.workspace.default if CONFIG.workspace.default else 'default'
@@ -283,6 +283,10 @@ def register_runner(cli_endpoint, config):
 		hooks = []
 		drivers = driver.split(',') if driver else []
 		drivers = list(dict.fromkeys(CONFIG.drivers.defaults + drivers))
+		# 'local' is a sentinel meaning "no remote drivers": it overrides the configured
+		# defaults so a run can opt out of e.g. the default api driver and stay local.
+		if 'local' in drivers:
+			drivers = []
 		supported_drivers = get_available_drivers()
 		context['drivers'] = []
 		for driver in drivers:

--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -307,9 +307,22 @@ def register_runner(cli_endpoint, config):
 		if 'api' in context['drivers']:
 			try:
 				from secator.hooks.api import get_workspace_name
+				from secator.query.api import ApiBackend
 
-				workspace_name = get_workspace_name(context.get('workspace_id'))
-				context['workspace_name'] = workspace_name
+				ws_value = context.get('workspace_id')
+				if ws_value and ws_value != 'default' and not ApiBackend._is_object_id(ws_value):
+					# A workspace name was passed (e.g. -ws test): resolve it to its id
+					# using the backend so runners/findings are tagged with the real id.
+					workspaces = ApiBackend(workspace_id='').list_workspaces()
+					match = next((w for w in workspaces if w.get('name') == ws_value), None)
+					if not match:
+						raise Exception(f'Workspace "{ws_value}" not found in remote API.')
+					workspace_id = str(match.get('_id') or match.get('id'))
+					context['workspace_id'] = workspace_id
+					context['workspace_name'] = ws_value
+					console.print(f'[dim]Resolved workspace "[bold gold3]{ws_value}[/]" from remote API [id: {workspace_id}][/]')  # noqa: E501
+				else:
+					context['workspace_name'] = get_workspace_name(ws_value)
 			except Exception as e:
 				console.print(f'[bold red]Error getting workspace from API: {e}.[/]')
 				sys.exit(1)

--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -306,23 +306,14 @@ def register_runner(cli_endpoint, config):
 
 		if 'api' in context['drivers']:
 			try:
-				from secator.hooks.api import get_workspace_name
-				from secator.query.api import ApiBackend
+				# Resolve the workspace (name or id) to its real id so runners/findings
+				# are tagged with the ObjectId. Note the runner re-resolves this after
+				# profile / route-based workspace assignment (see secator.hooks.api).
+				from secator.hooks.api import resolve_workspace
 
-				ws_value = context.get('workspace_id')
-				if ws_value and ws_value != 'default' and not ApiBackend._is_object_id(ws_value):
-					# A workspace name was passed (e.g. -ws test): resolve it to its id
-					# using the backend so runners/findings are tagged with the real id.
-					workspaces = ApiBackend(workspace_id='').list_workspaces()
-					match = next((w for w in workspaces if w.get('name') == ws_value), None)
-					if not match:
-						raise Exception(f'Workspace "{ws_value}" not found in remote API.')
-					workspace_id = str(match.get('_id') or match.get('id'))
-					context['workspace_id'] = workspace_id
-					context['workspace_name'] = ws_value
-					console.print(f'[dim]Resolved workspace "[bold gold3]{ws_value}[/]" from remote API [id: {workspace_id}][/]')  # noqa: E501
-				else:
-					context['workspace_name'] = get_workspace_name(ws_value)
+				workspace_id, workspace_name = resolve_workspace(context.get('workspace_id'))
+				context['workspace_id'] = workspace_id
+				context['workspace_name'] = workspace_name
 			except Exception as e:
 				console.print(f'[bold red]Error getting workspace from API: {e}.[/]')
 				sys.exit(1)

--- a/secator/completion.py
+++ b/secator/completion.py
@@ -33,9 +33,11 @@ def complete_workspaces(ctx, param, incomplete):
 
 def complete_drivers(ctx, param, incomplete):
 	"""Complete driver names."""
+	# 'local' is not a hook driver but is a valid value meaning "no remote drivers".
+	names = ['local'] + get_available_drivers()
 	return [
 		CompletionItem(name)
-		for name in get_available_drivers()
+		for name in names
 		if name.startswith(incomplete)
 	]
 

--- a/secator/config.py
+++ b/secator/config.py
@@ -292,7 +292,7 @@ class ApiAddon(StrictModel):
 	workspace_get_endpoint: str = 'workspace/{workspace_id}'
 	workspace_delete_endpoint: str = 'workspace/{workspace_id}'
 	runners_list_endpoint: str = 'runners/any'
-	runner_delete_endpoint: str = '{runner_type}/{runner_id}'
+	runner_delete_endpoint: str = 'runner/{runner_id}?type={runner_type}'
 
 
 class Addons(StrictModel):

--- a/secator/config.py
+++ b/secator/config.py
@@ -31,9 +31,7 @@ USER_AGENTS = {
 }
 
 
-class StrictModel(BaseModel):
-	# Note: extra keys are ignored (not forbidden) so removed/renamed config keys
-	# (e.g. a legacy `backends:` block) don't break loading of existing configs.
+class StrictModel(BaseModel, extra='forbid'):
 	pass
 
 

--- a/secator/config.py
+++ b/secator/config.py
@@ -147,10 +147,6 @@ class Drivers(StrictModel):
 	defaults: List[str] = []
 
 
-class Backends(StrictModel):
-	current: str = 'local'
-
-
 class Workspace(StrictModel):
 	default: str = ''
 	routes: Dict[str, List[str]] = {}
@@ -320,7 +316,6 @@ class SecatorConfig(StrictModel):
 	wordlists: Wordlists = Wordlists()
 	profiles: Profiles = Profiles()
 	drivers: Drivers = Drivers()
-	backends: Backends = Backends()
 	workspace: Workspace = Workspace()
 	addons: Addons = Addons()
 	security: Security = Security()

--- a/secator/config.py
+++ b/secator/config.py
@@ -31,7 +31,9 @@ USER_AGENTS = {
 }
 
 
-class StrictModel(BaseModel, extra='forbid'):
+class StrictModel(BaseModel):
+	# Note: extra keys are ignored (not forbidden) so removed/renamed config keys
+	# (e.g. a legacy `backends:` block) don't break loading of existing configs.
 	pass
 
 

--- a/secator/config.py
+++ b/secator/config.py
@@ -147,6 +147,10 @@ class Drivers(StrictModel):
 	defaults: List[str] = []
 
 
+class Backends(StrictModel):
+	current: str = 'local'
+
+
 class Workspace(StrictModel):
 	default: str = ''
 	routes: Dict[str, List[str]] = {}
@@ -282,8 +286,10 @@ class ApiAddon(StrictModel):
 	finding_create_endpoint: str = 'findings'
 	finding_update_endpoint: str = 'finding/{finding_id}'
 	finding_search_endpoint: str = 'findings/_search'
+	workspace_list_endpoint: str = 'workspaces'
 	workspace_get_endpoint: str = 'workspace/{workspace_id}'
 	workspace_delete_endpoint: str = 'workspace/{workspace_id}'
+	runners_list_endpoint: str = 'runners'
 	runner_delete_endpoint: str = '{runner_type}/{runner_id}'
 
 
@@ -312,6 +318,7 @@ class SecatorConfig(StrictModel):
 	wordlists: Wordlists = Wordlists()
 	profiles: Profiles = Profiles()
 	drivers: Drivers = Drivers()
+	backends: Backends = Backends()
 	workspace: Workspace = Workspace()
 	addons: Addons = Addons()
 	security: Security = Security()

--- a/secator/config.py
+++ b/secator/config.py
@@ -2,7 +2,7 @@ import os
 from collections.abc import MutableMapping
 from pathlib import Path
 from subprocess import call, DEVNULL
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from typing_extensions import Annotated, Self
 
 import validators
@@ -227,35 +227,35 @@ class AiAddon(StrictModel):
 	user_response_timeout: int = 600
 	encrypt_pii: bool = True
 	permissions: Dict = {
-		"allow": [
-			"target({targets})",
-			"read({workspace}/*,/dev/null,/tmp/*)",
-			"write({workspace}/.outputs/*,/dev/null,/tmp/*)",
-			"shell(curl,wget,dig,whois,host,grep,cat,ls,head,tail,jq,wc,find,"
-			"cd,git,diff,stat,du,df,tree,sort,uniq,cut,tr,echo,realpath,readlink,"
-			"file,strings,xxd,base64,for,while,which,true,timeout,"
-			"tee,cp,mv,mkdir,touch,chmod,sed,awk,xargs,docker,printf,"
-			"redis-cli,nc,ncat,nmap,sqlmap,nikto,gobuster,feroxbuster,ffuf,"
-			"socat,telnet,openssl,ssh,scp,rsync,ping,traceroute,tcpdump,ss,netstat)",
-			"task(*)",
-			"workflow(*)",
+		'allow': [
+			'target({targets})',
+			'read({workspace}/*,/dev/null,/tmp/*)',
+			'write({workspace}/.outputs/*,/dev/null,/tmp/*)',
+			'shell(curl,wget,dig,whois,host,grep,cat,ls,head,tail,jq,wc,find,'
+			'cd,git,diff,stat,du,df,tree,sort,uniq,cut,tr,echo,realpath,readlink,'
+			'file,strings,xxd,base64,for,while,which,true,timeout,'
+			'tee,cp,mv,mkdir,touch,chmod,sed,awk,xargs,docker,printf,'
+			'redis-cli,nc,ncat,nmap,sqlmap,nikto,gobuster,feroxbuster,ffuf,'
+			'socat,telnet,openssl,ssh,scp,rsync,ping,traceroute,tcpdump,ss,netstat)',
+			'task(*)',
+			'workflow(*)',
 		],
-		"deny": [
-			"target(169.254.169.254)",
-			"target(127.0.0.1)",
-			"target(localhost)",
-			"read(/etc/shadow)",
-			"read(~/.ssh/*)",
-			"read(~/.aws/*)",
-			"write(/etc/*)",
-			"write(/usr/*)",
-			"shell(rm -rf /*,dd,mkfs,env,printenv)",
+		'deny': [
+			'target(169.254.169.254)',
+			'target(127.0.0.1)',
+			'target(localhost)',
+			'read(/etc/shadow)',
+			'read(~/.ssh/*)',
+			'read(~/.aws/*)',
+			'write(/etc/*)',
+			'write(/usr/*)',
+			'shell(rm -rf /*,dd,mkfs,env,printenv)',
 		],
-		"ask": [
-			"target(*)",
-			"shell(python,python3,bash,sh,exec,node,ruby,perl,gcc,g++,make,go,php,java,javac)",
-			"read(*)",
-			"write(*)",
+		'ask': [
+			'target(*)',
+			'shell(python,python3,bash,sh,exec,node,ruby,perl,gcc,g++,make,go,php,java,javac)',
+			'read(*)',
+			'write(*)',
 		],
 	}
 
@@ -281,7 +281,9 @@ class ApiAddon(StrictModel):
 	header_name: str = 'Bearer'
 	force_ssl: bool = True
 	timeout: int = 60
+	org_id: Optional[int] = None  # Override org to query (admins only); defaults to the user's own org
 	runner_create_endpoint: str = 'runners'
+	runner_get_endpoint: str = 'runner/{runner_id}'
 	runner_update_endpoint: str = 'runner/{runner_id}'
 	finding_create_endpoint: str = 'findings'
 	finding_update_endpoint: str = 'finding/{finding_id}'
@@ -289,7 +291,7 @@ class ApiAddon(StrictModel):
 	workspace_list_endpoint: str = 'workspaces'
 	workspace_get_endpoint: str = 'workspace/{workspace_id}'
 	workspace_delete_endpoint: str = 'workspace/{workspace_id}'
-	runners_list_endpoint: str = 'runners'
+	runners_list_endpoint: str = 'runners/any'
 	runner_delete_endpoint: str = '{runner_type}/{runner_id}'
 
 
@@ -781,6 +783,7 @@ class Config(DotMap):
 		if (value.startswith('{') and value.endswith('}')) or (value.startswith('[') and value.endswith(']')):
 			try:
 				import json
+
 				return json.loads(value)
 			except Exception:
 				pass
@@ -803,6 +806,7 @@ class Config(DotMap):
 		"""Validate that all profile names exist. Returns True if all valid or validation cannot run."""
 		try:
 			from secator.loader import get_configs_by_type
+
 			available = [p.name for p in get_configs_by_type('profile')]
 			invalid = [p for p in profile_names if p not in available]
 			if invalid:
@@ -810,6 +814,7 @@ class Config(DotMap):
 				return False
 		except Exception as e:
 			import logging
+
 			logging.debug('Profile validation skipped due to exception', exc_info=e)
 		return True
 

--- a/secator/exporters/csv.py
+++ b/secator/exporters/csv.py
@@ -26,7 +26,10 @@ class CsvExporter(Exporter):
 			csv_path = f'{self.report.output_folder}/report_{output_type}.csv'
 			csv_paths.append(csv_path)
 			with open(csv_path, 'w', newline='') as output_file:
-				dict_writer = _csv.DictWriter(output_file, keys)
+				# extrasaction='ignore': backends (e.g. API) may attach computed fields
+				# not in the output-type schema (e.g. 'is_exploitable'); only write the
+				# schema columns instead of raising on extras.
+				dict_writer = _csv.DictWriter(output_file, keys, extrasaction='ignore')
 				dict_writer.writeheader()
 				dict_writer.writerows(items)
 

--- a/secator/hooks/api.py
+++ b/secator/hooks/api.py
@@ -32,13 +32,15 @@ API_RUNNER_UPDATE_ENDPOINT = CONFIG.addons.api.runner_update_endpoint
 API_FINDING_CREATE_ENDPOINT = CONFIG.addons.api.finding_create_endpoint
 API_FINDING_UPDATE_ENDPOINT = CONFIG.addons.api.finding_update_endpoint
 API_WORKSPACE_GET_ENDPOINT = CONFIG.addons.api.workspace_get_endpoint
+API_WORKSPACE_LIST_ENDPOINT = CONFIG.addons.api.workspace_list_endpoint
+API_ORG_ID = CONFIG.addons.api.org_id
 FORCE_SSL = CONFIG.addons.api.force_ssl
 API_TIMEOUT = CONFIG.addons.api.timeout
 
 
 def get_runner_dbg(runner):
 	"""Runner debug object"""
-	return {runner.unique_name: runner.status, 'type': runner.config.type, 'class': runner.__class__.__name__, 'caller': runner.config.name, **runner.context}
+	return {runner.unique_name: runner.status, 'type': runner.config.type, 'class': runner.__class__.__name__, 'caller': runner.config.name, **runner.context}  # noqa: E501
 
 
 def _make_request(method, endpoint, data=None):
@@ -70,10 +72,12 @@ def update_runner(self):
 	update = self.toDict()
 	chunk = update.get('chunk')
 	_id = self.context.get(f'{runner_type}_chunk_id') if chunk else self.context.get(f'{runner_type}_id')
-	workspace_name = get_workspace_name(self.context.get('workspace_id'))
-	if workspace_name:
-		self.context['workspace_name'] = workspace_name
-	debug('to_update', sub='hooks.api', id=_id, obj=get_runner_dbg(self), obj_after=True, obj_breaklines=False, verbose=True)
+	workspace_id, workspace_name = resolve_workspace(self.context.get('workspace_id'))
+	self.context['workspace_id'] = workspace_id
+	self.context['workspace_name'] = workspace_name
+	update['context']['workspace_id'] = workspace_id
+	update['context']['workspace_name'] = workspace_name
+	debug('to_update', sub='hooks.api', id=_id, obj=get_runner_dbg(self), obj_after=True, obj_breaklines=False, verbose=True)  # noqa: E501
 
 	start_time = time.time()
 
@@ -106,11 +110,11 @@ def update_finding(self, item):
 	in_api = update.get('_context', {}).get('api', False)
 	_type = item._type
 	_uuid = item._uuid if hasattr(item, '_uuid') else None
-	workspace_name = get_workspace_name(self.context.get('workspace_id'))
-	if workspace_name:
-		self.context['workspace_name'] = workspace_name
-		update['_context']['workspace_name'] = workspace_name
-		update['_context']['workspace_id'] = self.context.get('workspace_id')
+	workspace_id, workspace_name = resolve_workspace(self.context.get('workspace_id'))
+	self.context['workspace_id'] = workspace_id
+	self.context['workspace_name'] = workspace_name
+	update['_context']['workspace_name'] = workspace_name
+	update['_context']['workspace_id'] = workspace_id
 	if not in_api:
 		# Create new finding
 		update['_context']['api'] = True
@@ -129,29 +133,53 @@ def update_finding(self, item):
 	end_time = time.time()
 	elapsed = end_time - start_time
 
-	debug_obj = {_type: status, 'type': 'finding', 'class': self.__class__.__name__, 'caller': self.config.name, **self.context}
+	debug_obj = {_type: status, 'type': 'finding', 'class': self.__class__.__name__, 'caller': self.config.name, **self.context}  # noqa: E501
 	debug(f'in {elapsed:.4f}s', sub='hooks.api', id=str(getattr(item, '_uuid', 'unknown')), obj=debug_obj, obj_after=False)
 
 	return item
 
 
+def _is_object_id(value):
+	"""Return True if value looks like a 24-char hex MongoDB ObjectId."""
+	return bool(value) and len(value) == 24 and all(c in '0123456789abcdefABCDEF' for c in value)
+
+
 @cache
-def get_workspace_name(workspace_id):
-	"""Get workspace name from API."""
-	if not API_WORKSPACE_GET_ENDPOINT:
-		return None
-	if workspace_id == 'default':
-		raise Exception(
-			'Workspace `default` cannot be used for API integration: please use a valid workspace ID using `-ws <workspace_id>` (CLI) or `context.workspace_id = <workspace_id>` (Python API).'
-		)  # noqa: E501
-	if not workspace_id:
-		raise Exception('No workspace ID provided: please use a valid workspace ID using `-ws <workspace_id>` (CLI) or `context.workspace_id = <workspace_id>` (Python API).')  # noqa: E501
-	result = _make_request('GET', f'{API_WORKSPACE_GET_ENDPOINT.format(workspace_id=workspace_id)}')
-	if result and result.get('name'):
-		name = result['name']
-		console.print(Info(message=f'Loaded workspace "{name}" from remote API [id: {workspace_id}]'))
-		return name
-	return None
+def resolve_workspace(value):
+	"""Resolve a workspace name-or-id to (workspace_id, workspace_name) via the API.
+
+	Accepts a 24-char hex ObjectId (looked up by id) or a workspace name (looked up
+	in the workspace list, scoped to the configured org). Cached per input value.
+
+	The runner's profile / route-based workspace assignment overwrites
+	context['workspace_id'] with a workspace name, so callers re-resolve it here to
+	make sure the id sent to the API is always the real ObjectId.
+	"""
+	if value == 'default':
+		raise Exception('Workspace `default` cannot be used for API integration: please use a valid workspace using `-ws <workspace>` (CLI) or `context.workspace_id = <workspace>` (Python API).')  # noqa: E501
+	if not value:
+		raise Exception('No workspace provided: please use a valid workspace using `-ws <workspace>` (CLI) or `context.workspace_id = <workspace>` (Python API).')  # noqa: E501
+
+	# ObjectId -> fetch the workspace to confirm it exists and get its name.
+	if _is_object_id(value):
+		result = _make_request('GET', f'{API_WORKSPACE_GET_ENDPOINT.format(workspace_id=value)}')
+		if result and result.get('name'):
+			console.print(Info(message=f'Loaded workspace "{result["name"]}" from remote API [id: {value}]'))
+			return value, result['name']
+		raise Exception(f'Workspace id "{value}" not found in remote API.')
+
+	# Name -> resolve to id via the workspace list (scoped to the configured org).
+	endpoint = API_WORKSPACE_LIST_ENDPOINT
+	if API_ORG_ID is not None:
+		endpoint += f'?org_id={API_ORG_ID}'
+	result = _make_request('GET', endpoint)
+	items = result if isinstance(result, list) else (result.get('items') or result.get('results') or [])
+	match = next((w for w in items if w.get('name') == value), None)
+	if not match:
+		raise Exception(f'Workspace "{value}" not found in remote API.')
+	workspace_id = str(match.get('_id') or match.get('id'))
+	console.print(Info(message=f'Resolved workspace "{value}" from remote API [id: {workspace_id}]'))
+	return workspace_id, value
 
 
 HOOKS = {
@@ -171,7 +199,7 @@ HOOKS = {
 		'on_duplicate': [update_finding],
 		'on_end': [update_runner],
 	},
-	Task: {'on_init': [update_runner], 'on_start': [update_runner], 'on_interval': [update_runner], 'on_item': [update_finding], 'on_duplicate': [update_finding], 'on_end': [update_runner]},
+	Task: {'on_init': [update_runner], 'on_start': [update_runner], 'on_interval': [update_runner], 'on_item': [update_finding], 'on_duplicate': [update_finding], 'on_end': [update_runner]},  # noqa: E501
 }
 
 

--- a/secator/hooks/api.py
+++ b/secator/hooks/api.py
@@ -38,39 +38,23 @@ API_TIMEOUT = CONFIG.addons.api.timeout
 
 def get_runner_dbg(runner):
 	"""Runner debug object"""
-	return {
-		runner.unique_name: runner.status,
-		'type': runner.config.type,
-		'class': runner.__class__.__name__,
-		'caller': runner.config.name,
-		**runner.context
-	}
+	return {runner.unique_name: runner.status, 'type': runner.config.type, 'class': runner.__class__.__name__, 'caller': runner.config.name, **runner.context}
 
 
 def _make_request(method, endpoint, data=None):
 	"""Make HTTP request to external API endpoint."""
-	url = f"{API_URL.rstrip('/')}/{endpoint.lstrip('/')}"
-	headers = {
-		"Content-Type": "application/json"
-	}
+	url = f'{API_URL.rstrip("/")}/{endpoint.lstrip("/")}'
+	headers = {'Content-Type': 'application/json'}
 	if API_KEY:
-		headers["Authorization"] = f"{API_HEADER_NAME} {API_KEY}"
+		headers['Authorization'] = f'{API_HEADER_NAME} {API_KEY}'
 	verify = FORCE_SSL
 	timeout = API_TIMEOUT
 	debug(f'API request: {method} {url}', sub='hooks.api', verbose=True)
 	debug('API headers', sub='hooks.api', verbose=True, obj=headers)
 	json_data = json.dumps(data, cls=DataclassEncoder) if data else None
 	if json_data:
-		debug('API data', sub='hooks.api', verbose=True, obj=json_data)
-
-	response = requests.request(
-		method=method,
-		url=url,
-		data=json_data,
-		headers=headers,
-		verify=verify,
-		timeout=timeout
-	)
+		debug('API data', sub='hooks.api', verbose=True, obj=json_data, obj_after=True)
+	response = requests.request(method=method, url=url, data=json_data, headers=headers, verify=verify, timeout=timeout)
 	result = response.json()
 	debug('API response', sub='hooks.api', verbose=True, obj=result)
 	if not response.ok and result.get('detail'):
@@ -89,25 +73,14 @@ def update_runner(self):
 	workspace_name = get_workspace_name(self.context.get('workspace_id'))
 	if workspace_name:
 		self.context['workspace_name'] = workspace_name
-	debug(
-		'to_update',
-		sub='hooks.api',
-		id=_id,
-		obj=get_runner_dbg(self),
-		obj_after=True,
-		obj_breaklines=False,
-		verbose=True
-	)
+	debug('to_update', sub='hooks.api', id=_id, obj=get_runner_dbg(self), obj_after=True, obj_breaklines=False, verbose=True)
 
 	start_time = time.time()
 
 	if _id:
 		# Update existing runner
 		result = _make_request('PUT', f'{API_RUNNER_UPDATE_ENDPOINT.format(runner_id=_id)}', update)
-		_log_runner_api_time(
-			self,
-			start_time, '[dim gold4]updated in ', 's[/]', _id
-		)
+		_log_runner_api_time(self, start_time, '[dim gold4]updated in ', 's[/]', _id)
 		self.last_updated_db = start_time
 	else:
 		# Create new runner
@@ -156,20 +129,8 @@ def update_finding(self, item):
 	end_time = time.time()
 	elapsed = end_time - start_time
 
-	debug_obj = {
-		_type: status,
-		'type': 'finding',
-		'class': self.__class__.__name__,
-		'caller': self.config.name,
-		**self.context
-	}
-	debug(
-		f'in {elapsed:.4f}s',
-		sub='hooks.api',
-		id=str(getattr(item, '_uuid', 'unknown')),
-		obj=debug_obj,
-		obj_after=False
-	)
+	debug_obj = {_type: status, 'type': 'finding', 'class': self.__class__.__name__, 'caller': self.config.name, **self.context}
+	debug(f'in {elapsed:.4f}s', sub='hooks.api', id=str(getattr(item, '_uuid', 'unknown')), obj=debug_obj, obj_after=False)
 
 	return item
 
@@ -180,7 +141,9 @@ def get_workspace_name(workspace_id):
 	if not API_WORKSPACE_GET_ENDPOINT:
 		return None
 	if workspace_id == 'default':
-		raise Exception('Workspace `default` cannot be used for API integration: please use a valid workspace ID using `-ws <workspace_id>` (CLI) or `context.workspace_id = <workspace_id>` (Python API).')  # noqa: E501
+		raise Exception(
+			'Workspace `default` cannot be used for API integration: please use a valid workspace ID using `-ws <workspace_id>` (CLI) or `context.workspace_id = <workspace_id>` (Python API).'
+		)  # noqa: E501
 	if not workspace_id:
 		raise Exception('No workspace ID provided: please use a valid workspace ID using `-ws <workspace_id>` (CLI) or `context.workspace_id = <workspace_id>` (Python API).')  # noqa: E501
 	result = _make_request('GET', f'{API_WORKSPACE_GET_ENDPOINT.format(workspace_id=workspace_id)}')
@@ -208,14 +171,7 @@ HOOKS = {
 		'on_duplicate': [update_finding],
 		'on_end': [update_runner],
 	},
-	Task: {
-		'on_init': [update_runner],
-		'on_start': [update_runner],
-		'on_interval': [update_runner],
-		'on_item': [update_finding],
-		'on_duplicate': [update_finding],
-		'on_end': [update_runner]
-	}
+	Task: {'on_init': [update_runner], 'on_start': [update_runner], 'on_interval': [update_runner], 'on_item': [update_finding], 'on_duplicate': [update_finding], 'on_end': [update_runner]},
 }
 
 

--- a/secator/query/__init__.py
+++ b/secator/query/__init__.py
@@ -26,17 +26,25 @@ class QueryEngine:
         self.backend = self._select_backend()
 
     def _select_backend(self) -> QueryBackend:
-        """Select appropriate backend based on context."""
+        """Select appropriate backend based on context or config default."""
+        from secator.config import CONFIG
         drivers = self.context.get('drivers', [])
         if 'mongodb' in drivers:
             return MongoDBBackend(self.workspace_id, context=self.context)
         elif 'api' in drivers:
             return ApiBackend(self.workspace_id, context=self.context)
         else:
-            # For JSON backend, use workspace_name for directory (reports are saved by name)
-            workspace_name = self.context.get('workspace_name', self.workspace_id)
-            results = self.context.get('results')
-            return JsonBackend(workspace_name, context=self.context, results=results)
+            # Fall back to config default backend
+            current = CONFIG.backends.current
+            if current == 'mongodb':
+                return MongoDBBackend(self.workspace_id, context=self.context)
+            elif current == 'api':
+                return ApiBackend(self.workspace_id, context=self.context)
+            else:
+                # For JSON backend, use workspace_name for directory (reports are saved by name)
+                workspace_name = self.context.get('workspace_name', self.workspace_id)
+                results = self.context.get('results')
+                return JsonBackend(workspace_name, context=self.context, results=results)
 
     def search(self, query: dict, limit: int = 0, dedupe: bool = False,
                exclude_fields: List[str] = None) -> List[Dict[str, Any]]:
@@ -55,3 +63,15 @@ class QueryEngine:
     def update(self, query: dict, update: dict) -> int:
         """Update records matching query."""
         return self.backend.update(query, update)
+
+    def list_workspaces(self) -> List[Dict[str, Any]]:
+        """List all workspaces via the active backend."""
+        return self.backend.list_workspaces()
+
+    def get_workspace(self, workspace_id: str) -> Dict[str, Any]:
+        """Get info for a specific workspace via the active backend."""
+        return self.backend.get_workspace(workspace_id)
+
+    def list_runners(self, workspace_id: str = None, runner_type: str = None) -> List[Dict[str, Any]]:
+        """List runners (tasks/workflows/scans) via the active backend."""
+        return self.backend.list_runners(workspace_id=workspace_id, runner_type=runner_type)

--- a/secator/query/__init__.py
+++ b/secator/query/__init__.py
@@ -1,6 +1,6 @@
 # secator/query/__init__.py
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from secator.query._base import QueryBackend
 from secator.query.api import ApiBackend
@@ -72,6 +72,21 @@ class QueryEngine:
         """Get info for a specific workspace via the active backend."""
         return self.backend.get_workspace(workspace_id)
 
-    def list_runners(self, workspace_id: str = None, runner_type: str = None) -> List[Dict[str, Any]]:
-        """List runners (tasks/workflows/scans) via the active backend."""
-        return self.backend.list_runners(workspace_id=workspace_id, runner_type=runner_type)
+    def list_runners(
+        self, workspace_id: str = None, runner_type: str = None, has_parent: Optional[bool] = None
+    ) -> List[Dict[str, Any]]:
+        """List runners (tasks/workflows/scans) via the active backend.
+
+        has_parent: filter on the runner's parent relationship. None lists all runners,
+        False lists only outermost (root) runners, True lists only nested children.
+        """
+        return self.backend.list_runners(
+            workspace_id=workspace_id, runner_type=runner_type, has_parent=has_parent
+        )
+
+    def get_runner(self, runner_id: str, runner_type: str) -> Optional[Dict[str, Any]]:
+        """Get a single runner by ID via the active backend.
+
+        runner_id: the backend runner id. runner_type: singular type (task/workflow/scan).
+        """
+        return self.backend.get_runner(runner_id, runner_type=runner_type)

--- a/secator/query/__init__.py
+++ b/secator/query/__init__.py
@@ -14,10 +14,12 @@ __all__ = ['QueryEngine', 'QueryBackend', 'ApiBackend', 'MongoDBBackend', 'JsonB
 class QueryEngine:
     """Query engine with pluggable backends."""
 
+    # Drivers that have a query backend, keyed by driver name. 'local' is the
+    # filesystem (JSON) backend.
     BACKENDS = {
         'api': ApiBackend,
         'mongodb': MongoDBBackend,
-        'json': JsonBackend,
+        'local': JsonBackend,
     }
 
     def __init__(self, workspace_id: str, context: dict = None):
@@ -25,26 +27,33 @@ class QueryEngine:
         self.context = context or {}
         self.backend = self._select_backend()
 
-    def _select_backend(self) -> QueryBackend:
-        """Select appropriate backend based on context or config default."""
+    @classmethod
+    def resolve_backend(cls, driver: str = None) -> str:
+        """Resolve the effective query backend driver name.
+
+        Uses the passed --driver if it corresponds to an available backend, else the
+        first driver in CONFIG.drivers.defaults that does, else 'local'.
+        """
         from secator.config import CONFIG
+        if driver in cls.BACKENDS:
+            return driver
+        for d in CONFIG.drivers.defaults:
+            if d in cls.BACKENDS:
+                return d
+        return 'local'
+
+    def _select_backend(self) -> QueryBackend:
+        """Select the backend from the context drivers (first that has a backend),
+        defaulting to the local (JSON) backend."""
         drivers = self.context.get('drivers', [])
-        if 'mongodb' in drivers:
-            return MongoDBBackend(self.workspace_id, context=self.context)
-        elif 'api' in drivers:
-            return ApiBackend(self.workspace_id, context=self.context)
-        else:
-            # Fall back to config default backend
-            current = CONFIG.backends.current
-            if current == 'mongodb':
-                return MongoDBBackend(self.workspace_id, context=self.context)
-            elif current == 'api':
-                return ApiBackend(self.workspace_id, context=self.context)
-            else:
-                # For JSON backend, use workspace_name for directory (reports are saved by name)
-                workspace_name = self.context.get('workspace_name', self.workspace_id)
-                results = self.context.get('results')
-                return JsonBackend(workspace_name, context=self.context, results=results)
+        backend_name = next((d for d in drivers if d in self.BACKENDS), 'local')
+        if backend_name == 'local':
+            # The JSON backend reads from the workspace_name directory (reports are
+            # saved by name), not the workspace id.
+            workspace_name = self.context.get('workspace_name', self.workspace_id)
+            results = self.context.get('results')
+            return JsonBackend(workspace_name, context=self.context, results=results)
+        return self.BACKENDS[backend_name](self.workspace_id, context=self.context)
 
     def search(self, query: dict, limit: int = 0, dedupe: bool = False,
                exclude_fields: List[str] = None) -> List[Dict[str, Any]]:

--- a/secator/query/_base.py
+++ b/secator/query/_base.py
@@ -29,9 +29,22 @@ class QueryBackend(ABC):
 		"""Get info for a specific workspace."""
 		return None
 
-	def list_runners(self, workspace_id: str = None, runner_type: str = None) -> List[Dict[str, Any]]:
-		"""List runners (tasks/workflows/scans) from this backend."""
+	def list_runners(
+		self, workspace_id: str = None, runner_type: str = None, has_parent: Optional[bool] = None
+	) -> List[Dict[str, Any]]:
+		"""List runners (tasks/workflows/scans) from this backend.
+
+		has_parent: None lists all runners, False only outermost (root) runners,
+		True only nested children.
+		"""
 		return []
+
+	def get_runner(self, runner_id: str, runner_type: str) -> Optional[Dict[str, Any]]:
+		"""Get a single runner by ID from this backend.
+
+		runner_id: the backend runner id. runner_type: singular type (task/workflow/scan).
+		"""
+		return None
 
 	def get_base_query(self) -> dict:
 		"""Base query - ALWAYS enforced, cannot be overridden."""

--- a/secator/query/_base.py
+++ b/secator/query/_base.py
@@ -21,6 +21,18 @@ class QueryBackend(ABC):
 		self.config = config or {}
 		self.context = context or {}
 
+	def list_workspaces(self) -> List[Dict[str, Any]]:
+		"""List all workspaces accessible via this backend."""
+		return []
+
+	def get_workspace(self, workspace_id: str) -> Optional[Dict[str, Any]]:
+		"""Get info for a specific workspace."""
+		return None
+
+	def list_runners(self, workspace_id: str = None, runner_type: str = None) -> List[Dict[str, Any]]:
+		"""List runners (tasks/workflows/scans) from this backend."""
+		return []
+
 	def get_base_query(self) -> dict:
 		"""Base query - ALWAYS enforced, cannot be overridden."""
 		return {

--- a/secator/query/_base.py
+++ b/secator/query/_base.py
@@ -30,7 +30,8 @@ class QueryBackend(ABC):
 		return None
 
 	def list_runners(
-		self, workspace_id: str = None, runner_type: str = None, has_parent: Optional[bool] = None
+		self, workspace_id: Optional[str] = None, runner_type: Optional[str] = None,
+		has_parent: Optional[bool] = None
 	) -> List[Dict[str, Any]]:
 		"""List runners (tasks/workflows/scans) from this backend.
 

--- a/secator/query/api.py
+++ b/secator/query/api.py
@@ -58,13 +58,21 @@ class ApiBackend(QueryBackend):
             result = self._make_request('POST', endpoint, query)
 
             if isinstance(result, list):
-                return result
+                items = result
             elif isinstance(result, dict) and 'items' in result:
-                return result['items']
+                items = result['items']
             elif isinstance(result, dict) and 'results' in result:
-                return result['results']
+                items = result['results']
+            else:
+                items = []
 
-            return []
+            # Drop the backend-only '_id' field so results match the output-type
+            # schema (the CSV exporter rejects unknown fields), matching the
+            # MongoDB backend behaviour.
+            for item in items:
+                if isinstance(item, dict):
+                    item.pop('_id', None)
+            return items
         except Exception as e:
             console.print(Warning(message=f"API search failed: {e}"))
             return []

--- a/secator/query/api.py
+++ b/secator/query/api.py
@@ -93,6 +93,8 @@ class ApiBackend(QueryBackend):
         """List workspaces from API."""
         try:
             endpoint = CONFIG.addons.api.workspace_list_endpoint
+            if CONFIG.addons.api.org_id is not None:
+                endpoint += f'?org_id={CONFIG.addons.api.org_id}'
             result = self._make_request('GET', endpoint)
             if isinstance(result, list):
                 return result
@@ -105,6 +107,16 @@ class ApiBackend(QueryBackend):
             console.print(Warning(message=f'API list_workspaces failed: {e}'))
             return []
 
+    def get_runner(self, runner_id: str, runner_type: str):
+        """Get a single runner by ID from API (GET /runner/{runner_id}?type=<type>)."""
+        try:
+            endpoint = CONFIG.addons.api.runner_get_endpoint.format(runner_id=runner_id)
+            endpoint += f'?type={runner_type}'
+            return self._make_request('GET', endpoint)
+        except Exception as e:
+            console.print(Warning(message=f'API get_runner failed: {e}'))
+            return None
+
     def get_workspace(self, workspace_id: str):
         """Get workspace info from API."""
         try:
@@ -114,15 +126,35 @@ class ApiBackend(QueryBackend):
             console.print(Warning(message=f'API get_workspace failed: {e}'))
             return None
 
-    def list_runners(self, workspace_id: str = None, runner_type: str = None):
-        """List runners from API."""
+    @staticmethod
+    def _is_object_id(value: str) -> bool:
+        """Return True if value looks like a 24-char hex MongoDB ObjectId."""
+        return bool(value) and len(value) == 24 and all(c in '0123456789abcdefABCDEF' for c in value)
+
+    def list_runners(self, workspace_id: str = None, runner_type: str = None, has_parent: Optional[bool] = None):
+        """List runners from API.
+
+        The CLI passes a workspace name via -ws. The API accepts either workspace_id
+        (a 24-char hex ObjectId) or workspace_name. Detect which one was passed so that
+        names resolve correctly while raw ObjectIds keep working.
+
+        has_parent: when not None, only return runners matching that parent relationship
+        (False = outermost runners only, True = nested children only).
+        """
         try:
             endpoint = CONFIG.addons.api.runners_list_endpoint
             params = []
             if workspace_id:
-                params.append(f'workspace_id={workspace_id}')
+                if self._is_object_id(workspace_id):
+                    params.append(f'workspace_id={workspace_id}')
+                else:
+                    params.append(f'workspace_name={workspace_id}')
             if runner_type:
                 params.append(f'type={runner_type}')
+            if CONFIG.addons.api.org_id is not None:
+                params.append(f'org_id={CONFIG.addons.api.org_id}')
+            if has_parent is not None:
+                params.append(f'has_parent={str(has_parent).lower()}')
             if params:
                 endpoint += '?' + '&'.join(params)
             result = self._make_request('GET', endpoint)

--- a/secator/query/api.py
+++ b/secator/query/api.py
@@ -88,3 +88,51 @@ class ApiBackend(QueryBackend):
         payload = {"query": query, "update": update}
         result = self._make_request("PATCH", "findings/update", data=payload)
         return result.get("modified_count", 0)
+
+    def list_workspaces(self):
+        """List workspaces from API."""
+        try:
+            endpoint = CONFIG.addons.api.workspace_list_endpoint
+            result = self._make_request('GET', endpoint)
+            if isinstance(result, list):
+                return result
+            elif isinstance(result, dict) and 'items' in result:
+                return result['items']
+            elif isinstance(result, dict) and 'results' in result:
+                return result['results']
+            return []
+        except Exception as e:
+            console.print(Warning(message=f'API list_workspaces failed: {e}'))
+            return []
+
+    def get_workspace(self, workspace_id: str):
+        """Get workspace info from API."""
+        try:
+            endpoint = CONFIG.addons.api.workspace_get_endpoint.format(workspace_id=workspace_id)
+            return self._make_request('GET', endpoint)
+        except Exception as e:
+            console.print(Warning(message=f'API get_workspace failed: {e}'))
+            return None
+
+    def list_runners(self, workspace_id: str = None, runner_type: str = None):
+        """List runners from API."""
+        try:
+            endpoint = CONFIG.addons.api.runners_list_endpoint
+            params = []
+            if workspace_id:
+                params.append(f'workspace_id={workspace_id}')
+            if runner_type:
+                params.append(f'type={runner_type}')
+            if params:
+                endpoint += '?' + '&'.join(params)
+            result = self._make_request('GET', endpoint)
+            if isinstance(result, list):
+                return result
+            elif isinstance(result, dict) and 'items' in result:
+                return result['items']
+            elif isinstance(result, dict) and 'results' in result:
+                return result['results']
+            return []
+        except Exception as e:
+            console.print(Warning(message=f'API list_runners failed: {e}'))
+            return []

--- a/secator/query/api.py
+++ b/secator/query/api.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlencode
 
 import requests
 
@@ -139,7 +140,8 @@ class ApiBackend(QueryBackend):
         """Return True if value looks like a 24-char hex MongoDB ObjectId."""
         return bool(value) and len(value) == 24 and all(c in '0123456789abcdefABCDEF' for c in value)
 
-    def list_runners(self, workspace_id: str = None, runner_type: str = None, has_parent: Optional[bool] = None):
+    def list_runners(self, workspace_id: Optional[str] = None, runner_type: Optional[str] = None,
+                     has_parent: Optional[bool] = None):
         """List runners from API.
 
         The CLI passes a workspace name via -ws. The API accepts either workspace_id
@@ -151,20 +153,22 @@ class ApiBackend(QueryBackend):
         """
         try:
             endpoint = CONFIG.addons.api.runners_list_endpoint
-            params = []
+            # Build params as a dict and url-encode them (workspace names may contain
+            # spaces or other characters that must be escaped).
+            params = {}
             if workspace_id:
                 if self._is_object_id(workspace_id):
-                    params.append(f'workspace_id={workspace_id}')
+                    params['workspace_id'] = workspace_id
                 else:
-                    params.append(f'workspace_name={workspace_id}')
+                    params['workspace_name'] = workspace_id
             if runner_type:
-                params.append(f'type={runner_type}')
+                params['type'] = runner_type
             if CONFIG.addons.api.org_id is not None:
-                params.append(f'org_id={CONFIG.addons.api.org_id}')
+                params['org_id'] = CONFIG.addons.api.org_id
             if has_parent is not None:
-                params.append(f'has_parent={str(has_parent).lower()}')
+                params['has_parent'] = str(has_parent).lower()
             if params:
-                endpoint += '?' + '&'.join(params)
+                endpoint += '?' + urlencode(params)
             result = self._make_request('GET', endpoint)
             if isinstance(result, list):
                 return result

--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -194,3 +194,44 @@ class JsonBackend(QueryBackend):
 					self._results[i][k] = v
 				count += 1
 		return count
+
+	def list_workspaces(self):
+		"""List workspaces from local reports directory."""
+		workspaces = []
+		if self.reports_dir.exists():
+			for child in sorted(self.reports_dir.iterdir()):
+				if child.is_dir():
+					workspaces.append({
+						'workspace_id': child.name,
+						'workspace_name': child.name,
+						'path': str(child),
+					})
+		return workspaces
+
+	def get_workspace(self, workspace_id: str):
+		"""Get workspace info from local filesystem."""
+		workspace_path = self.reports_dir / sanitize_folder_name(workspace_id)
+		if workspace_path.exists():
+			return {'workspace_id': workspace_id, 'workspace_name': workspace_id, 'path': str(workspace_path)}
+		return None
+
+	def list_runners(self, workspace_id: str = None, runner_type: str = None):
+		"""List runners from local report JSON files."""
+		import json as _json
+		from secator.utils import list_reports, get_info_from_report_path
+		paths = list_reports(workspace=workspace_id, type=runner_type)
+		runners = []
+		for path in paths:
+			try:
+				path_info = get_info_from_report_path(path)
+				with open(path, 'r') as f:
+					data = _json.load(f)
+				info = data.get('info', {})
+				info['_type'] = path_info.get('type', '')
+				info['_id'] = path_info.get('type', '') + '/' + path_info.get('id', '')
+				info['_workspace'] = path_info.get('workspace', '')
+				info['_path'] = str(path)
+				runners.append(info)
+			except Exception:
+				continue
+		return runners

--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -215,13 +215,13 @@ class JsonBackend(QueryBackend):
 			return {'workspace_id': workspace_id, 'workspace_name': workspace_id, 'path': str(workspace_path)}
 		return None
 
-	def list_runners(self, workspace_id: str = None, runner_type: str = None, has_parent: Optional[bool] = None):
+	def list_runners(self, workspace_id: Optional[str] = None, runner_type: Optional[str] = None,
+					 has_parent: Optional[bool] = None):
 		"""List runners from local report JSON files.
 
 		has_parent: when not None, only return runners matching that parent relationship
 		(False = outermost runners only, True = nested children only).
 		"""
-		import json as _json
 		from secator.utils import list_reports, get_info_from_report_path
 		paths = list_reports(workspace=workspace_id, type=runner_type)
 		runners = []
@@ -229,7 +229,7 @@ class JsonBackend(QueryBackend):
 			try:
 				path_info = get_info_from_report_path(path)
 				with open(path, 'r') as f:
-					data = _json.load(f)
+					data = json.load(f)
 				info = data.get('info', {})
 				if has_parent is not None and info.get('has_parent', False) != has_parent:
 					continue
@@ -238,6 +238,7 @@ class JsonBackend(QueryBackend):
 				info['_workspace'] = path_info.get('workspace', '')
 				info['_path'] = str(path)
 				runners.append(info)
-			except Exception:
+			except Exception as e:
+				debug(f'failed to load runner report {path}: {e}', sub='query.json')
 				continue
 		return runners

--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -215,8 +215,12 @@ class JsonBackend(QueryBackend):
 			return {'workspace_id': workspace_id, 'workspace_name': workspace_id, 'path': str(workspace_path)}
 		return None
 
-	def list_runners(self, workspace_id: str = None, runner_type: str = None):
-		"""List runners from local report JSON files."""
+	def list_runners(self, workspace_id: str = None, runner_type: str = None, has_parent: Optional[bool] = None):
+		"""List runners from local report JSON files.
+
+		has_parent: when not None, only return runners matching that parent relationship
+		(False = outermost runners only, True = nested children only).
+		"""
 		import json as _json
 		from secator.utils import list_reports, get_info_from_report_path
 		paths = list_reports(workspace=workspace_id, type=runner_type)
@@ -227,6 +231,8 @@ class JsonBackend(QueryBackend):
 				with open(path, 'r') as f:
 					data = _json.load(f)
 				info = data.get('info', {})
+				if has_parent is not None and info.get('has_parent', False) != has_parent:
+					continue
 				info['_type'] = path_info.get('type', '')
 				info['_id'] = path_info.get('type', '') + '/' + path_info.get('id', '')
 				info['_workspace'] = path_info.get('workspace', '')

--- a/secator/query/mongodb.py
+++ b/secator/query/mongodb.py
@@ -67,3 +67,76 @@ class MongoDBBackend(QueryBackend):
 		client = self._get_client()
 		result = client.main.findings.update_one(query, update)
 		return result.modified_count
+
+	def list_workspaces(self):
+		"""List workspaces by aggregating workspace_id from the findings collection."""
+		try:
+			client = self._get_client()
+			db = client.main
+			pipeline = [
+				{'$group': {
+					'_id': '$_context.workspace_id',
+					'workspace_name': {'$first': '$_context.workspace_name'},
+					'count': {'$sum': 1},
+				}},
+				{'$project': {
+					'_id': 0,
+					'workspace_id': '$_id',
+					'workspace_name': 1,
+					'count': 1,
+				}},
+				{'$sort': {'workspace_id': 1}},
+			]
+			return list(db.findings.aggregate(pipeline))
+		except Exception as e:
+			console.print(Warning(message=f'MongoDB list_workspaces failed: {e}'))
+			return []
+
+	def get_workspace(self, workspace_id: str):
+		"""Get workspace info from MongoDB by aggregating findings for workspace_id."""
+		try:
+			client = self._get_client()
+			db = client.main
+			pipeline = [
+				{'$match': {'_context.workspace_id': workspace_id}},
+				{'$group': {
+					'_id': '$_context.workspace_id',
+					'workspace_name': {'$first': '$_context.workspace_name'},
+					'count': {'$sum': 1},
+				}},
+				{'$project': {
+					'_id': 0,
+					'workspace_id': '$_id',
+					'workspace_name': 1,
+					'count': 1,
+				}},
+			]
+			results = list(db.findings.aggregate(pipeline))
+			return results[0] if results else None
+		except Exception as e:
+			console.print(Warning(message=f'MongoDB get_workspace failed: {e}'))
+			return None
+
+	def list_runners(self, workspace_id: str = None, runner_type: str = None):
+		"""List runners from MongoDB tasks/workflows/scans collections."""
+		try:
+			client = self._get_client()
+			db = client.main
+			runner_types = [runner_type + 's'] if runner_type else ['tasks', 'workflows', 'scans']
+			runners = []
+			for rtype in runner_types:
+				query = {}
+				if workspace_id:
+					query['context.workspace_id'] = workspace_id
+				for doc in db[rtype].find(query):
+					doc.pop('_id', None)
+					doc['_type'] = rtype
+					rtype_singular = rtype.rstrip('s')
+					runner_id = doc.get('context', {}).get(f'{rtype_singular}_id', '')
+					doc['_id_str'] = f'{rtype}/{runner_id}' if runner_id else rtype
+					doc['_workspace'] = doc.get('context', {}).get('workspace_id', '')
+					runners.append(doc)
+			return runners
+		except Exception as e:
+			console.print(Warning(message=f'MongoDB list_runners failed: {e}'))
+			return []

--- a/secator/query/mongodb.py
+++ b/secator/query/mongodb.py
@@ -117,8 +117,31 @@ class MongoDBBackend(QueryBackend):
 			console.print(Warning(message=f'MongoDB get_workspace failed: {e}'))
 			return None
 
-	def list_runners(self, workspace_id: str = None, runner_type: str = None):
-		"""List runners from MongoDB tasks/workflows/scans collections."""
+	def get_runner(self, runner_id: str, runner_type: str):
+		"""Get a single runner by ID from MongoDB."""
+		try:
+			from bson.objectid import ObjectId
+
+			client = self._get_client()
+			db = client.main
+			rtype = runner_type + 's'
+			query = {'_id': ObjectId(runner_id)} if ObjectId.is_valid(runner_id) else {'_id': runner_id}
+			doc = db[rtype].find_one(query)
+			if doc:
+				doc['_id'] = str(doc['_id'])
+				doc['_type'] = rtype
+				return doc
+			return None
+		except Exception as e:
+			console.print(Warning(message=f'MongoDB get_runner failed: {e}'))
+			return None
+
+	def list_runners(self, workspace_id: str = None, runner_type: str = None, has_parent: Optional[bool] = None):
+		"""List runners from MongoDB tasks/workflows/scans collections.
+
+		has_parent: when not None, only return runners matching that parent relationship
+		(False = outermost runners only, True = nested children only).
+		"""
 		try:
 			client = self._get_client()
 			db = client.main
@@ -128,6 +151,8 @@ class MongoDBBackend(QueryBackend):
 				query = {}
 				if workspace_id:
 					query['context.workspace_id'] = workspace_id
+				if has_parent is not None:
+					query['has_parent'] = has_parent
 				for doc in db[rtype].find(query):
 					doc.pop('_id', None)
 					doc['_type'] = rtype

--- a/secator/query/mongodb.py
+++ b/secator/query/mongodb.py
@@ -150,7 +150,8 @@ class MongoDBBackend(QueryBackend):
 			for rtype in runner_types:
 				query = {}
 				if workspace_id:
-					query['context.workspace_id'] = workspace_id
+					# Runners are keyed by workspace name for the mongodb backend.
+					query['context.workspace_name'] = workspace_id
 				if has_parent is not None:
 					query['has_parent'] = has_parent
 				for doc in db[rtype].find(query):
@@ -159,7 +160,7 @@ class MongoDBBackend(QueryBackend):
 					rtype_singular = rtype.rstrip('s')
 					runner_id = doc.get('context', {}).get(f'{rtype_singular}_id', '')
 					doc['_id_str'] = f'{rtype}/{runner_id}' if runner_id else rtype
-					doc['_workspace'] = doc.get('context', {}).get('workspace_id', '')
+					doc['_workspace'] = doc.get('context', {}).get('workspace_name', '')
 					runners.append(doc)
 			return runners
 		except Exception as e:

--- a/secator/query/mongodb.py
+++ b/secator/query/mongodb.py
@@ -69,25 +69,44 @@ class MongoDBBackend(QueryBackend):
 		return result.modified_count
 
 	def list_workspaces(self):
-		"""List workspaces by aggregating workspace_id from the findings collection."""
+		"""List workspaces for the mongodb backend.
+
+		There are no workspace objects, so workspaces are derived from the unique
+		`context.workspace_name` values across the tasks/workflows/scans collections
+		(with runner counts), plus a best-effort finding count per workspace name.
+		"""
 		try:
 			client = self._get_client()
 			db = client.main
-			pipeline = [
-				{'$group': {
-					'_id': '$_context.workspace_id',
-					'workspace_name': {'$first': '$_context.workspace_name'},
-					'count': {'$sum': 1},
-				}},
-				{'$project': {
-					'_id': 0,
-					'workspace_id': '$_id',
-					'workspace_name': 1,
-					'count': 1,
-				}},
-				{'$sort': {'workspace_id': 1}},
+			runners_count = {}
+			for rtype in ['tasks', 'workflows', 'scans']:
+				pipeline = [{'$group': {'_id': '$context.workspace_name', 'count': {'$sum': 1}}}]
+				for row in db[rtype].aggregate(pipeline):
+					name = row.get('_id')
+					if not name:
+						continue
+					runners_count[name] = runners_count.get(name, 0) + row.get('count', 0)
+
+			findings_count = {}
+			try:
+				pipeline = [{'$group': {'_id': '$_context.workspace_name', 'count': {'$sum': 1}}}]
+				for row in db.findings.aggregate(pipeline):
+					name = row.get('_id')
+					if name:
+						findings_count[name] = row.get('count', 0)
+			except Exception:
+				pass
+
+			return [
+				{
+					'name': name,
+					'_id': '',
+					'description': None,
+					'runners_count': runners_count[name],
+					'findings_count': findings_count.get(name, 0),
+				}
+				for name in sorted(runners_count)
 			]
-			return list(db.findings.aggregate(pipeline))
 		except Exception as e:
 			console.print(Warning(message=f'MongoDB list_workspaces failed: {e}'))
 			return []

--- a/secator/query/mongodb.py
+++ b/secator/query/mongodb.py
@@ -6,6 +6,8 @@ from secator.output_types import Warning
 from secator.query._base import QueryBackend
 from secator.rich import console
 
+RUNNER_COLLECTIONS = ('tasks', 'workflows', 'scans')
+
 
 class MongoDBBackend(QueryBackend):
 	"""Query backend for MongoDB."""
@@ -143,7 +145,10 @@ class MongoDBBackend(QueryBackend):
 
 			client = self._get_client()
 			db = client.main
-			rtype = runner_type + 's'
+			# Normalize singular/plural and reject unknown runner types.
+			rtype = runner_type.rstrip('s') + 's'
+			if rtype not in RUNNER_COLLECTIONS:
+				return None
 			query = {'_id': ObjectId(runner_id)} if ObjectId.is_valid(runner_id) else {'_id': runner_id}
 			doc = db[rtype].find_one(query)
 			if doc:
@@ -155,7 +160,8 @@ class MongoDBBackend(QueryBackend):
 			console.print(Warning(message=f'MongoDB get_runner failed: {e}'))
 			return None
 
-	def list_runners(self, workspace_id: str = None, runner_type: str = None, has_parent: Optional[bool] = None):
+	def list_runners(self, workspace_id: Optional[str] = None, runner_type: Optional[str] = None,
+					 has_parent: Optional[bool] = None):
 		"""List runners from MongoDB tasks/workflows/scans collections.
 
 		has_parent: when not None, only return runners matching that parent relationship
@@ -164,7 +170,11 @@ class MongoDBBackend(QueryBackend):
 		try:
 			client = self._get_client()
 			db = client.main
-			runner_types = [runner_type + 's'] if runner_type else ['tasks', 'workflows', 'scans']
+			if runner_type:
+				rtype = runner_type.rstrip('s') + 's'
+				runner_types = [rtype] if rtype in RUNNER_COLLECTIONS else []
+			else:
+				runner_types = list(RUNNER_COLLECTIONS)
 			runners = []
 			for rtype in runner_types:
 				query = {}

--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -101,11 +101,14 @@ def expand_runner_paths(tokens):
                 errors.append(f'Invalid range: {spec!r} in {part!r}. Start must be <= end.')
                 continue
             numbers = [str(n) for n in range(start, end + 1)]
-        else:
-            if not spec.isdigit():
-                errors.append(f'Invalid runner number: {spec!r} in {part!r}. Must be numeric.')
-                continue
+        elif spec.isdigit():
             numbers = [str(int(spec))]
+        elif len(spec) == 24 and all(c in '0123456789abcdefABCDEF' for c in spec):
+            # ObjectId (e.g. from `r list --driver api`): used as-is, no range expansion.
+            numbers = [spec]
+        else:
+            errors.append(f'Invalid runner id: {spec!r} in {part!r}. Must be a number or a 24-char hex id.')
+            continue
 
         for number in numbers:
             key = (type_plural, number)

--- a/secator/report.py
+++ b/secator/report.py
@@ -76,7 +76,11 @@ class Report:
 		if 'workspace_name' not in context:
 			context['workspace_name'] = self.workspace_name
 
-		engine = QueryEngine(self.workspace_name, context=context)
+		# Use the resolved workspace id (an ObjectId for the api/mongodb backends) so
+		# findings queries filter on the real id. The json backend reads workspace_name
+		# from the context for its directory, so it is unaffected by this value.
+		workspace_id = context.get('workspace_id')
+		engine = QueryEngine(workspace_id, context=context)
 		results = engine.search(query, limit=limit, dedupe=dedupe)
 
 		# Fill report (findings + targets)

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -681,8 +681,15 @@ class ai(PythonRunner):
 			elif isinstance(result, OutputType):
 				self.add_result(result, print=not is_from_subagent)
 
-			# Yield live to caller
-			yield result
+			# Query results are existing workspace findings surfaced only for the AI's
+			# observation; collect them for the tool result but don't yield them (which
+			# would re-report/duplicate them into the workspace via the runner hooks).
+			result_context = result._context if isinstance(result, OutputType) else (
+				result.get("_context", {}) if isinstance(result, dict) else {})
+			is_query_result = bool(result_context.get("ai_query_result"))
+			if not is_query_result:
+				# Yield live to caller
+				yield result
 
 			result = result.toDict() if isinstance(result, OutputType) else result
 			collected.append(result)

--- a/secator/tasks/search_vulns.py
+++ b/secator/tasks/search_vulns.py
@@ -124,7 +124,7 @@ class search_vulns(Vuln):
 				vuln = Vuln.lookup_cve(cve_id)
 				if vuln:
 					data.update(vuln.toDict())
-					data['confidence'] = confidence
+					data['confidence'] = self.confidence
 					data['references'].extend(references)
 					data['extra_data'].update(extra_data)
 

--- a/secator/tasks/search_vulns.py
+++ b/secator/tasks/search_vulns.py
@@ -60,10 +60,8 @@ class search_vulns(Vuln):
 			return
 		_in = self.inputs[0]
 		self.matched_at = None
-		self.confidence = 'low'
 		if '~' in _in:
 			split = _in.split('~')
-			self.confidence = 'high'
 			self.matched_at = split[0]
 			self.inputs[0] = split[1]
 		self.inputs[0] = self.inputs[0].replace('/', ' ').rstrip()
@@ -99,6 +97,7 @@ class search_vulns(Vuln):
 		# Yield each vulnerability
 		for cve_id, vuln_data in vulns.items():
 			match_reason = vuln_data.get('match_reason', '')
+			confidence = 'high'
 			tags = search_vulns.extract_tags(vuln_data)
 			exploits = vuln_data.get('exploits', [])
 			cvss_score = float(vuln_data.get('severity', {}).get('CVSS', {}).get('score', 0))
@@ -111,7 +110,7 @@ class search_vulns(Vuln):
 				'id': cve_id,
 				'name': cve_id,
 				'description': vuln_data.get('description', ''),
-				'confidence': self.confidence,
+				'confidence': confidence,
 				'cvss_score': cvss_score,
 				'epss_score': epss_score,
 				'cvss_vec': cvss_vector,
@@ -124,14 +123,13 @@ class search_vulns(Vuln):
 				vuln = Vuln.lookup_cve(cve_id)
 				if vuln:
 					data.update(vuln.toDict())
-					data['confidence'] = self.confidence
+					data['confidence'] = confidence
 					data['references'].extend(references)
 					data['extra_data'].update(extra_data)
 
 			# Add 'exploitable' and 'uncertain' tags
 			if match_reason == 'general_product_uncertain':
-				self.confidence = 'low'
-				data['confidence'] = self.confidence
+				data['confidence'] = 'low'
 				data['tags'].append('uncertain')
 			if len(exploits) > 0:
 				data['tags'].append('exploitable')
@@ -169,7 +167,7 @@ class search_vulns(Vuln):
 						provider=provider,
 						id=id,
 						matched_at=matched_at,
-						confidence=self.confidence,
+						confidence=confidence,
 						reference=exploit,
 						cves=[cve_id],
 						tags=tags,

--- a/secator/tasks/search_vulns.py
+++ b/secator/tasks/search_vulns.py
@@ -60,8 +60,10 @@ class search_vulns(Vuln):
 			return
 		_in = self.inputs[0]
 		self.matched_at = None
+		self.confidence = 'low'
 		if '~' in _in:
 			split = _in.split('~')
+			self.confidence = 'high'
 			self.matched_at = split[0]
 			self.inputs[0] = split[1]
 		self.inputs[0] = self.inputs[0].replace('/', ' ').rstrip()
@@ -97,7 +99,6 @@ class search_vulns(Vuln):
 		# Yield each vulnerability
 		for cve_id, vuln_data in vulns.items():
 			match_reason = vuln_data.get('match_reason', '')
-			confidence = 'high'
 			tags = search_vulns.extract_tags(vuln_data)
 			exploits = vuln_data.get('exploits', [])
 			cvss_score = float(vuln_data.get('severity', {}).get('CVSS', {}).get('score', 0))
@@ -110,7 +111,7 @@ class search_vulns(Vuln):
 				'id': cve_id,
 				'name': cve_id,
 				'description': vuln_data.get('description', ''),
-				'confidence': confidence,
+				'confidence': self.confidence,
 				'cvss_score': cvss_score,
 				'epss_score': epss_score,
 				'cvss_vec': cvss_vector,

--- a/secator/tasks/search_vulns.py
+++ b/secator/tasks/search_vulns.py
@@ -130,7 +130,8 @@ class search_vulns(Vuln):
 
 			# Add 'exploitable' and 'uncertain' tags
 			if match_reason == 'general_product_uncertain':
-				data['confidence'] = 'low'
+				self.confidence = 'low'
+				data['confidence'] = self.confidence
 				data['tags'].append('uncertain')
 			if len(exploits) > 0:
 				data['tags'].append('exploitable')
@@ -168,7 +169,7 @@ class search_vulns(Vuln):
 						provider=provider,
 						id=id,
 						matched_at=matched_at,
-						confidence=confidence,
+						confidence=self.confidence,
 						reference=exploit,
 						cves=[cve_id],
 						tags=tags,

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -544,21 +544,6 @@ class TestGetQueryEngine(unittest.TestCase):
 
 		self.assertEqual(count, 42)
 
-	# -- scope=workspace: mongodb takes priority over api --
-
-	def test_workspace_scope_mongodb_priority(self):
-		"""When both mongodb and api drivers present, mongodb wins."""
-		from secator.query.mongodb import MongoDBBackend
-
-		ctx = ActionContext(
-			targets=['t.com'],
-			model='m',
-			context={'workspace_id': 'ws1', 'drivers': ['api', 'mongodb']},
-		)
-		engine = ctx.get_query_engine()
-
-		self.assertIsInstance(engine.backend, MongoDBBackend)
-
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
 class TestHandleAddFinding(unittest.TestCase):

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -238,6 +238,12 @@ class TestHandleQuery(unittest.TestCase):
 		self.assertEqual(ai_results[0].extra_data['results'], 2)
 		mock_engine.search.assert_called_once_with({'port': 80}, limit=10)
 
+		# Query results are marked observation-only so the runner doesn't re-report them.
+		result_dicts = [r for r in results if isinstance(r, dict)]
+		self.assertEqual(len(result_dicts), 2)
+		for r in result_dicts:
+			self.assertTrue(r['_context'].get('ai_query_result'))
+
 	@patch('secator.ai.actions.ActionContext.get_query_engine')
 	def test_query_failure(self, mock_get_engine):
 		mock_engine = MagicMock()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -434,7 +434,7 @@ class TestCli(unittest.TestCase):
 		result = self.runner.invoke(cli, ['workspace', 'list'])
 		assert not result.exception
 		assert result.exit_code == 0
-		assert 'Workspace name' in result.output
+		assert 'Name' in result.output
 
 	def test_profile_list_command(self):
 		# Wide terminal so rich does not wrap the column headers across lines.

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -351,13 +351,13 @@ class TestQueryEngine(unittest.TestCase):
 		engine = QueryEngine(workspace_id='ws123', context={'drivers': ['mongodb']})
 		self.assertIsInstance(engine.backend, MongoDBBackend)
 
-	def test_query_engine_mongodb_takes_priority(self):
+	def test_query_engine_selects_first_driver(self):
 		from secator.query import QueryEngine
-		from secator.query.mongodb import MongoDBBackend
+		from secator.query.api import ApiBackend
 
-		# When both are available, MongoDB takes priority
+		# The backend is the first driver in the list that has a backend.
 		engine = QueryEngine(workspace_id='ws123', context={'drivers': ['api', 'mongodb']})
-		self.assertIsInstance(engine.backend, MongoDBBackend)
+		self.assertIsInstance(engine.backend, ApiBackend)
 
 	def test_query_engine_search_dedupe_removes_duplicates(self):
 		"""QueryEngine.search(dedupe=True) should remove duplicate findings."""

--- a/tests/unit/test_query_cli.py
+++ b/tests/unit/test_query_cli.py
@@ -54,6 +54,10 @@ class TestLooksLikeQueryExpr(unittest.TestCase):
 			"Analyze my workspace data",
 			"critical_vulns",
 			"show me the most exploitable hosts",
+			# Plain English containing 'in'/'and'/'or' must not be read as a query expression.
+			"What's in my workspace ?",
+			"subdomains and ips",
+			"show me urls or vulnerabilities",
 			"",
 		]
 		for phrase in phrases:

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -233,7 +233,13 @@ class TestExpandRunnerPaths:
     def test_non_numeric_id(self):
         refs, errors = expand_runner_paths(['tasks/abc'])
         assert refs == []
-        assert 'Must be numeric' in errors[0]
+        assert 'Must be a number or a 24-char hex id' in errors[0]
+
+    def test_object_id(self):
+        # A 24-char hex id (e.g. from `r list --driver api`) is accepted as-is.
+        refs, errors = expand_runner_paths(['workflows/6a298abc13cfda92d5b7ee63'])
+        assert errors == []
+        assert refs == [('workflows', 'workflow', '6a298abc13cfda92d5b7ee63')]
 
     def test_reversed_range(self):
         refs, errors = expand_runner_paths(['tasks/140-136'])

--- a/tests/unit/test_report_show_e2e.py
+++ b/tests/unit/test_report_show_e2e.py
@@ -282,6 +282,10 @@ class TestReportShowApiBackend(unittest.TestCase):
 
 	def _invoke(self, query_expr, api_response):
 		from secator.cli import cli
+		from secator.hooks.api import resolve_workspace
+
+		# Workspace name->id resolution is cached; reset so it re-resolves under the mock.
+		resolve_workspace.cache_clear()
 
 		captured = {}
 		captured_request = {}
@@ -291,6 +295,12 @@ class TestReportShowApiBackend(unittest.TestCase):
 
 		def mock_request(method, url, data=None, **kwargs):
 			import json as _json
+			# The api driver resolves the workspace name to its id first (GET /workspaces).
+			if method == 'GET' and 'workspace' in url:
+				resp = mock.MagicMock()
+				resp.json.return_value = [{'name': WORKSPACE, '_id': WORKSPACE}]
+				resp.raise_for_status = mock.MagicMock()
+				return resp
 			captured_request['method'] = method
 			captured_request['url'] = url
 			captured_request['body'] = _json.loads(data) if data else {}
@@ -388,8 +398,8 @@ class TestReportListCurrentWorkspace(unittest.TestCase):
 				console.capture() as cap:
 			cfg.workspace.default = default_ws
 			report_list.callback(
-				workspace=workspace_opt, runner_type=None, time_delta=None, show_all=False, interesting=False,
-				status=None,
+				workspace=workspace_opt, runner_type=None, time_delta=None, driver='local', show_all=False,
+				interesting=False, status=None, show_children=False,
 			)
 		# Strip ANSI codes then flatten whitespace so assertions work on plain text
 		return ' '.join(_strip_ansi(cap.get()).split())
@@ -445,9 +455,10 @@ class TestReportListInteresting(unittest.TestCase):
 	def _invoke(self, args):
 		from secator.cli import cli
 		# Under CliRunner there is no TTY, so report_list takes the piped branch and prints paths,
-		# which still respects the filters.
+		# which still respects the filters. Pin --driver local so the filesystem branch is used
+		# regardless of the ambient drivers.defaults config.
 		with mock.patch('secator.cli.list_reports', return_value=[self.with_vuln, self.no_vuln, self.unknown_sev]):
-			return CliRunner().invoke(cli, ['r', 'list'] + args)
+			return CliRunner().invoke(cli, ['r', 'list', '--driver', 'local'] + args)
 
 	def test_interesting_filters_to_vuln_reports(self):
 		result = self._invoke(['-i'])

--- a/tests/unit/test_report_show_e2e.py
+++ b/tests/unit/test_report_show_e2e.py
@@ -454,71 +454,73 @@ class TestReportListInteresting(unittest.TestCase):
 
 	def _invoke(self, args):
 		from secator.cli import cli
-		# Under CliRunner there is no TTY, so report_list takes the piped branch and prints paths,
-		# which still respects the filters. Pin --driver local so the filesystem branch is used
-		# regardless of the ambient drivers.defaults config.
+		# Pin --driver local so the filesystem branch is used regardless of the ambient
+		# drivers.defaults config. Assertions check the runner id (e.g. 'tasks/1'), which is
+		# plain text in the table — unlike the full path, which only appears via a file://
+		# hyperlink that rich renders only when the console is detected as a terminal.
+		# COLUMNS keeps the table wide so the id isn't wrapped across lines.
 		with mock.patch('secator.cli.list_reports', return_value=[self.with_vuln, self.no_vuln, self.unknown_sev]):
-			return CliRunner().invoke(cli, ['r', 'list', '--driver', 'local'] + args)
+			return CliRunner().invoke(cli, ['r', 'list', '--driver', 'local'] + args, env={'COLUMNS': '400'})
 
 	def test_interesting_filters_to_vuln_reports(self):
 		result = self._invoke(['-i'])
 		self.assertEqual(result.exit_code, 0)
-		self.assertIn(str(self.with_vuln), result.output)
-		self.assertNotIn(str(self.no_vuln), result.output)
+		self.assertIn('tasks/1', result.output)
+		self.assertNotIn('tasks/2', result.output)
 		# Unknown/empty-severity vulns render as '-' and are not interesting
-		self.assertNotIn(str(self.unknown_sev), result.output)
+		self.assertNotIn('tasks/3', result.output)
 
 	def test_long_flag_equivalent(self):
 		result = self._invoke(['--interesting'])
-		self.assertIn(str(self.with_vuln), result.output)
-		self.assertNotIn(str(self.no_vuln), result.output)
-		self.assertNotIn(str(self.unknown_sev), result.output)
+		self.assertIn('tasks/1', result.output)
+		self.assertNotIn('tasks/2', result.output)
+		self.assertNotIn('tasks/3', result.output)
 
 	def test_without_interesting_shows_all(self):
 		result = self._invoke([])
-		self.assertIn(str(self.with_vuln), result.output)
-		self.assertIn(str(self.no_vuln), result.output)
-		self.assertIn(str(self.unknown_sev), result.output)
+		self.assertIn('tasks/1', result.output)
+		self.assertIn('tasks/2', result.output)
+		self.assertIn('tasks/3', result.output)
 
 	def test_status_filter(self):
 		result = self._invoke(['--status', 'FAILURE'])
 		self.assertEqual(result.exit_code, 0)
-		self.assertIn(str(self.no_vuln), result.output)
-		self.assertNotIn(str(self.with_vuln), result.output)
-		self.assertNotIn(str(self.unknown_sev), result.output)
+		self.assertIn('tasks/2', result.output)
+		self.assertNotIn('tasks/1', result.output)
+		self.assertNotIn('tasks/3', result.output)
 
 	def test_status_filter_case_insensitive(self):
 		# lower-case, UPPER-case and Title-case must all behave identically
 		for variant in ('success', 'SUCCESS', 'Success'):
 			result = self._invoke(['--status', variant])
-			self.assertIn(str(self.with_vuln), result.output, variant)
-			self.assertIn(str(self.unknown_sev), result.output, variant)
-			self.assertNotIn(str(self.no_vuln), result.output, variant)
+			self.assertIn('tasks/1', result.output, variant)
+			self.assertIn('tasks/3', result.output, variant)
+			self.assertNotIn('tasks/2', result.output, variant)
 		# Title-case on a different status value
 		result = self._invoke(['--status', 'Failure'])
-		self.assertIn(str(self.no_vuln), result.output)
-		self.assertNotIn(str(self.with_vuln), result.output)
+		self.assertIn('tasks/2', result.output)
+		self.assertNotIn('tasks/1', result.output)
 
 	def test_status_and_interesting_combined(self):
 		# Only the SUCCESS report that also has real-severity vulns survives both filters
 		result = self._invoke(['-i', '--status', 'SUCCESS'])
-		self.assertIn(str(self.with_vuln), result.output)
-		self.assertNotIn(str(self.unknown_sev), result.output)
-		self.assertNotIn(str(self.no_vuln), result.output)
+		self.assertIn('tasks/1', result.output)
+		self.assertNotIn('tasks/3', result.output)
+		self.assertNotIn('tasks/2', result.output)
 
 	def test_status_partial_regex_match(self):
 		# 'FAIL' is a regex search, so it matches FAILURE
 		result = self._invoke(['--status', 'FAIL'])
 		self.assertEqual(result.exit_code, 0)
-		self.assertIn(str(self.no_vuln), result.output)
-		self.assertNotIn(str(self.with_vuln), result.output)
+		self.assertIn('tasks/2', result.output)
+		self.assertNotIn('tasks/1', result.output)
 
 	def test_status_alternation_regex(self):
 		# '(SUCCESS|FAILURE)' matches both statuses
 		result = self._invoke(['--status', '(SUCCESS|FAILURE)'])
-		self.assertIn(str(self.with_vuln), result.output)
-		self.assertIn(str(self.no_vuln), result.output)
-		self.assertIn(str(self.unknown_sev), result.output)
+		self.assertIn('tasks/1', result.output)
+		self.assertIn('tasks/2', result.output)
+		self.assertIn('tasks/3', result.output)
 
 	def test_status_no_match(self):
 		# A valid regex matching no status yields no reports (no crash, no warning)


### PR DESCRIPTION
Closes #1161

## Summary

Adds query backends with a pluggable `--driver`, workspace **name** resolution for the API driver, and a set of `secator r list` / `secator r info` improvements.

## Backends & config
- New `backends` config section with `backends.current` defaulting to `local`.
- `list_workspaces`, `get_workspace`, `list_runners`, and `get_runner` implemented across all query backends (JSON, MongoDB, API).
- MongoDB: aggregates `_context.workspace_id` from findings for workspaces; queries collections for runners.
- API addon config: `workspace_list_endpoint`, `runners_list_endpoint` (`/runners/any`), `runner_get_endpoint`, plus an optional `org_id` (admin override; defaults to the user's own org).
- `QueryEngine` falls back to `CONFIG.backends.current` when no driver is in context.

## Workspace name resolution (API driver)
- `secator <task|workflow|scan> -ws <name> --driver api` resolves the workspace **name** to its id via the backend (`cli_helper`), so runners/findings are tagged with the real workspace id. ObjectIds and the `default` workspace keep their existing behavior.
- `r list` / `r info` resolve the API workspace by name (`workspace_name` query param) vs. id (ObjectId detection).
- `report.py` builds the export-time findings query with the resolved workspace id.
- Workspace resolution is centralized in `hooks/api.resolve_workspace()` (name **or** ObjectId → `(id, name)`, org-scoped, cached) and used by both `cli_helper` and the API hook. The API hook re-resolves on every runner update, because the runner's **profile / route-based workspace assignment** overwrites `context['workspace_id']` with a workspace *name* — this was leaving the export-time `findings/_search` filtering on the name and returning `403`.

## `secator r list`
- `--driver` option (local / mongodb / api).
- Id column shows `{runner_type}/{runner_id}` so the value is directly usable with `r info`.
- `--show-children` toggles the `has_parent` filter — by default only outermost runners are listed; with the flag, nested sub-tasks/sub-workflows are included. Warns that the flag is a no-op on the local driver.

## `secator r info`
- `--driver` option — fetches a runner from the backend (`GET /runner/{id}?type=<type>`) instead of the local report file.
- Renders dict fields (`config`, `run_opts`, `context`, …) as syntax-highlighted YAML.
- `config` and `output` are only shown with `--show-all`; the verbose `config.opts` key is dropped.
- `warnings` are loaded and displayed below the table, mirroring how errors are shown.

## Companion PRs
- secator-api: freelabz/secator-api#160 (workspace name/org resolution, child-runner quota fix, unique workspace name per org, `progress` float, token delete fix)
- secator-ui: freelabz/secator-ui#207 (token input `:model-value` fix)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI `ws list` and `r list` commands now accept a `--driver` option to query workspaces and reports from local storage, MongoDB, or a remote API.
  * Added backend configuration setting to specify a default query driver.
  * Unified interface for listing and retrieving workspace and report data across multiple data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
