### PR TITLE
feat(routing): allow tasks.overrides.<task>.profile to re-route static-profile tasks

### DIFF
--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -2,8 +2,37 @@ import os
 import re
 
 from dotmap import DotMap
+from secator.config import CONFIG
 from secator.output_types import Error
 from secator.utils import deduplicate, debug
+
+
+def resolve_task_queue(task_cls, opts):
+	"""Resolve the Celery queue (== task profile) for a task at dispatch time.
+
+	A dynamic (callable) profile encodes the task author's per-run resource routing (e.g. katana
+	headless -> extra_large) and always wins. A static profile is overridable via
+	``tasks.overrides.<task>.profile`` so an operator can route a task to a dedicated queue (e.g.
+	nmap -> a long-running pool via SECATOR_TASKS_OVERRIDES_NMAP_PROFILE) without code changes —
+	while never being able to silently flatten a dynamic profile onto a single queue and send a
+	heavy variant to a small pool.
+
+	Args:
+		task_cls (type): The task class (a Command subclass).
+		opts (dict): Run options, passed to a dynamic profile callable.
+
+	Returns:
+		str: The queue name.
+	"""
+	if callable(task_cls.profile):
+		return task_cls.profile(opts)
+	# CONFIG.tasks.overrides is a DotMap-like Config that auto-vivifies missing keys to a truthy
+	# empty object (not None), so normalize to a plain dict before lookups.
+	task_overrides = CONFIG.tasks.overrides.get(task_cls.__name__, {})
+	if hasattr(task_overrides, 'toDict'):
+		task_overrides = task_overrides.toDict()
+	override = task_overrides.get('profile')
+	return override if override else task_cls.profile
 
 
 def _format_nested(template, data):

--- a/secator/runners/task.py
+++ b/secator/runners/task.py
@@ -1,5 +1,6 @@
 from secator.config import CONFIG
 from secator.runners import Runner
+from secator.runners._helpers import resolve_task_queue
 from secator.loader import discover_tasks
 from celery import chain
 
@@ -58,8 +59,14 @@ class Task(Runner):
 		opts['skip_if_no_inputs'] = False
 		opts['caller'] = 'Task'
 
-		# Create task signature
-		profile = task_cls.profile(opts) if callable(task_cls.profile) else task_cls.profile
+		# Create task signature. The queue is the task's profile. A dynamic (callable) profile
+		# encodes the task author's per-run resource routing (e.g. katana headless -> extra_large)
+		# and always wins. Only a STATIC profile is overridable via `tasks.overrides.<task>.profile`
+		# (e.g. route nmap to a long-running pool with SECATOR_TASKS_OVERRIDES_NMAP_PROFILE) — so an
+		# env override can never silently flatten a dynamic profile and send a heavy variant to a
+		# small pool. (The instance-level override in Command.__init__ runs on the worker, too late
+		# to affect routing.)
+		profile = resolve_task_queue(task_cls, opts)
 		sig = run_command.si(self.results, self.config.name, self.inputs, opts).set(queue=profile)
 		task_id = sig.freeze().task_id
 		self.add_subtask(task_id, self.config.name, self.description)

--- a/secator/runners/workflow.py
+++ b/secator/runners/workflow.py
@@ -3,6 +3,7 @@ from dotmap import DotMap
 from secator.config import CONFIG
 from secator.output_types import Info
 from secator.runners._base import Runner
+from secator.runners._helpers import resolve_task_queue
 from secator.runners.task import Task
 from secator.tree import build_runner_tree, walk_runner_tree
 from secator.utils import merge_opts
@@ -105,7 +106,7 @@ class Workflow(Runner):
 				task_opts['aliases'] = [node.id, node.name]
 				if task.__name__ != node.name:
 					task_opts['aliases'].append(task.__name__)
-				profile = task.profile(task_opts) if callable(task.profile) else task.profile
+				profile = resolve_task_queue(task, task_opts)
 				sig = task.s(self.inputs, **task_opts).set(queue=profile)
 				task_id = sig.freeze().task_id
 				debug(f'{node.id} sig built ix: {ix}, parent_ix: {parent_ix}', sub=self.config.name)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -17,6 +17,40 @@ level = logging.DEBUG if DEBUG == ["1"] else logging.ERROR
 setup_logging(level)
 
 
