### PR TITLE
fix(nmap): repair truncated XML on timeout + per-task max timeout

### DIFF
--- a/secator/config.py
+++ b/secator/config.py
@@ -870,19 +870,96 @@ class Config(DotMap):
 		return key_map
 
 	def apply_env_overrides(self, print_errors=True):
-		"""Override config values from environment variables."""
+		"""Override config values from environment variables.
+
+		A variable ``SECATOR_<UPPERCASED_DOTTED_KEY>`` overrides the matching config key (dots replaced
+		by underscores), e.g. ``SECATOR_CELERY_BROKER_URL``. Dynamic dict keys are also supported, e.g.
+		``SECATOR_TASKS_OVERRIDES_NMAP_MAX_TIMEOUT=500`` maps to ``tasks.overrides.nmap.max_timeout``.
+		"""
 		prefix = 'SECATOR_'
 		for var in os.environ:
-			if var.startswith(prefix):
-				key = var[len(prefix) :]  # remove prefix
-				if key in self._keymap:
-					path = '.'.join(k.lower() for k in self._keymap[key])
-					value = os.environ[var]
-					self.set(path, value, set_partial=False)
-					if not self.validate(print_errors=False) and print_errors:
-						console.print(f'[bold red]{var} (override failed)[/]')
-				# elif print_errors:
-				# 	console.print(f'[bold red]{var} (override failed: key not found)[/]')
+			if not var.startswith(prefix):
+				continue
+			key = var[len(prefix):]  # remove prefix
+			path = self._resolve_env_key(key)
+			if path is None:
+				continue
+			self.set(path, os.environ[var], set_partial=False)
+			if not self.validate(print_errors=False) and print_errors:
+				console.print(f'[bold red]{var} (override failed)[/]')
+
+	def _resolve_env_key(self, key):
+		"""Resolve an env var key (``SECATOR_`` prefix already stripped) to a dotted config path.
+
+		Returns the dotted path for a direct keymap hit, or for a dynamic key nested inside a dict
+		field (e.g. ``TASKS_OVERRIDES_NMAP_MAX_TIMEOUT`` -> ``tasks.overrides.nmap.max_timeout``).
+		Returns None when the key does not map to a known config field.
+
+		Args:
+			key (str): Env var name with the ``SECATOR_`` prefix removed.
+
+		Returns:
+			str | None: Dotted config path, or None.
+		"""
+		# Direct keymap hit (also covers dynamic keys already present in the loaded config)
+		if key in self._keymap:
+			return '.'.join(k.lower() for k in self._keymap[key])
+
+		# Otherwise, find the longest keymap prefix that resolves to a dict field, then resolve the
+		# remaining dynamic segments under it.
+		best = None
+		for map_key, path_parts in self._keymap.items():
+			if not key.startswith(map_key + '_'):
+				continue
+			target = self
+			try:
+				for part in path_parts:
+					target = target[part]
+			except (KeyError, TypeError):
+				continue
+			if isinstance(target, MutableMapping) and not isinstance(target, str):
+				if best is None or len(map_key) > len(best[0]):
+					best = (map_key, path_parts)
+		if best is None:
+			return None
+
+		map_key, path_parts = best
+		remainder = key[len(map_key) + 1:].lower()  # e.g. 'nmap_max_timeout'
+		dotted_prefix = '.'.join(p.lower() for p in path_parts)
+
+		# tasks.overrides maps a task name -> {attr: value}. The task name may itself contain
+		# underscores (e.g. search_vulns), so disambiguate it against the known task list.
+		if [p.lower() for p in path_parts] == ['tasks', 'overrides']:
+			task_name = Config._match_task_name(remainder)
+			if not task_name or remainder == task_name:
+				return None
+			attr = remainder[len(task_name) + 1:]
+			return f'{dotted_prefix}.{task_name}.{attr}'
+
+		# Generic single-level dynamic dict (e.g. wordlists.defaults): the remainder is the leaf key.
+		return f'{dotted_prefix}.{remainder}'
+
+	@staticmethod
+	def _match_task_name(remainder):
+		"""Return the longest task name that prefixes an underscored remainder, else None.
+
+		Task names are read from the ``secator/tasks`` package directory (filenames match task class
+		names by convention), avoiding any task imports at config-load time.
+
+		Args:
+			remainder (str): Lowercased underscored remainder, e.g. 'search_vulns_input_chunk_size'.
+
+		Returns:
+			str | None: Matching task name, e.g. 'search_vulns'.
+		"""
+		tasks_dir = Path(__file__).parent / 'tasks'
+		if not tasks_dir.is_dir():
+			return None
+		candidates = [
+			f.stem for f in tasks_dir.glob('*.py')
+			if not f.stem.startswith('_') and (remainder == f.stem or remainder.startswith(f.stem + '_'))
+		]
+		return max(candidates, key=len) if candidates else None
 
 
 def download_files(data: dict, target_folder: Path, offline_mode: bool, type: str):

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -137,6 +137,10 @@ class Command(Runner):
 	# Profile
 	profile = 'small'
 
