### PR TITLE
fix: restore on_end hooks for chunk-parent tasks on unpickle

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -399,6 +399,15 @@ def mark_runner_completed(results, runner, enable_hooks=True):
 	for item in results:
 		runner.add_result(item, print=False)
 
+	# [chunk-debug] callback runner state (hooks re-attached via __setstate__ from context['drivers'])
+	debug(
+		f'mark_completed {runner.unique_name}: drivers={runner.context.get("drivers")} '
+		f'on_end_hooks={len(runner.resolved_hooks.get("on_end", []))} '
+		f'enable_hooks={runner.enable_hooks} done={runner.done} '
+		f'task_id={runner.context.get("task_id")} chunk={runner.chunk} has_children={runner.has_children}',
+		sub='chunk'
+	)
+
 	# Run mark_completed (duplicate checks, db updates if enable_hooks is True)
 	runner.mark_completed()
 
@@ -564,6 +573,14 @@ def break_task(task, task_opts, results=[]):
 	if IN_WORKER:
 		console.print(Info(message=f'Task {task.unique_name} is now async, building chord with {len(sigs)} chunks'))
 	# console.print(Info(message=f'Results: {results}'))
+
+	# [chunk-debug] live parent state right before it's pickled into the chord callback
+	debug(
+		f'break_task {task.unique_name}: drivers={task.context.get("drivers")} '
+		f'on_end_hooks={len(task.resolved_hooks.get("on_end", []))} '
+		f'task_id={task.context.get("task_id")} chunk={task.chunk} has_children={task.has_children}',
+		sub='chunk'
+	)
 
 	# Build Celery workflow
 	workflow = chord(

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -399,15 +399,6 @@ def mark_runner_completed(results, runner, enable_hooks=True):
 	for item in results:
 		runner.add_result(item, print=False)
 
-	# [chunk-debug] callback runner state (hooks re-attached via __setstate__ from context['drivers'])
-	debug(
-		f'mark_completed {runner.unique_name}: drivers={runner.context.get("drivers")} '
-		f'on_end_hooks={len(runner.resolved_hooks.get("on_end", []))} '
-		f'enable_hooks={runner.enable_hooks} done={runner.done} '
-		f'task_id={runner.context.get("task_id")} chunk={runner.chunk} has_children={runner.has_children}',
-		sub='chunk'
-	)
-
 	# Run mark_completed (duplicate checks, db updates if enable_hooks is True)
 	runner.mark_completed()
 
@@ -573,14 +564,6 @@ def break_task(task, task_opts, results=[]):
 	if IN_WORKER:
 		console.print(Info(message=f'Task {task.unique_name} is now async, building chord with {len(sigs)} chunks'))
 	# console.print(Info(message=f'Results: {results}'))
-
-	# [chunk-debug] live parent state right before it's pickled into the chord callback
-	debug(
-		f'break_task {task.unique_name}: drivers={task.context.get("drivers")} '
-		f'on_end_hooks={len(task.resolved_hooks.get("on_end", []))} '
-		f'task_id={task.context.get("task_id")} chunk={task.chunk} has_children={task.has_children}',
-		sub='chunk'
-	)
 
 	# Build Celery workflow
 	workflow = chord(

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -482,7 +482,18 @@ class Runner:
 			from secator.utils import deep_merge_dicts
 
 			merged_hooks = deep_merge_dicts(*hooks_list)
-		self.register_hooks(merged_hooks)
+		# Driver HOOKS dicts are keyed by base runner class (Scan/Workflow/Task). A task
+		# runner's class is its command subclass (e.g. ``whois``), never the base ``Task``,
+		# so register_hooks()' exact ``hooks.get(self.__class__)`` lookup would miss the
+		# ``Task`` entry and the task's on_end hook would never re-register on unpickle.
+		# That left chunk-parent tasks — the only tasks pickled into a chord callback —
+		# stuck in RUNNING because mark_runner_completed() ran zero on_end hooks. Flatten
+		# to the base runner type's hooks first (same convention as Workflow handing
+		# ``self._hooks.get(Task)`` to its task signatures) so they restore in the worker.
+		from secator.runners import Scan, Task, Workflow
+
+		base_cls = {'scan': Scan, 'workflow': Workflow, 'task': Task}.get(self.config.type)
+		self.register_hooks(merged_hooks.get(base_cls, {}) if base_cls else merged_hooks)
 
 	@classmethod
 	def requires_local_execution(cls, inputs, run_opts):

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -431,3 +431,46 @@ class TestRunnerPickle(unittest.TestCase):
 
 		finally:
 			del sys.modules['secator.hooks.fakedriver']
+
+	def test_task_pickle_restores_hooks_from_base_task_key(self):
+		"""Regression for chunk-parent tasks stuck in RUNNING.
+
+		A driver's HOOKS dict is keyed by the *base* runner classes (Scan/Workflow/Task),
+		but a task runner's class is its command subclass (e.g. ``httpx``), never the base
+		``Task``. So __setstate__ must flatten driver HOOKS to the runner's base type before
+		register_hooks() — otherwise its exact ``hooks.get(self.__class__)`` lookup misses
+		the ``Task`` entry and the task's on_end hook is never re-registered on unpickle.
+		Only chunk-parent tasks get pickled into a chord callback, so they were the ones
+		left stuck in RUNNING because mark_runner_completed() ran zero on_end hooks."""
+		import pickle
+		import sys
+		import types
+		from unittest.mock import patch
+		from secator.runners import Task
+		from secator.tasks import httpx
+
+		# Simulate an external driver module keyed by the BASE Task class, exactly like the
+		# real mongodb/api driver HOOKS dicts.
+		fake_module = types.ModuleType('secator.hooks.faketaskdriver')
+
+		def on_end(runner, *args):
+			pass
+
+		on_end.__module__ = 'secator.hooks.faketaskdriver'
+		on_end.__qualname__ = 'on_end'
+		fake_module.on_end = on_end
+		fake_module.HOOKS = {Task: {'on_end': [on_end]}}
+		sys.modules['secator.hooks.faketaskdriver'] = fake_module
+
+		try:
+			with patch('secator.loader.discover_external_drivers', return_value=['faketaskdriver']):
+				context = {'drivers': ['faketaskdriver']}
+				# Instance class is `httpx` (a Command subclass), not the base Task.
+				task = httpx(['example.com'], hooks={Task: {'on_end': [on_end]}}, context=context, dry_run=True)
+				self.assertIsNot(type(task), Task)  # sanity: command subclass, not base Task
+				restored = pickle.loads(pickle.dumps(task))
+				# With the fix, on_end is re-registered from the base `Task` key in HOOKS.
+				self.assertIn(on_end, restored.resolved_hooks.get('on_end', []))
+
+		finally:
+			del sys.modules['secator.hooks.faketaskdriver']


### PR DESCRIPTION
## Problem

Chunked-task **parents** stayed stuck in `RUNNING` in production (with the MongoDB backend), even though all their chunks completed `SUCCESS`. Workflows started by a scan transitioned to `RUNNING`/completed correctly — only chunk-parent tasks were affected.

## Root cause

When a task is chunked, `break_task` builds a chord whose callback is `mark_runner_completed.s(runner=task)` — this **pickles the parent task**. `__getstate__` strips hooks; `__setstate__` re-registers them from `context['drivers']`.

`__setstate__` rebuilt the driver `HOOKS` dict, which is **keyed by the base runner classes** (`{Scan, Workflow, Task}`), and passed the whole thing to `register_hooks()`. But `register_hooks()` only does an exact `hooks.get(self.__class__)` lookup — and a task runner's class is its **command subclass** (`whois`, `getasn`, …), never the base `Task`. So the `Task` hook entry was missed, the on_end hook was never re-registered, and the chord callback ran **zero on_end hooks** → `update_runner` never marked the parent complete.

Workflows were unaffected because a workflow runner's class *is* exactly `Workflow`, so the class-keyed lookup hits.

## Fix

In `__setstate__`, flatten the driver `HOOKS` to the runner's **base type** (`config.type → Scan/Workflow/Task`) before calling `register_hooks()` — the same convention the live path already uses (`workflow.py` hands `self._hooks.get(Task)` to its task signatures).

## Verification

- Reproduced live (domain scan via the API with the MongoDB backend): chunk parents `whois`/`getasn` stuck `RUNNING` with all chunks `SUCCESS`. After the fix: `on_end_hooks=1` in the callback and both parents reach `SUCCESS`.
- Added regression test `test_task_pickle_restores_hooks_from_base_task_key` — confirmed it fails without the fix and passes with it.
- Temporary debug instrumentation removed; net diff is the fix + test only.