### PR TITLE
fix(katana): use extra_large profile for headless crawls

### DIFF
--- a/secator/tasks/katana.py
+++ b/secator/tasks/katana.py
@@ -82,7 +82,11 @@ class katana(HttpCrawler):
 			opts_conf=dict(katana.opts, **katana.meta_opts),
 			opt_aliases=opts.get('aliases', []),
 		)
-		return 'large' if headless is True else 'medium'
+		# Headless crawls render pages in a browser and can hold large result
+		# sets in memory (deduplicating/forwarding tens of thousands of URLs),
+		# which has caused workers to exceed the `large` memory budget and get
+		# evicted under node memory pressure. Use `extra_large` for headroom.
+		return 'extra_large' if headless is True else 'medium'
 
 	@staticmethod
 	def on_init(self):


### PR DESCRIPTION
## Why

Headless katana crawls render pages in a browser and can hold large result sets in memory (deduplicating / forwarding tens of thousands of URLs). On the `large` profile this pushed a worker's memory past the **node** memory-eviction threshold, so the kubelet evicted the pod (`BackoffLimitExceeded`), the task was marked `FAILURE`, and the rest of the workflow could not run.

### Concrete incident (prod, 2026-06-19)
- ScaledJob `worker-large-jbstc` (`-Q large,results`) ran katana task `6a34d44ff63623b2893db6ae`
- Worker deduplicated/forwarded **37,643** results, then started the headless crawl.
- `05:32:38  Evicted: The node was low on resource: memory. Threshold quantity: 100Mi, available: 65908Ki` → `Killing: Stopping container worker-large`.
- This was a **node memory-pressure eviction** (SIGTERM→SIGKILL), not a per-container cgroup OOMKill. Task ended `status: FAILURE`, `progress: 0`.

## What

`katana.dynamic_profile` now returns `extra_large` (was `large`) for headless crawls, routing them to the `extra_large` queue/worker for memory headroom. Non-headless crawls stay on `medium`.

`extra_large` is an existing profile (also used by `dalfox` and `nuclei`) with a dedicated worker in the prod fleet.

## Note

This is an interim mitigation. The deeper issue — a worker killed mid-task (eviction **or** OOMKill) leaving the task/workflow stuck — needs orchestration-level handling (worker-loss redelivery / chord-failure propagation) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved memory resource allocation for headless browser crawling to enhance stability and performance during web reconnaissance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->