### PR TITLE
fix(wpscan): add --no-update and --update flags

### DIFF
--- a/secator/tasks/wpscan.py
+++ b/secator/tasks/wpscan.py
@@ -36,7 +36,9 @@ class wpscan(VulnHttp):
 		'login_uri': {'type': str, 'short': 'lu', 'help': 'URI of the login page if different from /wp-login.php'},
 		'detection_mode': {'type': str, 'short': 'dm', 'help': 'Detection mode between mixed, passive, and aggressive'},
 		'random_user_agent': {'is_flag': True, 'short': 'rua', 'help': 'Random user agent'},
-		'disable_tls_checks': {'is_flag': True, 'short': 'dtc', 'help': 'Disable TLS checks'}
+		'disable_tls_checks': {'is_flag': True, 'short': 'dtc', 'help': 'Disable TLS checks'},
+		'no_update': {'is_flag': True, 'default': None, 'help': 'Do not update wordpress DB'},
+		'update': {'is_flag': True, 'default': None, 'help': 'Update Wordpress DB'}
 	}
 	opt_key_map = {
 		HEADER: OPT_NOT_SUPPORTED,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WPScan task now supports additional configuration flags to control database behavior: `--no_update` prevents automatic WP database updates, while `--update` forces database synchronization, providing greater flexibility in scan operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->