### PR TITLE
fix(chain): keep non-persisted outputs (Target/Info) through the Celery chain so subdomains feed host_recon with MongoDB

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -108,6 +108,36 @@ if IN_WORKER:
 	setup_handlers()
 
 
+def chain_results(results):
+	"""Reduce results for passing through the Celery chain with MongoDB enabled.
+
+	Persisted findings are reduced to their Mongo ObjectId string (re-hydrated
+	downstream by secator.hooks.mongodb.get_results). Non-persisted outputs
+	(EXECUTION_TYPES like Target/Info, which carry uuid4 ids that are never
+	stored in db.findings) are kept as objects so they survive the round-trip
+	instead of being silently dropped by get_results' ObjectId.is_valid() filter.
+
+	Without this, scope-tagged Target inputs (e.g. the subdomains feeding
+	host_recon in a domain scan) are lost and the workflow falls back to its
+	original input.
+	"""
+	from bson.objectid import ObjectId
+	out, seen = [], set()
+	for r in results:
+		if isinstance(r, str):
+			if r not in seen:
+				seen.add(r)
+				out.append(r)
+		elif getattr(r, '_uuid', None) and ObjectId.is_valid(str(r._uuid)):
+			uid = str(r._uuid)
+			if uid not in seen:
+				seen.add(uid)
+				out.append(uid)
+		else:
+			out.append(r)
+	return out
+
+
 @retry(Exception, tries=3, delay=2)
 def update_state(celery_task, task, force=False):
 	"""Update task state to add metadata information."""
@@ -228,7 +258,7 @@ def run_command(self, results, name, targets, opts={}):
 	update_state(self, task, force=True)
 
 	if CONFIG.addons.mongodb.enabled:
-		return [r._uuid for r in task.results]
+		return chain_results(task.results)
 	return task.results
 
 
@@ -255,9 +285,9 @@ def forward_results(results):
 	results = flatten(results)
 	if IN_WORKER and CONFIG.addons.mongodb.enabled:
 		console.print(Info(message=f'Extracting uuids from {len(results)} results'))
-		uuids = [r._uuid for r in results if hasattr(r, '_uuid')]
-		uuids.extend([r for r in results if isinstance(r, str)])
-		results = list(set(uuids))
+		# Keep non-persisted outputs (Target/Info etc.) as objects so they survive
+		# the chain; only persisted findings are reduced to their ObjectId uuid.
+		results = chain_results(results)
 	else:
 		results = deduplicate(results, attr='_uuid')
 
@@ -340,7 +370,7 @@ def mark_runner_started(results, runner, enable_hooks=True):
 
 	# Return only uuids when mongodb is enabled
 	if IN_WORKER and CONFIG.addons.mongodb.enabled:
-		return [r._uuid for r in runner.results]
+		return chain_results(runner.results)
 
 	return runner.results
 
@@ -389,7 +419,7 @@ def mark_runner_completed(results, runner, enable_hooks=True):
 
 	# Return only uuids when mongodb is enabled
 	if IN_WORKER and CONFIG.addons.mongodb.enabled:
-		return [r._uuid for r in runner.results]
+		return chain_results(runner.results)
 
 	return runner.results
 

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -301,6 +301,14 @@ def mark_runner_started(results, runner, enable_hooks=True):
 	for item in results:
 		runner.add_result(item, print=False)
 
+	# [chain-debug] temporary instrumentation: composition of re-hydrated results
+	# feeding the scan-level targets_ extractor (diagnosing cross-workflow chaining).
+	_by_type = {}
+	for r in runner.results:
+		_t = getattr(r, '_type', type(r).__name__)
+		_by_type[_t] = _by_type.get(_t, 0) + 1
+	debug(f'{runner.unique_name} mark_started: results by_type={_by_type} parent_scope={runner.context.get("parent_scope")}', sub='chain')  # noqa: E501
+
 	# Emit scope-tagged Targets for workflows with a scan-level targets_ extractor.
 	# This resolves the extractor at execution time (when Port/result data is available)
 	# so all tasks in the chain can find the correct inputs via parent_scope filtering.
@@ -311,6 +319,7 @@ def mark_runner_started(results, runner, enable_hooks=True):
 		}
 		ctx = {'ancestor_id': runner.ancestor_id, 'node_chain_start': True}
 		scoped_inputs, _, _ = run_extractors(runner.results, target_extractor_opts, runner.inputs, ctx=ctx)
+		debug(f'{runner.unique_name} scope-extractor -> {len(scoped_inputs)} inputs: {scoped_inputs}', sub='chain')
 		for name in scoped_inputs:
 			t = TargetOutput(name=name)
 			t._context['scope'] = scope

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -331,14 +331,6 @@ def mark_runner_started(results, runner, enable_hooks=True):
 	for item in results:
 		runner.add_result(item, print=False)
 
