### PR TITLE
fix(query): bare `type.field` resolves to a boolean match (field == True)

### DIFF
--- a/secator/query/utils.py
+++ b/secator/query/utils.py
@@ -150,8 +150,16 @@ def _split_logical_op(query, op):
 
 
 def _parse_value(raw):
-    """Convert a string token to int, float, or stripped string."""
+    """Convert a string token to bool, int, float, or stripped string."""
     raw = raw.strip().strip("'\"")
+    # Boolean literals ("True"/"true", "False"/"false") become real booleans so a
+    # comparison like `ip.alive == True` resolves to a boolean match (not the string
+    # "True") across all backends.
+    low = raw.lower()
+    if low == 'true':
+        return True
+    if low == 'false':
+        return False
     try:
         return int(raw)
     except ValueError:
@@ -283,9 +291,16 @@ def _parse_single_expr(expr):
             result[field] = value if mongo_op is None else {mongo_op: value}
         return result
 
-    # Fallback: treat as type name
+    # Fallback: a bare "type.field" with no operator is a boolean truthiness check,
+    # i.e. "ip.alive" means "ip.alive == True" (resolves identically across backends).
+    # A bare "type" with no field is just the type.
     parts = expr.split('.', 1)
-    return {'_type': parts[0].strip()}
+    _type = parts[0].strip()
+    field = parts[1].strip() if len(parts) > 1 else None
+    result = {'_type': _type}
+    if field:
+        result[field] = True
+    return result
 
 
 def _normalize_logical_ops(query):

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -59,6 +59,21 @@ class TestPythonExprToMongo:
         result = python_expr_to_mongo('domain')
         assert result == {'_type': 'domain'}
 
+    def test_bare_field_is_boolean_true(self):
+        # "ip.alive" (no operator) is a truthiness shorthand: it must resolve to a
+        # boolean match (alive == True), not drop the field. Regression for the
+        # resolved query missing the boolean comparison.
+        assert python_expr_to_mongo('ip.alive') == {'_type': 'ip', 'alive': True}
+
+    def test_bare_field_matches_explicit_eq_true(self):
+        # The bare form must resolve identically to "== True".
+        assert python_expr_to_mongo('ip.alive') == python_expr_to_mongo('ip.alive == True')
+
+    def test_boolean_literals_parse_as_bool(self):
+        assert python_expr_to_mongo('ip.alive == True') == {'_type': 'ip', 'alive': True}
+        assert python_expr_to_mongo('ip.alive == False') == {'_type': 'ip', 'alive': False}
+        assert python_expr_to_mongo('ip.alive == true') == {'_type': 'ip', 'alive': True}
+
     def test_greater_than(self):
         result = python_expr_to_mongo('vulnerability.severity_score > 7')
         assert result == {'_type': 'vulnerability', 'severity_score': {'$gt': 7}}


### PR DESCRIPTION
## Bug
`secator r show -q "ip.alive"` (and `SECATOR_DEBUG=query`) resolved with **no boolean comparison** — the `.alive` field was dropped, so it matched *all* IPs instead of alive ones.

## Root cause
In `_parse_single_expr` (secator/query/utils.py), a bare `type.field` term with no operator fell through to the fallback, which did `expr.split('.')` and returned only `{'_type': 'ip'}` — discarding the field.

Separately, `_parse_value("True")` returned the **string** `"True"`, so even `ip.alive == True` resolved to `{alive: "True"}` (string), not a real boolean match.

## Fix
- A bare `type.field` is now a **truthiness shorthand** → `{'_type': type, field: True}`. So `ip.alive` resolves **identically to `ip.alive == True`** across all backends (mongodb/sqlite/json/api — `{field: True}` is the canonical equality form each handles).
- `_parse_value` now parses `True`/`False` (case-insensitive) literals as real booleans, so `== True`/`== False` produce boolean matches too.
- Type-only (`ip`) and all comparison operators (`>`, `==`, `in`, `~=`, …) are unchanged.

## Verification
Resolved live: `ip.alive` → `{'_type':'ip','alive':True}`, identical to `ip.alive == True`; `== False` works. Added regression tests in `test_query_utils.py`. Full query suite: **150 passed** (parser + sqlite/mongodb/json/api backends + CLI + e2e); `flake8 secator/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Boolean value parsing in queries improved: string literals "true" and "false" (case-insensitive) are now correctly converted to booleans instead of being treated as text strings
  * Query field expression handling improved: bare field references are now properly evaluated as boolean truthiness conditions, enabling more intuitive query syntax

<!-- end of auto-generated comment: release notes by coderabbit.ai -->