### PR TITLE
fix: stop a workflow inheriting a sibling workflow's errors

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -346,11 +346,27 @@ class Runner:
 			return [r for r in self.results if isinstance(r, Warning) and self._is_own_source(r._source)]
 		return [r for r in self.results if isinstance(r, Warning)]
 
+	def _owns_error(self, r):
+		"""Whether Error *r* was produced within this runner's own subtree.
+
+		- task: only errors from its own source (incl. its chunks).
+		- workflow: only its own subtree's errors. In a scan, results forward from one
+		  workflow to the next, so without this a later workflow would inherit an
+		  earlier sibling's Error and wrongly report FAILURE even when all its own
+		  tasks succeeded. A workflow's tasks are tagged
+		  ``_context['ancestor_id'] == <workflow config name>`` (see Workflow.run), and
+		  a workflow-level error carries the workflow's own ``_source``.
+		- scan / other composite: aggregate every descendant error (no siblings above).
+		"""
+		if self.config.type == 'task':
+			return self._is_own_source(r._source)
+		if self.config.type == 'workflow':
+			return r._context.get('ancestor_id') == self.config.name or self._is_own_source(r._source)
+		return True
+
 	@property
 	def errors(self):
-		if self.config.type == 'task':
-			return [r for r in self.results if isinstance(r, Error) and self._is_own_source(r._source)]
-		return [r for r in self.results if isinstance(r, Error)]
+		return [r for r in self.results if isinstance(r, Error) and self._owns_error(r)]
 
 	@property
 	def self_results(self):
@@ -370,9 +386,7 @@ class Runner:
 
 	@property
 	def self_errors(self):
-		if self.config.type == 'task':
-			return [r for r in self.results if isinstance(r, Error) and self._is_own_source(r._source)]
-		return [r for r in self.results if isinstance(r, Error)]
+		return [r for r in self.results if isinstance(r, Error) and self._owns_error(r)]
 
 	@property
 	def self_findings_count(self):

--- a/tests/unit/test_error_scoping.py
+++ b/tests/unit/test_error_scoping.py
@@ -1,0 +1,68 @@
+"""Error-scoping regression tests.
+
+In a scan, results forward from one workflow to the next, so a workflow's
+``results`` can contain ``Error`` outputs produced by an *earlier sibling*
+workflow. Status is ``FAILURE if self_errors else SUCCESS``, and ``self_errors``
+for a workflow used to count *every* error in ``results`` — so a later workflow
+wrongly reported FAILURE even when all of its own tasks succeeded.
+
+The fix scopes a workflow's errors to its own subtree (``ancestor_id`` ==
+the workflow's config name, or a workflow-level error from its own ``_source``),
+while a scan keeps aggregating every descendant error.
+"""
+import unittest
+
+from secator.runners import Scan, Workflow
+from secator.output_types import Error
+from secator.loader import get_configs_by_type
+
+
+class TestErrorScoping(unittest.TestCase):
+	def _workflow(self):
+		workflows = get_configs_by_type('workflow')
+		if not workflows:
+			self.skipTest('No workflows configured')
+		wf = Workflow(workflows[0], inputs=['example.com'], run_opts={'dry_run': True}, context={})
+		wf.started = True
+		wf.done = True
+		return wf
+
+	def test_workflow_ignores_sibling_forwarded_error(self):
+		wf = self._workflow()
+		# An error produced by a different (earlier) workflow, forwarded into this one.
+		foreign = Error(message='boom', _source='other.task', _context={'ancestor_id': 'other_workflow'})
+		wf.add_result(foreign, print=False, output=False, hooks=False, queue=False)
+		self.assertEqual(wf.self_errors, [], 'workflow must not inherit a sibling workflow error')
+		self.assertEqual(wf.status, 'SUCCESS')
+
+	def test_workflow_counts_its_own_subtree_error(self):
+		wf = self._workflow()
+		own = Error(message='mine', _source=f'{wf.config.name}.task', _context={'ancestor_id': wf.config.name})
+		wf.add_result(own, print=False, output=False, hooks=False, queue=False)
+		self.assertIn(own, wf.self_errors)
+		self.assertEqual(wf.status, 'FAILURE')
+
+	def test_workflow_counts_its_own_direct_error(self):
+		# A workflow-level error (not from a task) carries the workflow's own _source.
+		wf = self._workflow()
+		direct = Error(message='wf-level', _source=wf.unique_name)
+		wf.add_result(direct, print=False, output=False, hooks=False, queue=False)
+		self.assertIn(direct, wf.self_errors)
+		self.assertEqual(wf.status, 'FAILURE')
+
+	def test_scan_aggregates_all_descendant_errors(self):
+		scans = get_configs_by_type('scan')
+		if not scans:
+			self.skipTest('No scans configured')
+		scan = Scan(scans[0], inputs=['example.com'], run_opts={'dry_run': True}, context={})
+		scan.started = True
+		scan.done = True
+		# An error from any child workflow's subtree must make the scan FAILURE.
+		e = Error(message='child failed', _source='wf.task', _context={'ancestor_id': 'some_workflow'})
+		scan.add_result(e, print=False, output=False, hooks=False, queue=False)
+		self.assertIn(e, scan.self_errors)
+		self.assertEqual(scan.status, 'FAILURE')
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Bug (long-standing)
When a task fails it correctly fails its workflow and the scan — but it **also** made any *subsequent* workflow in the scan report **FAILURE**, even when all of that workflow's own tasks succeeded.

## Root cause
In a scan, results forward from one workflow to the next (`chain_previous_results=True`), so a later workflow's `results` contain the `Error` outputs produced by an earlier **sibling** workflow. Status is `FAILURE if self_errors else SUCCESS`, and for a workflow `self_errors`/`errors` counted **every** `Error` in `results` (the non-task branch). So a later workflow inherited the earlier one's errors → false FAILURE.

## Fix
Scope a workflow's errors to its **own subtree** via a shared `_owns_error(r)` helper:
- **task** — errors from its own `_source` (incl. its chunks). *(unchanged)*
- **workflow** — `r._context['ancestor_id'] == self.config.name` (a workflow's tasks are tagged with that ancestor id in `Workflow.run`) **or** the error carries the workflow's own `_source` (workflow-level errors). `ancestor_id` is name-based and set at build time, so it's backend-independent and unique per sibling workflow.
- **scan / other composite** — aggregate **every** descendant error. *(unchanged)* The errors still physically remain in the results that flow up, so a scan still fails if any child failed.

So: a failing task → fails its task, its workflow, and the scan; but **not** sibling workflows whose own tasks all succeeded.

## Tests
`tests/unit/test_error_scoping.py`: a workflow ignores a sibling's forwarded error (SUCCESS), counts its own subtree error and its own direct error (FAILURE), and a scan aggregates all descendant errors (FAILURE). All pass; existing `test_runners` (56) still green; flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed error scoping in workflows to prevent sibling workflow errors from being incorrectly attributed to the current workflow.
  * Improved workflow and scan failure status computation to accurately reflect only errors originating within their execution tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->