### PR TITLE
fix(mongodb): warn instead of crashing on DocumentTooLarge

### DIFF
--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -7,7 +7,7 @@ from celery import shared_task
 
 from secator.config import CONFIG
 from secator.hooks._dedup import compute_duplicate_updates
-from secator.output_types import OUTPUT_TYPES
+from secator.output_types import OUTPUT_TYPES, Warning
 from secator.runners import Scan, Task, Workflow
 from secator.utils import debug, escape_mongodb_url
 
@@ -81,25 +81,32 @@ def update_runner(self):
 	_id = self.context.get(f'{type}_chunk_id') if chunk else self.context.get(f'{type}_id')
 	debug('to_update', sub='hooks.mongodb', id=_id, obj=get_runner_dbg(self), obj_after=True, obj_breaklines=False, verbose=True)  # noqa: E501
 	start_time = time.time()
-	if _id:
-		db = client.main
-		start_time = time.time()
-		db[collection].update_one({'_id': ObjectId(_id)}, {'$set': update})
-		end_time = time.time()
-		elapsed = end_time - start_time
-		debug(
-			f'[dim gold4]updated in {elapsed:.4f}s[/]', sub='hooks.mongodb', id=_id, obj=get_runner_dbg(self), obj_after=False)  # noqa: E501
-		self.last_updated_db = start_time
-	else:  # sync update and save result to runner object
-		runner = db[collection].insert_one(update)
-		_id = str(runner.inserted_id)
-		if chunk:
-			self.context[f'{type}_chunk_id'] = _id
-		else:
-			self.context[f'{type}_id'] = _id
-		end_time = time.time()
-		elapsed = end_time - start_time
-		debug(f'in {elapsed:.4f}s', sub='hooks.mongodb', id=_id, obj=get_runner_dbg(self), obj_after=False)
+	try:
+		if _id:
+			db = client.main
+			start_time = time.time()
+			db[collection].update_one({'_id': ObjectId(_id)}, {'$set': update})
+			end_time = time.time()
+			elapsed = end_time - start_time
+			debug(
+				f'[dim gold4]updated in {elapsed:.4f}s[/]', sub='hooks.mongodb', id=_id, obj=get_runner_dbg(self), obj_after=False)  # noqa: E501
+			self.last_updated_db = start_time
+		else:  # sync update and save result to runner object
+			runner = db[collection].insert_one(update)
+			_id = str(runner.inserted_id)
+			if chunk:
+				self.context[f'{type}_chunk_id'] = _id
+			else:
+				self.context[f'{type}_id'] = _id
+			end_time = time.time()
+			elapsed = end_time - start_time
+			debug(f'in {elapsed:.4f}s', sub='hooks.mongodb', id=_id, obj=get_runner_dbg(self), obj_after=False)
+	except pymongo.errors.DocumentTooLarge:
+		# The runner state exceeds MongoDB's 16MB BSON limit (usually huge outputs).
+		# Don't crash the runner over a persistence limit — warn and carry on.
+		msg = f'{self.unique_name} state exceeds MongoDB\'s 16MB document limit; skipping this DB update.'
+		self.add_result(Warning(message=msg), hooks=False)
+		debug(msg, sub='hooks.mongodb', id=_id)
 
 
 def update_finding(self, item):
@@ -111,13 +118,22 @@ def update_finding(self, item):
 	update = item.toDict()
 	_type = item._type
 	_id = ObjectId(item._uuid) if ObjectId.is_valid(item._uuid) else None