+class TestTaskQueueRouting(unittest.TestCase):
+	"""resolve_task_queue: static profiles are overridable, dynamic profiles always win."""
+
+	def setUp(self):
+		from secator.config import CONFIG
+		self._saved = dict(CONFIG.tasks.overrides) if CONFIG.tasks.overrides else {}
+
+	def tearDown(self):
+		from secator.config import CONFIG
+		CONFIG.tasks.overrides = self._saved
+
+	def test_static_profile_default(self):
+		from secator.runners._helpers import resolve_task_queue
+		from secator.tasks import nmap
+		self.assertEqual(resolve_task_queue(nmap, {}), 'small')
+
+	def test_static_profile_override_applies(self):
+		from secator.config import CONFIG
+		from secator.runners._helpers import resolve_task_queue
+		from secator.tasks import nmap
+		CONFIG.tasks.overrides['nmap'] = {'profile': 'small_long'}
+		self.assertEqual(resolve_task_queue(nmap, {}), 'small_long')
+
+	def test_dynamic_profile_ignores_override(self):
+		"""A callable profile (katana) must not be flattened by an env override."""
+		from secator.config import CONFIG
+		from secator.runners._helpers import resolve_task_queue
+		from secator.tasks import katana
+		CONFIG.tasks.overrides['katana'] = {'profile': 'small_long'}
+		# headless vs non-headless still resolve via dynamic_profile, never to the override.
+		self.assertNotEqual(resolve_task_queue(katana, {'headless': True}), 'small_long')
+		self.assertEqual(resolve_task_queue(katana, {}), 'medium')
+
+
 class TestTasks(unittest.TestCase, CommandOutputTester):
 
 	def setUp(self):


### PR DESCRIPTION
## Problem

A task's Celery queue == its `profile`, resolved from the **class** at *dispatch* time (`task.py` / `workflow.py:108`). The existing `tasks.overrides` mechanism is applied via `setattr` on the **instance** in `Command.__init__` — which runs on the worker, *after* routing. So `tasks.overrides.<task>.profile` could never actually change a task's queue.

## Change

Add `resolve_task_queue(task_cls, opts)` (in `runners/_helpers.py`), used by **both** queue-setting sites:

```python
if callable(task_cls.profile):
    return task_cls.profile(opts)            # dynamic profile ALWAYS wins
override = CONFIG.tasks.overrides[task].get('profile')
return override or task_cls.profile          # static profile is overridable
```

- **Static profiles are overridable** — e.g. `SECATOR_TASKS_OVERRIDES_NMAP_PROFILE=small_long` routes nmap to a dedicated queue with no code change.
- **Dynamic (callable) profiles always win and are never overridable.** katana's `dynamic_profile` sends the memory-heavy *headless* variant to a bigger pool; letting an env override flatten that onto one queue could send a heavy variant to a small pool and re-introduce OOM/eviction. So the override is ignored for callable profiles.

Also fixes a real gotcha: `CONFIG.tasks.overrides` is a DotMap-like `Config` that auto-vivifies missing keys to a *truthy* empty object (not `None`), which made a no-override lookup resolve to `Config()` instead of the static profile — normalized via `toDict()`.

## Tests

`tests/unit/test_tasks.py::TestTaskQueueRouting` — static default, static override applies, dynamic ignores override. Full unit suite green.

## Companion

Deploy side (dedicated `worker-small-long` pool + nmap routing): `secator-cloud-pulumi` branch `feat/per-worker-active-deadline`. This PR is the routing prerequisite — the override is inert without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved task queue routing system with enhanced profile resolution capabilities. The system now intelligently handles both dynamic calculations and configuration overrides, providing greater flexibility in task scheduling and distribution.

* **Tests**
  * Added comprehensive unit tests to validate task queue routing behavior across different static and dynamic profile resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->