### PR TITLE
chore(docker): add pipx to dev image for installing python tools

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,6 +6,7 @@ RUN apk add --no-cache \
     musl-dev \
     linux-headers \
     python3-dev \
+    pipx \
     sudo
 
 RUN adduser -D secator


### PR DESCRIPTION
Adds the `pipx` apk package to `Dockerfile.dev` so Python-based tools (e.g. `wafw00f`) can be installed in isolated venvs inside the dev container.

pipx-installed apps land in `~/.local/bin`, which is already on the `secator` user's `PATH`, so installed tools are immediately invokable. Each tool gets its own venv, avoiding dependency clashes with secator's own deps.

Verified `apk add pipx` resolves cleanly on `python:3.12-alpine` (pipx 1.8.0).

Usage inside the container:
```bash
pipx install wafw00f
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to include an additional package dependency for improved development workflow support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->