### PR TITLE
fix(api-hook): refuse cleartext --driver api transport to non-loopback hosts

### DIFF
--- a/secator/hooks/api.py
+++ b/secator/hooks/api.py
@@ -16,6 +16,8 @@ import time
 import requests
 
 from functools import cache
+from ipaddress import ip_address
+from urllib.parse import urlsplit
 
 from secator.config import CONFIG
 from secator.output_types import FINDING_TYPES, Error, Info
@@ -44,9 +46,43 @@ def get_runner_dbg(runner):
 	return {runner.unique_name: runner.status, 'type': runner.config.type, 'class': runner.__class__.__name__, 'caller': runner.config.name, **runner.context}  # noqa: E501
 
 
+def _is_loopback_host(host):
+	"""Return True if host is localhost or a loopback IP address."""
+	if not host:
+		return False
+	host = host.strip('[]').lower()
+	if host == 'localhost':
+		return True
+	try:
+		return ip_address(host).is_loopback
+	except ValueError:
+		return False
+
+
+def _check_transport_security(url):
+	"""Refuse cleartext transport to a non-loopback host.
+
+	`force_ssl` only controls TLS certificate *verification*; it must never be a
+	way to ship targets/output/the Bearer key over plaintext HTTP to a remote
+	host. Allow http:// only for loopback (localhost / 127.0.0.1 / ::1) dev use.
+	"""
+	parts = urlsplit(url)
+	if parts.scheme == 'https':
+		return
+	if parts.scheme == 'http' and _is_loopback_host(parts.hostname):
+		return
+	raise Exception(
+		f'Refusing to send API data over cleartext transport to "{url}": the api driver '
+		f'transmits targets, command output and the Bearer API key. Use an https:// API_URL '
+		f'(addons.api.url) for remote hosts; plaintext http:// is only allowed for loopback. '
+		f'Note: `force_ssl:false` controls TLS cert verification only and does not enable this.'
+	)
+
+
 def _make_request(method, endpoint, data=None):
 	"""Make HTTP request to external API endpoint."""
 	url = f'{API_URL.rstrip("/")}/{endpoint.lstrip("/")}'
+	_check_transport_security(url)
 	headers = {'Content-Type': 'application/json'}
 	if API_KEY:
 		headers['Authorization'] = f'{API_HEADER_NAME} {API_KEY}'

--- a/tests/unit/test_api_hook_transport.py
+++ b/tests/unit/test_api_hook_transport.py
@@ -1,0 +1,54 @@
+"""API hook transport-security tests.
+
+The ``api`` driver POSTs runner/finding data — including raw targets, accumulated
+command output and the Bearer API key — to the configured ``addons.api.url``.
+``_make_request`` must refuse to do that over cleartext HTTP to a remote host,
+regardless of ``force_ssl`` (which only governs TLS certificate *verification*).
+Loopback http:// stays allowed for local dev. These tests pin that guard.
+"""
+
+import unittest
+from unittest import mock
+
+from secator.hooks import api as api_hook
+
+
+class TestApiHookTransportGuard(unittest.TestCase):
+	def _check(self, url):
+		with mock.patch.object(api_hook, 'API_URL', url):
+			# Stop before any real network call: the guard runs first, so if it
+			# allows the request, requests.request is reached and we short-circuit.
+			with mock.patch.object(api_hook.requests, 'request') as req:
+				req.side_effect = RuntimeError('reached_network')
+				api_hook._make_request('GET', 'workspaces')
+
+	def test_remote_http_rejected(self):
+		with self.assertRaises(Exception) as ctx:
+			self._check('http://app.secator.cloud/api')
+		self.assertIn('cleartext', str(ctx.exception).lower())
+
+	def test_remote_http_rejected_even_with_force_ssl_false(self):
+		with mock.patch.object(api_hook, 'FORCE_SSL', False):
+			with self.assertRaises(Exception) as ctx:
+				self._check('http://10.0.0.5:8081/api')
+			self.assertIn('cleartext', str(ctx.exception).lower())
+
+	def test_https_remote_allowed(self):
+		# Allowed by the guard -> proceeds to the network call (which we stub).
+		with self.assertRaises(RuntimeError) as ctx:
+			self._check('https://app.secator.cloud/api')
+		self.assertEqual(str(ctx.exception), 'reached_network')
+
+	def test_http_localhost_allowed(self):
+		with self.assertRaises(RuntimeError) as ctx:
+			self._check('http://localhost:8081/api')
+		self.assertEqual(str(ctx.exception), 'reached_network')
+
+	def test_http_loopback_ip_allowed(self):
+		with self.assertRaises(RuntimeError) as ctx:
+			self._check('http://127.0.0.1:8081/api')
+		self.assertEqual(str(ctx.exception), 'reached_network')
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
P0 transport hardening for the \`--driver api\` egress. Part of the cross-repo auth-hardening effort (\`gke-admin/docs/auth-improvements.md\` §P0). Same branch name across repos.

## Change
\`secator/hooks/api.py\` \`_make_request\` now refuses to send to a non-HTTPS \`API_URL\` unless the host is loopback (localhost/127.0.0.0-8/::1), before any network I/O. \`force_ssl:false\` can no longer enable cleartext transmission of targets/output/Bearer key to a remote host — it still controls TLS cert *verification* for loopback/dev only.

## Verification
5 unit tests (\`tests/unit/test_api_hook_transport.py\`): remote http → rejected (even with force_ssl:false); https → allowed; http://localhost + http://127.0.0.1 → allowed. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforced transport security for API calls, requiring HTTPS for remote hosts while permitting HTTP for local development (localhost and 127.0.0.1).

* **Tests**
  * Added test suite validating transport security enforcement, including verification that cleartext HTTP is blocked for remote hosts even when SSL verification is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->