+	# Max execution timeout (seconds). If None, defaults to CONFIG.celery.task_max_timeout.
+	# Overridable via `secator config set tasks.overrides.<task>.max_timeout <seconds>`.
+	max_timeout = None
+
 	def __init__(self, inputs=[], **run_opts):
 
 		# Build runnerconfig on-the-fly
@@ -695,6 +699,17 @@ class Command(Runner):
 			self.monitor_stop_event.set()
 			self.monitor_thread.join(timeout=2.0)
 
+	def get_max_timeout(self):
+		"""Resolve the effective max execution timeout (seconds).
+
+		Uses the per-task ``max_timeout`` (set on the class or via
+		``tasks.overrides.<task>.max_timeout``) when defined, otherwise falls back to the global
+		``CONFIG.celery.task_max_timeout``. A value of -1 means no timeout.
+		"""
+		if self.max_timeout is not None:
+			return self.max_timeout
+		return CONFIG.celery.task_max_timeout
+
 	def _monitor_process(self):
 		"""Monitor thread that checks process health and kills if necessary."""
 		last_stats_time = 0
@@ -726,10 +741,11 @@ class Command(Runner):
 							break
 
 				# Check execution time
-				if self.process_start_time and CONFIG.celery.task_max_timeout != -1:
+				max_timeout = self.get_max_timeout()
+				if self.process_start_time and max_timeout != -1:
 					elapsed_time = current_time - self.process_start_time
-					if elapsed_time > CONFIG.celery.task_max_timeout:
-						warning = Warning(message=f'Task timeout {CONFIG.celery.task_max_timeout}s exceeded')
+					if elapsed_time > max_timeout:
+						warning = Warning(message=f'Task timeout {max_timeout}s exceeded: incomplete results saved')
 						if self.monitor_queue is not None:
 							self.monitor_queue.put(warning)
 						self.stop_process(exit_ok=True, sig=signal.SIGTERM)

--- a/secator/tasks/nmap.py
+++ b/secator/tasks/nmap.py
@@ -194,6 +194,10 @@ class nmap(ReconPort):
 		results = []
 		with open(self.output_path, 'r') as f:
 			content = f.read()
+			# nmap may produce truncated XML when killed (e.g. task timeout exceeded), missing the closing
+			# </nmaprun> tag. Repair it so the partial results can still be parsed.
+			if '<nmaprun' in content and '</nmaprun>' not in content:
+				content = content.rstrip() + '\n</nmaprun>\n'
 			try:
 				results = xmltodict.parse(content)  # parse XML to dict
 			except Exception as exc:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -84,6 +84,50 @@ class TestConfig(unittest.TestCase):
 		yaml_data = Config.read_yaml(self.config_test)
 		self.assertEqual(yaml_data['tasks']['overrides']['nuclei']['input_chunk_size'], 100)
 
