### PR TITLE
fix(ffuf): guard against missing has_fuzz_keyword attribute

### DIFF
--- a/secator/tasks/ffuf.py
+++ b/secator/tasks/ffuf.py
@@ -72,6 +72,7 @@ class ffuf(HttpFuzzer):
 		},
 	}
 	encoding = 'ansi'
+	has_fuzz_keyword = False
 	install_version = 'v2.1.0'
 	install_cmd = 'go install -v github.com/ffuf/ffuf/v2@[install_version]'
 	github_handle = 'ffuf/ffuf'
@@ -103,7 +104,7 @@ class ffuf(HttpFuzzer):
 	@staticmethod
 	def on_cmd_opts(self, opts):
 		# Fuzz host header
-		if self.get_opt_value('subs') and not self.has_fuzz_keyword and len(self.inputs) > 0:
+		if self.get_opt_value('subs') and len(self.inputs) > 0 and not self.has_fuzz_keyword:
 			host = self.inputs[0].split('://')[1].split('/')[0]
 			opts['header']['value']['Host'] = f'FUZZ.{host}'
 			if self.get_opt_value('wordlist') == 'http':


### PR DESCRIPTION
## Problem

Subdomain (host-header) fuzzing runs crash with:

```
File "secator/tasks/ffuf.py", line 106, in on_cmd_opts
  if self.get_opt_value('subs') and not self.has_fuzz_keyword and len(self.inputs) > 0:
AttributeError: 'ffuf' object has no attribute 'has_fuzz_keyword'
```

## Root cause

`self.has_fuzz_keyword` is **only** assigned inside `before_init`, after an early `return` that fires when `self.inputs` is empty:

```python
if not self.inputs:
    return
fuzz_in_url = 'FUZZ' in self.inputs[0]
self.has_fuzz_keyword = ...   # never reached when inputs is empty
```

`on_cmd_opts` then reads `self.has_fuzz_keyword` **before** the `len(self.inputs) > 0` guard — Python evaluates `not self.has_fuzz_keyword` first in the `and` chain — so the attribute is dereferenced even when there are no inputs, raising `AttributeError`. `on_json_loaded` (line 143) reads the same attribute and shares the latent risk.

## Fix

- Add a class-level `has_fuzz_keyword = False` default so the attribute always exists regardless of the `before_init` path taken.
- Reorder the `on_cmd_opts` condition to `subs and len(inputs) > 0 and not has_fuzz_keyword` so the empty-inputs case short-circuits before any attribute/host parsing.

No behavior change on the normal path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of fuzzing operations by improving initialization checks and condition evaluation logic to prevent potential errors during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->