### PR TITLE
feat(celery): cap worker-loss redeliveries to abandon repeatedly-killed tasks

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -15,7 +15,7 @@ from retry import retry
 from secator.celery_signals import setup_handlers
 from secator.definitions import IN_WORKER
 from secator.config import CONFIG
-from secator.output_types import Info, Target as TargetOutput
+from secator.output_types import Error, Info, Target as TargetOutput
 from secator.rich import console
 from secator.runners import Scan, Task, Workflow
 from secator.runners._helpers import run_extractors
@@ -200,6 +200,81 @@ def start_runner(self, config, targets, results=[], run_opts={}, hooks={}, valid
 	runner.run()
 
 
+def bump_worker_loss_count(task_id):
+	"""Increment and return the worker-loss delivery count for a Celery task id.
+
+	Stored on the Celery result backend (via its generic key/value interface) so it survives a
+	worker being killed and works with whatever backend is configured — Redis, filesystem, cache,
+	S3/GCS, etc. — not just Redis. Returns 1 on the first delivery, 2 on the first redelivery, and
+	so on. Returns 0 (cap disabled) if the backend supports neither atomic ``incr`` nor
+	``get``/``set`` (e.g. the database/RPC backends), so the cap simply no-ops there.
+
+	Args:
+		task_id (str): Celery request id (stable across worker-loss redeliveries).
+
+	Returns:
+		int: Number of times this task has been delivered, or 0 if unsupported.
+	"""
+	backend = app.backend
+	key = backend.get_key_for_task(f'worker-loss-{task_id}')
+
+	# Preferred: atomic incr (Redis, Memcached) — race-free.
+	try:
+		return backend.incr(key)
+	except NotImplementedError:
+		pass  # Backend has no atomic counter; fall back to get/set below.
+	except Exception as e:
+		debug(f'worker-loss incr failed for {task_id}: {e}', sub='celery.state')
+		return 0
+
+	# Fallback: get/set, implemented by every key/value result backend (filesystem, S3, GCS, ...).
+	# Worker-loss redeliveries of the same task id are sequential (only one attempt runs at a
+	# time), so a non-atomic read-modify-write is safe here.
+	try:
+		raw = backend.get(key)
+		count = (int(raw) if raw else 0) + 1
+		backend.set(key, str(count))
+		return count
+	except Exception as e:
+		debug(f'worker-loss get/set failed for {task_id}: {e}', sub='celery.state')
+		return 0
+
+
+def abandon_task(name, targets, opts, results):
+	"""Abandon a task that has exhausted its worker-loss retries.
+
+	Returns a normal (forwarded) result list with an Error appended, so the surrounding
+	chord/chain proceeds and the workflow finishes instead of hanging forever on a task whose
+	worker keeps getting killed (OOM / eviction).
+
+	Args:
+		name (str): Task name.
+		targets (list): Task targets.
+		opts (dict): Task options (already carries context).
+		results (list): Incoming results from upstream tasks.
+
+	Returns:
+		list: Forwarded results including a FAILURE Error for this task.
+	"""
+	results = forward_results(results)
+	opts['results'] = results
+	opts['sync'] = True
+	task_cls = Task.get_task_class(name)
+	task = task_cls(targets, **opts)
+	task.mark_started()
+	task.add_result(Error(
+		message=(
+			f'Task {name} abandoned after {CONFIG.celery.task_max_retries} retries '
+			'(worker repeatedly lost — likely OOM kill or node eviction).'
+		),
+		_source=task.unique_name,
+	))
+	task.mark_completed()
+	if CONFIG.addons.mongodb.enabled:
+		return chain_results(task.results)
+	return task.results
+
+
 @app.task(bind=True)
 def run_command(self, results, name, targets, opts={}):
 	# Set Celery request id in context
@@ -223,6 +298,16 @@ def run_command(self, results, name, targets, opts={}):
 		routing_key = self.request.delivery_info['routing_key']
 		context['routing_key'] = routing_key
 		debug(f'Task "{name}" running with routing key "{routing_key}"', sub='celery.state')
+
+		# Worker-loss redelivery cap. With task_acks_late + task_reject_on_worker_lost, a task
+		# whose worker is killed (cgroup OOMKill of the child, or a node-pressure eviction) is
+		# redelivered with the SAME Celery id. Count redeliveries on the result backend and
+		# abandon after task_max_retries, so a task that OOMs every run can't loop forever and
+		# block the surrounding chord/workflow.
+		if CONFIG.celery.task_max_retries != -1 and CONFIG.celery.task_acks_late:
+			delivery_count = bump_worker_loss_count(self.request.id)
+			if delivery_count > CONFIG.celery.task_max_retries:
+				return abandon_task(name, targets, opts, results)
 
 	# Flatten + dedupe + filter results
 	results = forward_results(results)

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -257,7 +257,7 @@ def bump_worker_loss_count(task_id):
 		return 0
 
 
-def abandon_task(name, targets, opts, results):
+def abandon_task(name, targets, opts, results, delivery_count=None):
 	"""Abandon a task that has exhausted its worker-loss retries.
 
 	Returns a normal (forwarded) result list with an Error appended, so the surrounding
@@ -269,6 +269,9 @@ def abandon_task(name, targets, opts, results):
 		targets (list): Task targets.
 		opts (dict): Task options (already carries context).
 		results (list): Incoming results from upstream tasks.
+		delivery_count (int | None): How many times this task was delivered (a redelivery
+			is the broker's doing under ``task_acks_late``; it is NOT a re-run of the work).
+			Reported separately from the retry cap so the message is unambiguous.
 
 	Returns:
 		list: Forwarded results including a FAILURE Error for this task.
@@ -279,10 +282,12 @@ def abandon_task(name, targets, opts, results):
 	task_cls = Task.get_task_class(name)
 	task = task_cls(targets, **opts)
 	task.mark_started()
+	attempts = f'{delivery_count} delivery attempts' if delivery_count is not None else 'repeated delivery attempts'
 	task.add_result(Error(
 		message=(
-			f'Task {name} abandoned after {CONFIG.celery.task_max_retries} retries '
-			'(worker repeatedly lost — likely OOM kill or node eviction).'
+			f'Task {name} abandoned after {attempts} '
+			f'(retry cap: {CONFIG.celery.task_max_retries}; worker repeatedly lost — '
+			'likely OOM kill or node eviction).'
 		),
 		_source=task.unique_name,
 	))
@@ -336,7 +341,7 @@ def run_command(self, results, name, targets, opts={}):
 		if CONFIG.celery.task_max_retries != -1 and CONFIG.celery.task_acks_late:
 			delivery_count = bump_worker_loss_count(self.request.id)
 			if worker_loss_retries_exhausted(delivery_count, CONFIG.celery.task_max_retries):
-				return abandon_task(name, targets, opts, results)
+				return abandon_task(name, targets, opts, results, delivery_count)
 
 	# Flatten + dedupe + filter results
 	results = forward_results(results)

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -98,6 +98,8 @@ app.conf.update(
 		'worker_pool_restarts': True,
 		'worker_prefetch_multiplier': CONFIG.celery.worker_prefetch_multiplier,
 		'worker_send_task_events': CONFIG.celery.worker_send_task_events,
+		'worker_cancel_long_running_tasks_on_connection_loss':
+			CONFIG.celery.worker_cancel_long_running_tasks_on_connection_loss,
 	}
 )
 app.autodiscover_tasks(['secator.hooks.mongodb'], related_name=None)
@@ -200,6 +202,18 @@ def start_runner(self, config, targets, results=[], run_opts={}, hooks={}, valid
 	runner.run()
 
 
+def _expire_worker_loss_key(backend, key):
+	"""Best-effort TTL on a worker-loss counter key so they don't accumulate forever.
+
+	Tied to ``result_expires`` (the lifetime of the task's own result). Not all result
+	backends implement ``expire``; ignore if unsupported.
+	"""
+	try:
+		backend.expire(key, CONFIG.celery.result_expires)
+	except Exception:
+		pass
+
+
 def bump_worker_loss_count(task_id):
 	"""Increment and return the worker-loss delivery count for a Celery task id.
 
@@ -220,7 +234,9 @@ def bump_worker_loss_count(task_id):
 
 	# Preferred: atomic incr (Redis, Memcached) — race-free.
 	try:
-		return backend.incr(key)
+		count = backend.incr(key)
+		_expire_worker_loss_key(backend, key)
+		return count
 	except NotImplementedError:
 		pass  # Backend has no atomic counter; fall back to get/set below.
 	except Exception as e:
@@ -234,6 +250,7 @@ def bump_worker_loss_count(task_id):
 		raw = backend.get(key)
 		count = (int(raw) if raw else 0) + 1
 		backend.set(key, str(count))
+		_expire_worker_loss_key(backend, key)
 		return count
 	except Exception as e:
 		debug(f'worker-loss get/set failed for {task_id}: {e}', sub='celery.state')
@@ -275,6 +292,18 @@ def abandon_task(name, targets, opts, results):
 	return task.results
 
 
+def worker_loss_retries_exhausted(delivery_count, max_retries):
+	"""Whether a task has exhausted its allowed worker-loss redeliveries.
+
+	``delivery_count`` includes the INITIAL delivery (it is 1 on first run), so the
+	number of *redeliveries* is ``delivery_count - 1``. We abandon once redeliveries
+	exceed ``max_retries`` — i.e. ``task_max_retries=3`` allows the initial run plus 3
+	redeliveries (4 attempts total) before abandoning. (The initial delivery must not
+	count as a retry — that was the off-by-one in the original cap.)
+	"""
+	return (delivery_count - 1) > max_retries
+
+
 @app.task(bind=True)
 def run_command(self, results, name, targets, opts={}):
 	# Set Celery request id in context
@@ -306,7 +335,7 @@ def run_command(self, results, name, targets, opts={}):
 		# block the surrounding chord/workflow.
 		if CONFIG.celery.task_max_retries != -1 and CONFIG.celery.task_acks_late:
 			delivery_count = bump_worker_loss_count(self.request.id)
-			if delivery_count > CONFIG.celery.task_max_retries:
+			if worker_loss_retries_exhausted(delivery_count, CONFIG.celery.task_max_retries):
 				return abandon_task(name, targets, opts, results)
 
 	# Flatten + dedupe + filter results

--- a/secator/config.py
+++ b/secator/config.py
@@ -74,6 +74,7 @@ class Celery(StrictModel):
 	task_acks_late: bool = False
 	task_send_sent_event: bool = False
 	task_reject_on_worker_lost: bool = False
+	task_max_retries: int = -1  # max worker-loss redeliveries before abandoning a task (-1 = unlimited / disabled)
 	task_max_timeout: int = -1
 	task_memory_limit_mb: int = -1
 	worker_max_tasks_per_child: int = 20

--- a/secator/config.py
+++ b/secator/config.py
@@ -83,6 +83,10 @@ class Celery(StrictModel):
 	worker_kill_after_task: bool = False
 	worker_kill_after_idle_seconds: int = -1
 	worker_command_verbose: bool = False
+	# Cancel (and redeliver, with acks_late) a worker's in-flight tasks when it loses the broker
+	# connection, instead of letting them run detached as zombies. Part of the OOM/eviction
+	# robustness layer; enable in deployment alongside task_acks_late + task_reject_on_worker_lost.
+	worker_cancel_long_running_tasks_on_connection_loss: bool = False
 
 
 class Cli(StrictModel):

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -341,6 +341,60 @@ class TestDelayMethods(unittest.TestCase):
 		self.assertIsNotNone(sig)
 
 
+class TestWorkerLossRetryCap(unittest.TestCase):
+	"""Worker-loss redelivery cap (task_acks_late + task_reject_on_worker_lost)."""
+
+	def test_bump_worker_loss_count_get_set_fallback(self):
+		"""Counter increments via the generic get/set fallback (any KV backend, e.g. filesystem)."""
+		from secator.celery import app, bump_worker_loss_count
+
+		# Use a unique id so reruns don't collide, and clean up the backend key afterwards.
+		task_id = f'wl-test-{id(self)}'
+		key = app.backend.get_key_for_task(f'worker-loss-{task_id}')
+		try:
+			self.assertEqual(bump_worker_loss_count(task_id), 1)
+			self.assertEqual(bump_worker_loss_count(task_id), 2)
+			self.assertEqual(bump_worker_loss_count(task_id), 3)
+			# A different task id is counted independently.
+			self.assertEqual(bump_worker_loss_count(f'{task_id}-other'), 1)
+		finally:
+			try:
+				app.backend.delete(key)
+				app.backend.delete(app.backend.get_key_for_task(f'worker-loss-{task_id}-other'))
+			except Exception:
+				pass
+
+	def test_bump_worker_loss_count_prefers_atomic_incr(self):
+		"""When the backend implements atomic incr (Redis/Memcached), it is used directly."""
+		from unittest.mock import patch
+		from secator.celery import app, bump_worker_loss_count
+
+		with patch.object(app.backend, 'incr', return_value=42, create=True) as mock_incr:
+			self.assertEqual(bump_worker_loss_count('task-abc'), 42)
+			mock_incr.assert_called_once()
+
+	def test_bump_worker_loss_count_disabled_without_kv(self):
+		"""Returns 0 (cap disabled) on backends with neither incr nor get/set (db/RPC)."""
+		from unittest.mock import patch
+		from secator.celery import app, bump_worker_loss_count
+
+		with patch.object(app.backend, 'incr', side_effect=NotImplementedError, create=True), \
+				patch.object(app.backend, 'get', side_effect=NotImplementedError, create=True):
+			self.assertEqual(bump_worker_loss_count('task-abc'), 0)
+
+	def test_abandon_task_returns_failure_error(self):
+		"""Abandoning returns results with a self-owned FAILURE Error so the chord proceeds."""
+		from secator.tasks import httpx
+		from secator.celery import abandon_task
+		if httpx not in TEST_TASKS:
+			return
+
+		results = abandon_task('httpx', ['example.com'], {'context': {}}, [])
+		errors = [r for r in results if r._type == 'error']
+		self.assertEqual(len(errors), 1)
+		self.assertIn('abandoned after', errors[0].message)
+
+
 class TestRunnerPickle(unittest.TestCase):
 	"""Test that Runner objects with dynamic driver hooks can be pickled/unpickled."""
 

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -389,10 +389,13 @@ class TestWorkerLossRetryCap(unittest.TestCase):
 		if httpx not in TEST_TASKS:
 			return
 
-		results = abandon_task('httpx', ['example.com'], {'context': {}}, [])
+		results = abandon_task('httpx', ['example.com'], {'context': {}}, [], delivery_count=2)
 		errors = [r for r in results if r._type == 'error']
 		self.assertEqual(len(errors), 1)
-		self.assertIn('abandoned after', errors[0].message)
+		# Message separates delivery attempts (broker redeliveries) from the retry cap, so it
+		# reads sensibly even when the cap is 0 (a redelivery still occurs; the work isn't re-run).
+		self.assertIn('abandoned after 2 delivery attempts', errors[0].message)
+		self.assertIn('retry cap:', errors[0].message)
 
 	def test_retries_exhausted_does_not_count_initial_delivery(self):
 		"""delivery_count includes the initial run; task_max_retries=N allows N redeliveries."""

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -394,6 +394,28 @@ class TestWorkerLossRetryCap(unittest.TestCase):
 		self.assertEqual(len(errors), 1)
 		self.assertIn('abandoned after', errors[0].message)
 
+	def test_retries_exhausted_does_not_count_initial_delivery(self):
+		"""delivery_count includes the initial run; task_max_retries=N allows N redeliveries."""
+		from secator.celery import worker_loss_retries_exhausted
+		# task_max_retries=3 -> initial (1) + 3 redeliveries (2,3,4) allowed, abandon on the 5th delivery.
+		self.assertFalse(worker_loss_retries_exhausted(1, 3))  # initial run
+		self.assertFalse(worker_loss_retries_exhausted(2, 3))  # redelivery 1
+		self.assertFalse(worker_loss_retries_exhausted(3, 3))  # redelivery 2
+		self.assertFalse(worker_loss_retries_exhausted(4, 3))  # redelivery 3 (last allowed)
+		self.assertTrue(worker_loss_retries_exhausted(5, 3))   # redelivery 4 -> abandon
+		# task_max_retries=0 -> no redeliveries; abandon on the first redelivery, not the initial run.
+		self.assertFalse(worker_loss_retries_exhausted(1, 0))
+		self.assertTrue(worker_loss_retries_exhausted(2, 0))
+
+	def test_worker_cancel_flag_wired_to_app_conf(self):
+		"""The worker_cancel_long_running_tasks_on_connection_loss config flag reaches app.conf."""
+		from secator.celery import app
+		from secator.config import CONFIG
+		self.assertEqual(
+			app.conf.worker_cancel_long_running_tasks_on_connection_loss,
+			CONFIG.celery.worker_cancel_long_running_tasks_on_connection_loss,
+		)
+
 
 class TestRunnerPickle(unittest.TestCase):
 	"""Test that Runner objects with dynamic driver hooks can be pickled/unpickled."""


### PR DESCRIPTION
## Problem

When a worker is killed mid-task — a cgroup **OOMKill** of the child process, or a node **memory-pressure eviction** — the task never returns a result. With `task_acks_late` + `task_reject_on_worker_lost`, the broker redelivers the task (same Celery id) to a fresh worker. That's the desired recovery, **except** for a task that OOMs on *every* run (e.g. a memory spike the inner `task_memory_limit_mb` monitor doesn't catch in time): it loops forever — OOM → redeliver → OOM — and the surrounding chord/workflow can **never complete**.

This was hit in prod: a headless `katana` task on `worker-large` was evicted (`The node was low on resource: memory`), the Job failed (`BackoffLimitExceeded`), and the workflow stalled.

## Change

Add **`celery.task_max_retries`** (`-1` = disabled). `run_command` counts redeliveries (keyed by the stable Celery id) and, once the cap is exceeded, **abandons** the task instead of re-running it: it returns a forwarded result list with a `FAILURE` `Error` appended (`"Task <name> abandoned after N retries (worker repeatedly lost — likely OOM kill or node eviction)."`), so the chord proceeds and the workflow finishes cleanly — mirroring the existing inner memory-limit warning.

### Backend-agnostic counter
The counter lives on the **Celery result backend's generic key/value interface**, not Redis internals and not any Secator data backend (Mongo/Postgres/SQLite):
- atomic `incr` when the backend provides it (Redis, Memcached) — race-free;
- `get`/`set` read-modify-write otherwise (filesystem, S3, GCS, cache, …) — safe because same-task redeliveries are **sequential**;
- backends with neither (database/RPC) degrade to *cap disabled* (no crash).

## Safety / rollout
**Inert by default** — `task_max_retries=-1` and `task_acks_late=False` ship unchanged, so this commit changes no behavior. Enabling the cap requires, at deploy time:
- `task_acks_late=1` + `task_reject_on_worker_lost=1`,
- `task_max_retries` set (e.g. `3`),
- ⚠️ **`broker_visibility_timeout` raised above the max task lifetime** (tasks run up to `activeDeadlineSeconds=10800`); leaving it at the default 1h would duplicate-execute long tasks once `acks_late` is on.

## Tests
`tests/unit/test_celery.py` — get/set fallback (real filesystem backend), atomic-incr path, unsupported-backend degradation, and the abandon path returning a `FAILURE` error. Full file: 22 passing.

## Scope note
This fully covers the **child-OOMKill retry loop**. A **whole-pod eviction** kills the parent too, so its redelivery comes via the slower Redis visibility-timeout restore; that case is primarily addressed by task-profile sizing (see #1198) + Guaranteed QoS. Externally un-sticking an already-stuck chord is a separate follow-up (Layer 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable worker-loss retry limit for tasks. When a task exceeds the maximum allowed retries after worker loss, it is automatically abandoned and marked as failed rather than retried indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->