+	def _parse_with_env(self, **env):
+		"""Parse a fresh config with the given SECATOR_* env vars set, then clean them up."""
+		from secator.config import Config
+		added = []
+		try:
+			for k, v in env.items():
+				os.environ[k] = v
+				added.append(k)
+			return Config.parse(path=self.config_test)
+		finally:
+			for k in added:
+				os.environ.pop(k, None)
+
+	def test_env_override_task_overrides_simple_name(self):
+		"""SECATOR_TASKS_OVERRIDES_NMAP_MAX_TIMEOUT maps to tasks.overrides.nmap.max_timeout (int)."""
+		config = self._parse_with_env(SECATOR_TASKS_OVERRIDES_NMAP_MAX_TIMEOUT='500')
+		self.assertEqual(config.tasks.overrides['nmap']['max_timeout'], 500)
+		self.assertIsInstance(config.tasks.overrides['nmap']['max_timeout'], int)
+
+	def test_env_override_task_overrides_underscore_name(self):
+		"""Task names containing underscores (search_vulns) disambiguate correctly from the attr."""
+		config = self._parse_with_env(SECATOR_TASKS_OVERRIDES_SEARCH_VULNS_INPUT_CHUNK_SIZE='7')
+		self.assertEqual(config.tasks.overrides['search_vulns']['input_chunk_size'], 7)
+
+	def test_env_override_unknown_task_is_ignored(self):
+		"""An env override targeting an unknown task name is ignored (no crash, no key)."""
+		config = self._parse_with_env(SECATOR_TASKS_OVERRIDES_NOTATASK_FOO='1')
+		self.assertNotIn('notatask', config.tasks.overrides)
+
+	def test_env_override_dynamic_dict_existing_key(self):
+		"""SECATOR_PAYLOADS_TEMPLATES_LSE overrides an existing payloads.templates entry."""
+		config = self._parse_with_env(SECATOR_PAYLOADS_TEMPLATES_LSE='https://mycustomtemplates.sh')
+		self.assertEqual(config.payloads.templates['lse'], 'https://mycustomtemplates.sh')
+
+	def test_env_override_dynamic_dict_new_key(self):
+		"""SECATOR_PAYLOADS_TEMPLATES_MYCUSTOM adds a new payloads.templates entry."""
+		config = self._parse_with_env(SECATOR_PAYLOADS_TEMPLATES_MYCUSTOM='https://new.sh')
+		self.assertEqual(config.payloads.templates['mycustom'], 'https://new.sh')
+
+	def test_env_override_direct_key_still_works(self):
+		"""A non-dynamic env override (SECATOR_CELERY_TASK_MAX_TIMEOUT) still applies."""
+		config = self._parse_with_env(SECATOR_CELERY_TASK_MAX_TIMEOUT='999')
+		self.assertEqual(config.celery.task_max_timeout, 999)
+
 	def test_set_workspace_profiles(self):
 		"""Test setting per-workspace default profiles via comma-separated string."""
 		from secator.config import Config

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -64,6 +64,98 @@ class TestTasks(unittest.TestCase, CommandOutputTester):
 			raise AssertionError("\n\n" + "\n\n".join(failures))
 
 
+class TestNmapTruncatedXml(unittest.TestCase):
+	"""nmap may produce truncated XML (missing </nmaprun>) when killed, e.g. on task timeout."""
+
+	def _parse(self, content):
+		from secator.output_types import Error, Port
+		from secator.tasks.nmap import nmap
+		fixtures_dir = os.path.join(os.path.dirname(__file__), '..', 'fixtures')
+		path = os.path.join(fixtures_dir, '_nmap_truncated_test.xml')
+		with open(path, 'w') as f:
+			f.write(content)
+		try:
+			task = nmap.__new__(nmap)
+			task.output_path = path
+			results = list(task.xml_to_json())
+		finally:
+			os.remove(path)
+		errors = [r for r in results if isinstance(r, Error)]
+		ports = [r for r in results if isinstance(r, Port)]
+		return errors, ports
+
+	def _load_full_fixture(self):
+		path = os.path.join(os.path.dirname(__file__), '..', 'fixtures', 'nmap_output.xml')
+		with open(path) as f:
+			return f.read()
+
+	def test_full_xml_parses(self):
+		"""A complete XML output parses without errors and yields ports."""
+		errors, ports = self._parse(self._load_full_fixture())
+		self.assertEqual(errors, [])
+		self.assertTrue(len(ports) > 0)
+
+	def test_truncated_xml_is_repaired(self):
+		"""XML truncated before </nmaprun> (host complete) is repaired and still yields ports."""
+		full = self._load_full_fixture()
+		truncated = full.split('</host>')[0] + '</host>\n'  # complete host but no runstats/</nmaprun>
+		errors, ports = self._parse(truncated)
+		self.assertEqual(errors, [])
+		self.assertTrue(len(ports) > 0)
+
+	def test_truncated_xml_no_host_does_not_error(self):
+		"""XML truncated mid-scan (no completed host) is repaired and parses without errors."""
+		truncated = (
+			'<?xml version="1.0" encoding="UTF-8"?>\n'
+			'<!DOCTYPE nmaprun>\n'
+			'<nmaprun scanner="nmap" args="nmap -p - secator.cloud" start="1781863253" version="7.98">\n'
+			'<scaninfo type="connect" protocol="tcp" numservices="65535" services="1-65535"/>\n'
+			'<verbose level="0"/>\n'
+			'<taskprogress task="Connect Scan" time="1781863273" percent="12.10" remaining="139" etc="1781863411"/>\n'
+		)
+		errors, ports = self._parse(truncated)
+		self.assertEqual(errors, [])
+
+
+class TestMaxTimeout(unittest.TestCase):
+	"""Per-task max_timeout resolution (class attribute, config override, global fallback)."""
+
+	def test_default_falls_back_to_global(self):
+		"""max_timeout=None resolves to CONFIG.celery.task_max_timeout."""
+		from secator.tasks.nmap import nmap
+		task = nmap.__new__(nmap)
+		self.assertIsNone(task.max_timeout)  # default class attribute
+		with unittest.mock.patch('secator.runners.command.CONFIG') as mock_config:
+			mock_config.celery.task_max_timeout = 42
+			self.assertEqual(task.get_max_timeout(), 42)
+
+	def test_per_task_value_takes_precedence(self):
+		"""A per-task max_timeout overrides the global default."""
+		from secator.tasks.nmap import nmap
+		task = nmap.__new__(nmap)
+		task.max_timeout = 100
+		with unittest.mock.patch('secator.runners.command.CONFIG') as mock_config:
+			mock_config.celery.task_max_timeout = 42
+			self.assertEqual(task.get_max_timeout(), 100)
+
+	def test_disabled_timeout_resolves_to_minus_one(self):
+		"""A per-task max_timeout of -1 (no timeout) is honored over a global limit."""
+		from secator.tasks.nmap import nmap
+		task = nmap.__new__(nmap)
+		task.max_timeout = -1
+		with unittest.mock.patch('secator.runners.command.CONFIG') as mock_config:
+			mock_config.celery.task_max_timeout = 42
+			self.assertEqual(task.get_max_timeout(), -1)
+
+	def test_config_override_sets_instance_attribute(self):
+		"""`tasks.overrides.<task>.max_timeout` is parsed as int and applied as an attribute."""
+		from secator.config import CONFIG
+		CONFIG.set('tasks.overrides.nmap.max_timeout', '100')
+		override = CONFIG.tasks.overrides.get('nmap', {})
+		self.assertEqual(override.get('max_timeout'), 100)
+		self.assertIsInstance(override.get('max_timeout'), int)
+
+
 class TestSearchVulnsGrouping(unittest.TestCase):
 
 	def _load_fixture(self):