-	# [chain-debug] temporary instrumentation: composition of re-hydrated results
-	# feeding the scan-level targets_ extractor (diagnosing cross-workflow chaining).
-	_by_type = {}
-	for r in runner.results:
-		_t = getattr(r, '_type', type(r).__name__)
-		_by_type[_t] = _by_type.get(_t, 0) + 1
-	debug(f'{runner.unique_name} mark_started: results by_type={_by_type} parent_scope={runner.context.get("parent_scope")}', sub='chain')  # noqa: E501
-
 	# Emit scope-tagged Targets for workflows with a scan-level targets_ extractor.
 	# This resolves the extractor at execution time (when Port/result data is available)
 	# so all tasks in the chain can find the correct inputs via parent_scope filtering.
@@ -349,7 +341,6 @@ def mark_runner_started(results, runner, enable_hooks=True):
 		}
 		ctx = {'ancestor_id': runner.ancestor_id, 'node_chain_start': True}
 		scoped_inputs, _, _ = run_extractors(runner.results, target_extractor_opts, runner.inputs, ctx=ctx)
-		debug(f'{runner.unique_name} scope-extractor -> {len(scoped_inputs)} inputs: {scoped_inputs}', sub='chain')
 		for name in scoped_inputs:
 			t = TargetOutput(name=name)
 			t._context['scope'] = scope

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -61,14 +61,23 @@ def get_results(uuids):
 	client = get_mongodb_client()
 	db = client.main
 	del_uuids = []
+	n_in = len(uuids) if hasattr(uuids, '__len__') else -1
 	for r in uuids:
 		if isinstance(r, tuple(OUTPUT_TYPES)):
 			yield r
 			del_uuids.append(r)
 	uuids = [ObjectId(u) for u in uuids if u not in del_uuids and ObjectId.is_valid(u)]
+	# [chain-debug] temporary instrumentation: which uuids resolve to findings on re-hydration
+	debug(f'get_results: in={n_in} prehydrated={len(del_uuids)} valid_objectids={len(uuids)}', sub='chain')
+	n_out = 0
+	by_type = {}
 	for r in db.findings.find({'_id': {'$in': uuids}}):
 		finding = load_finding(r)
+		if finding is not None:
+			n_out += 1
+			by_type[finding._type] = by_type.get(finding._type, 0) + 1
 		yield finding
+	debug(f'get_results: rehydrated={n_out} by_type={by_type}', sub='chain')
 
 
 def update_runner(self):

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -61,23 +61,14 @@ def get_results(uuids):
 	client = get_mongodb_client()
 	db = client.main
 	del_uuids = []
-	n_in = len(uuids) if hasattr(uuids, '__len__') else -1
 	for r in uuids:
 		if isinstance(r, tuple(OUTPUT_TYPES)):
 			yield r
 			del_uuids.append(r)
 	uuids = [ObjectId(u) for u in uuids if u not in del_uuids and ObjectId.is_valid(u)]
-	# [chain-debug] temporary instrumentation: which uuids resolve to findings on re-hydration
-	debug(f'get_results: in={n_in} prehydrated={len(del_uuids)} valid_objectids={len(uuids)}', sub='chain')
-	n_out = 0
-	by_type = {}
 	for r in db.findings.find({'_id': {'$in': uuids}}):
 		finding = load_finding(r)
-		if finding is not None:
-			n_out += 1
-			by_type[finding._type] = by_type.get(finding._type, 0) + 1
 		yield finding
-	debug(f'get_results: rehydrated={n_out} by_type={by_type}', sub='chain')
 
 
 def update_runner(self):


### PR DESCRIPTION
## Problem

In a domain/subdomain scan with the **MongoDB backend**, `subdomain_recon`'s discovered subdomains never feed `host_recon` — it runs on the original domain (`nmap jahmyst.synology.me`). Works locally **without** MongoDB.

## Root cause

`host_recon.mark_runner_started` correctly extracts the subdomains and emits them as **scope-tagged `Target`s**. But with MongoDB, results travel down the Celery chain as **uuids**, and `Target`/`Info` are `EXECUTION_TYPES` (never written to `db.findings`), so they carry `uuid4` ids — which `hooks.mongodb.get_results` drops (not valid ObjectIds). The scoped subdomain `Target`s were silently dropped before `host_recon`'s tasks ran, so they fell back to the original input. Without MongoDB the objects pass in-memory, so it works.

## Fix

`chain_results()` in `celery.py`: persisted findings → ObjectId uuid (re-hydrated downstream); **non-persisted outputs kept as objects** so they survive the chain. Applied to `forward_results` and the `run_*` / `mark_runner_started` / `mark_runner_completed` return paths.

## Validation

Confirmed locally with the MongoDB addon: `host_recon` now runs `nmap`/`httpx` against each of the 20 discovered subdomains (previously only the apex domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)