### PR TITLE
fix(nuclei): uppercase CVE id

### DIFF
--- a/secator/tasks/nuclei.py
+++ b/secator/tasks/nuclei.py
@@ -157,7 +157,7 @@ class nuclei(VulnMulti):
 	def id_extractor(item):
 		cve_ids = item['info'].get('classification', {}).get('cve-id') or []
 		if len(cve_ids) > 0:
-			return cve_ids[0]
+			return cve_ids[0].upper()
 		return None
 
 	@staticmethod


### PR DESCRIPTION
Always run upper() on the `cve_id` in the `nuclei` template as some templates have the CVE id in lowercase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CVE identifiers now display in uppercase format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->