### PR DESCRIPTION
## Problem

When nmap is killed because it exceeded `task_max_timeout`, it writes XML missing the closing `</nmaprun>` tag. Parsing then fails with:

```
[ERR] nmap Cannot parse XML output ... to valid JSON.
xml.parsers.expat.ExpatError: no element found: line 16, column 0
```

All partial results (ports discovered before the kill) are lost.

## Changes

**1. Repair truncated nmap XML** (`secator/tasks/nmap.py`)
Before parsing, if the document opened `<nmaprun` but never closed it, append the missing `</nmaprun>`. Ports found before the kill are now returned instead of discarded.

**2. Per-task max timeout** (`secator/runners/command.py`)
- New `max_timeout` class attribute on `Command` (default `None`), so any task can define its own timeout.
- Overridable via `secator config set tasks.overrides.<task>.max_timeout <seconds>`.
- Falls back to `CONFIG.celery.task_max_timeout` when `None`; `-1` means no timeout.
- Resolution centralized in `Command.get_max_timeout()`.

**3. Env-var overrides for dynamic dict keys** (`secator/config.py`)
`apply_env_overrides` previously only applied env vars whose key already existed in the keymap, so dynamic dict keys (absent at startup) were silently dropped. Env keys are now resolved against the longest matching dict-field prefix and the remaining dynamic segments are mapped:
- `tasks.overrides.<task>.<attr>` — the task name (which may contain underscores, e.g. `search_vulns`) is disambiguated against the task list read from the `tasks/` directory (filenames == class names), with no task imports at config-load time.
- single-level dynamic dicts (`payloads.templates.<name>`, `wordlists.defaults.<name>`, …) — the remainder is the leaf key.

Now working (values coerced to their type via the existing `set()` machinery; unknown keys ignored):
```
SECATOR_TASKS_OVERRIDES_NMAP_MAX_TIMEOUT=500
SECATOR_TASKS_OVERRIDES_SEARCH_VULNS_INPUT_CHUNK_SIZE=7
SECATOR_PAYLOADS_TEMPLATES_LSE=https://example.sh
```

**4. Clearer warning**
`Task timeout {n}s exceeded` → `Task timeout {n}s exceeded: incomplete results saved`.

## Tests

- `tests/unit/test_tasks.py`:
  - `TestNmapTruncatedXml` — full XML still parses; truncated XML (with/without a completed host) is repaired and still yields ports.
  - `TestMaxTimeout` — global fallback, per-task precedence, `-1` disabled, config-override int coercion.
- `tests/unit/test_config.py` — 6 env-override tests: simple task name, underscore task disambiguation, unknown-task ignored, existing/new single-level dynamic dict keys, and a non-dynamic direct key.

`test_tasks.py` (13) and `test_config.py` (42) pass in isolation via `secator test unit` (`SECATOR_DIRS_DATA=/tmp/.secator`). The unrelated failures in `test_cli`/`test_cve`/`test_offline` when running the whole suite at once are pre-existing (network/install + cross-module test-ordering pollution) and present on clean `main`. Lint clean on all changed source/test code (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)