-	if _id:
-		finding = db['findings'].update_one({'_id': _id}, {'$set': update})
-		status = 'UPDATED'
-	else:
-		finding = db['findings'].insert_one(update)
-		item._uuid = str(finding.inserted_id)
-		status = 'CREATED'
+	try:
+		if _id:
+			finding = db['findings'].update_one({'_id': _id}, {'$set': update})
+			status = 'UPDATED'
+		else:
+			finding = db['findings'].insert_one(update)
+			item._uuid = str(finding.inserted_id)
+			status = 'CREATED'
+	except pymongo.errors.DocumentTooLarge:
+		# A single finding exceeds MongoDB's 16MB BSON limit (e.g. a huge inline
+		# response body). Warn instead of crashing the runner; return the item so
+		# the chain continues.
+		msg = f'{item._type} finding exceeds MongoDB\'s 16MB document limit; skipping persist.'
+		self.add_result(Warning(message=msg), hooks=False)
+		debug(msg, sub='hooks.mongodb', id=str(item._uuid))
+		return item
 	end_time = time.time()
 	elapsed = end_time - start_time
 	debug_obj = {

--- a/tests/unit/test_mongodb_hooks.py
+++ b/tests/unit/test_mongodb_hooks.py
@@ -1,0 +1,68 @@
+"""Regression tests for the MongoDB driver hooks.
+
+A runner whose state (or a single finding) exceeds MongoDB's 16MB BSON limit used
+to raise `pymongo.errors.DocumentTooLarge` straight through `run_hooks`, crashing
+the runner. The hooks must instead catch it, emit a Warning, and carry on.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pymongo
+
+from secator.hooks import mongodb
+from secator.output_types import Info, Warning
+
+
+class _Cfg:
+    type = "task"
+    name = "nmap"
+
+
+class _FakeRunner:
+    def __init__(self):
+        self.config = _Cfg()
+        self.context = {"task_id": "0" * 24}
+        self.unique_name = "nmap"
+        self.status = "RUNNING"
+        self.results = []
+        self.last_updated_db = None
+
+    def toDict(self):
+        return {"status": "RUNNING"}
+
+    def add_result(self, item, **kwargs):
+        self.results.append(item)
+
+
+def _client_raising_too_large():
+    """A mongo client mock whose writes all raise DocumentTooLarge."""
+    client = MagicMock()
+    coll = client.main.__getitem__.return_value
+    err = pymongo.errors.DocumentTooLarge("'update' command document too large")
+    coll.update_one.side_effect = err
+    coll.insert_one.side_effect = err
+    return client
+
+
+class TestMongoDocumentTooLarge(unittest.TestCase):
+    def test_update_runner_warns_instead_of_raising(self):
+        with patch.object(mongodb, "get_mongodb_client", return_value=_client_raising_too_large()):
+            runner = _FakeRunner()
+            mongodb.update_runner(runner)  # must not raise
+        warnings = [r for r in runner.results if isinstance(r, Warning)]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("16MB", warnings[0].message)
+
+    def test_update_finding_warns_and_returns_item(self):
+        with patch.object(mongodb, "get_mongodb_client", return_value=_client_raising_too_large()):
+            runner = _FakeRunner()
+            item = Info(message="x")
+            out = mongodb.update_finding(runner, item)  # must not raise
+        self.assertIs(out, item)  # item returned so the chain continues
+        warnings = [r for r in runner.results if isinstance(r, Warning)]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("16MB", warnings[0].message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_mongodb_hooks.py
+++ b/tests/unit/test_mongodb_hooks.py
@@ -7,10 +7,15 @@ the runner. The hooks must instead catch it, emit a Warning, and carry on.
 import unittest
 from unittest.mock import MagicMock, patch
 
-import pymongo
+import pytest
 
-from secator.hooks import mongodb
-from secator.output_types import Info, Warning
+# The mongodb addon (pymongo) is an optional extra and is NOT installed in the base
+# unit-test environment (CI). Skip this whole module cleanly when it's absent —
+# importing secator.hooks.mongodb also pulls pymongo, so guard before that import.
+pymongo = pytest.importorskip("pymongo")
+
+from secator.hooks import mongodb  # noqa: E402
+from secator.output_types import Info, Warning  # noqa: E402
 
 
 class _Cfg:


### PR DESCRIPTION
## Bug
In production, a runner whose state exceeded MongoDB's 16MB BSON limit crashed with `pymongo.errors.DocumentTooLarge: 'update' command document too large` — the error propagated from `update_runner` (hooks/mongodb.py:87) through `run_hooks`, killing the runner over a persistence limit (usually huge outputs).

## Fix
Catch `pymongo.errors.DocumentTooLarge` in both Mongo write paths and **emit a Warning** on the runner instead of raising:
- **`update_runner`** — warn and skip the DB update; the runner continues.
- **`update_finding`** — same (a single oversized finding, e.g. a huge inline response); returns the item so the result chain continues.

The Warning is added with `hooks=False` (no re-entrant on_item) and surfaces in the runner output.

## Verification
Mocked the Mongo client to raise `DocumentTooLarge`: `update_runner`/`update_finding` no longer raise and add a single Warning. Added `tests/unit/test_mongodb_hooks.py` (2 tests, pass); `flake8 secator/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MongoDB integration to gracefully handle large document scenarios. When document sizes exceed limits, the system now records warnings and continues processing instead of crashing.

* **Tests**
  * Added unit tests verifying proper handling of oversized document scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->