### PR TITLE
fix(tty): rare issue with tty

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -195,7 +195,10 @@ class Command(Runner):
 		self.print_cmd = self.run_opts.get('print_cmd', False)
 
 		# TTY availability (can be explicitly disabled for non-interactive contexts)
-		self.has_tty = self.run_opts.get('tty', sys.stdin.isatty())
+		try:
+			self.has_tty = self.run_opts.get('tty', sys.stdin.isatty())
+		except (ValueError, AttributeError, OSError):
+			self.has_tty = self.run_opts.get('tty', False)
 
 		# Stat update
 		self.last_updated_stat = None


### PR DESCRIPTION
```
[17:23:59] ERROR    Dummy-11:Task secator.celery.run_command[649e293f-f7b6-42c4-8afd-137d2af66101] raised unexpected: ValueError('I/O operation on closed file')                                                             trace.py:309
                    ╭───────────────────────────────────────────────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────────────────────────────────────────────╮             
                    │ /home/bpce/Workspace/secator/.venv/lib/python3.12/site-packages/celery/app/trace.py:585 in trace_task                                                                                            │             
                    │                                                                                                                                                                                                      │             
                    │   582 │   │   │   │   │   if task_before_start:                                                                                                                                                      │             
                    │   583 │   │   │   │   │   │   task_before_start(uuid, args, kwargs)                                                                                                                                  │             
                    │   584 │   │   │   │   │                                                                                                                                                                              │             
                    │ ❱ 585 │   │   │   │   │   R = retval = fun(*args, **kwargs)                                                                                                                                          │             
                    │   586 │   │   │   │   │   state = SUCCESS                                                                                                                                                            │             
                    │   587 │   │   │   │   except Reject as exc:                                                                                                                                                          │             
                    │   588 │   │   │   │   │   I, R = Info(REJECTED, exc), ExceptionInfo(internal=True)                                                                                                                   │             
                    │                                                                                                                                                                                                      │             
                    │ /home/bpce/Workspace/secator/.venv/lib/python3.12/site-packages/celery/app/trace.py:858 in __protected_call__                                                                                    │             
                    │                                                                                                                                                                                                      │             
                    │   855 │   │   │   if req and not req._protected and \                                                                                                                                                │             
                    │   856 │   │   │   │   │   len(stack) == 1 and not req.called_directly:                                                                                                                               │             
                    │   857 │   │   │   │   req._protected = 1                                                                                                                                                             │             
                    │ ❱ 858 │   │   │   │   return self.run(*args, **kwargs)                                                                                                                                               │             
                    │   859 │   │   │   return orig(self, *args, **kwargs)                                                                                                                                                 │             
                    │   860 │   │   BaseTask.__call__ = __protected_call__                                                                                                                                                 │             
                    │   861 │   │   BaseTask._stackprotected = True                                                                                                                                                        │             
                    │                                                                                                                                                                                                      │             
                    │ /home/bpce/Workspace/secator/.venv/lib/python3.12/site-packages/secator/celery.py:238 in run_command                                                                                             │             
                    │                                                                                                                                                                                                      │             
                    │   235 │   # Initialize task                                                                                                                                                                          │             
                    │   236 │   sync = not IN_WORKER                                                                                                                                                                       │             
                    │   237 │   task_cls = Task.get_task_class(name)                                                                                                                                                       │             
                    │ ❱ 238 │   task = task_cls(targets, **opts)                                                                                                                                                           │             
                    │   239 │   chunk_it = task.needs_chunking(sync)                                                                                                                                                       │             
                    │   240 │   task.has_children = chunk_it                                                                                                                                                               │             
                    │   241 │   task.mark_started()                                                                                                                                                                        │             
                    │                                                                                                                                                                                                      │             
                    │ /home/bpce/Workspace/secator/.venv/lib/python3.12/site-packages/secator/runners/command.py:198 in __init__                                                                                       │             
                    │                                                                                                                                                                                                      │             
                    │    195 │   │   self.print_cmd = self.run_opts.get('print_cmd', False)                                                                                                                                │             
                    │    196 │   │                                                                                                                                                                                         │             
                    │    197 │   │   # TTY availability (can be explicitly disabled for non-interactive contexts)                                                                                                          │             
                    │ ❱  198 │   │   self.has_tty = self.run_opts.get('tty', sys.stdin.isatty())                                                                                                                           │             
                    │    199 │   │                                                                                                                                                                                         │             
                    │    200 │   │   # Stat update                                                                                                                                                                         │             
                    │    201 │   │   self.last_updated_stat = None                                                                                                                                                         │             
                    ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯             
                    ValueError: I/O operation on closed file
```

As per my testing, this happens only on workflows that have a structure like:

```
tasks:
  task1:
  _group:
     task2:
     task3:
  task4
```

I didn't have too much time to investigate more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal availability detection to handle edge cases more reliably, ensuring the application functions correctly even in environments where standard terminal properties cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->