### PR TITLE
feat(hooks): on_build — stable runner identity across redeliveries (L2)

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -544,6 +544,12 @@ def break_task(task, task_opts, results=[]):
 		opts['results'] = results
 		if 'targets_' in opts:
 			del opts['targets_']
+		# Mint each chunk's runner doc + id at build time so a redelivered
+		# chunk reuses the same doc (see L2 / on_build).
+		prev_enable_hooks = task.enable_hooks
+		task.enable_hooks = True
+		task.run_hooks('on_build', opts, sub='build')
+		task.enable_hooks = prev_enable_hooks
 		sig = type(task).si(chunk, **opts)
 		task_id = sig.freeze().task_id
 		full_name = f'{task.name}_{ix + 1}'

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -109,6 +109,46 @@ def update_runner(self):
 		debug(msg, sub='hooks.mongodb', id=_id)
 
 
+def build_pending_doc(parent, task_spec, child_type):
+	"""Minimal PENDING placeholder doc for a not-yet-run child runner.
+
+	The runtime update_runner does {'$set': self.toDict()} and fully overwrites
+	this once the child executes, so only the fields the UI tree / watchdog need
+	before that have to be correct here.
+	"""
+	return {
+		'name': task_spec.get('name'),
+		'status': 'PENDING',
+		'done': False,
+		'config': {'type': child_type, 'name': task_spec.get('name')},
+		'context': dict(task_spec.get('context', {})),
+		'has_parent': True,
+		'chunk': task_spec.get('chunk'),
+		'chunk_count': task_spec.get('chunk_count'),
+	}
+
+
+def on_build(self, task_spec):
+	"""Build-time hook: mint the child runner's Mongo doc + id before dispatch.
+
+	Fired by the PARENT runner (self) while assembling the Celery canvas, once
+	per child task/workflow/chunk. Inserts a PENDING placeholder and writes its
+	id into the child signature's serialized context so a redelivered task
+	reuses the same doc (update_one) instead of inserting a new one.
+	"""
+	client = get_mongodb_client()
+	db = client.main
+	parent_type = self.config.type                       # 'scan' | 'workflow' | 'task'
+	child_type = 'workflow' if parent_type == 'scan' else 'task'
+	collection = f'{child_type}s'
+	is_chunk = bool(task_spec.get('chunk'))
+	doc = build_pending_doc(self, task_spec, child_type)
+	_id = str(db[collection].insert_one(doc).inserted_id)
+	key = f'{child_type}_chunk_id' if is_chunk else f'{child_type}_id'
+	task_spec.setdefault('context', {})[key] = _id
+	return task_spec
+
+
 def update_finding(self, item):
 	if type(item) not in OUTPUT_TYPES:
 		return item
@@ -234,6 +274,7 @@ def tag_duplicates(ws_id: str = None, full_scan: bool = False, exclude_types=[],
 
 HOOKS = {
 	Scan: {
+		'on_build': [on_build],
 		'on_init': [update_runner],
 		'on_start': [update_runner],
 		'on_interval': [update_runner],
@@ -241,6 +282,7 @@ HOOKS = {
 		'on_end': [update_runner],
 	},
 	Workflow: {
+		'on_build': [on_build],
 		'on_init': [update_runner],
 		'on_start': [update_runner],
 		'on_interval': [update_runner],
@@ -248,11 +290,12 @@ HOOKS = {
 		'on_end': [update_runner],
 	},
 	Task: {
+		'on_build': [on_build],
 		'on_init': [update_runner],
 		'on_start': [update_runner],
 		'on_item': [update_finding],
 		'on_duplicate': [update_finding],
 		'on_interval': [update_runner],
-		'on_end': [update_runner]
+		'on_end': [update_runner],
 	}
 }

--- a/secator/hooks/sqlite.py
+++ b/secator/hooks/sqlite.py
@@ -168,6 +168,44 @@ def update_finding(self, item):
 	return item
 
 
+def build_pending_doc(parent, task_spec, child_type):
+	"""Minimal PENDING placeholder doc for a not-yet-run child runner."""
+	return {
+		'name': task_spec.get('name'),
+		'status': 'PENDING',
+		'done': False,
+		'config': {'type': child_type, 'name': task_spec.get('name')},
+		'context': dict(task_spec.get('context', {})),
+		'has_parent': True,
+		'chunk': task_spec.get('chunk'),
+		'chunk_count': task_spec.get('chunk_count'),
+	}
+
+
+def on_build(self, task_spec):
+	"""Build-time hook: mint the child runner's sqlite row + id before dispatch.
+
+	Fired by the PARENT runner (self) while assembling the Celery canvas, once
+	per child task/workflow/chunk. Inserts a PENDING placeholder and writes its
+	id into the child signature's serialized context so a redelivered task
+	reuses the same row (UPDATE) instead of inserting a new one.
+	"""
+	conn = get_sqlite_conn()
+	parent_type = self.config.type                       # 'scan' | 'workflow' | 'task'
+	child_type = 'workflow' if parent_type == 'scan' else 'task'
+	table = f'{child_type}s'
+	is_chunk = bool(task_spec.get('chunk'))
+	doc = build_pending_doc(self, task_spec, child_type)
+	_id = str(uuid.uuid4())
+	workspace_id = task_spec.get('context', {}).get('workspace_id')
+	payload = json.dumps(doc, default=str)
+	conn.execute(f"INSERT INTO {table} (id, workspace_id, data) VALUES (?, ?, ?)", (_id, workspace_id, payload))
+	conn.commit()
+	key = f'{child_type}_chunk_id' if is_chunk else f'{child_type}_id'
+	task_spec.setdefault('context', {})[key] = _id
+	return task_spec
+
+
 def find_duplicates(self):
 	from secator.definitions import IN_WORKER
 	ws_id = self.toDict().get('context', {}).get('workspace_id')
@@ -222,6 +260,7 @@ def tag_duplicates(ws_id: str = None, full_scan: bool = False, exclude_types=[],
 
 HOOKS = {
 	Scan: {
+		'on_build': [on_build],
 		'on_init': [update_runner],
 		'on_start': [update_runner],
 		'on_interval': [update_runner],
@@ -229,6 +268,7 @@ HOOKS = {
 		'on_end': [update_runner],
 	},
 	Workflow: {
+		'on_build': [on_build],
 		'on_init': [update_runner],
 		'on_start': [update_runner],
 		'on_interval': [update_runner],
@@ -236,6 +276,7 @@ HOOKS = {
 		'on_end': [update_runner],
 	},
 	Task: {
+		'on_build': [on_build],
 		'on_init': [update_runner],
 		'on_start': [update_runner],
 		'on_item': [update_finding],

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 HOOKS = [
 	'before_init',
+	'on_build',
 	'on_init',
 	'on_start',
 	'on_end',

--- a/secator/runners/workflow.py
+++ b/secator/runners/workflow.py
@@ -108,9 +108,10 @@ class Workflow(Runner):
 					task_opts['aliases'].append(task.__name__)
 				# Mint the child task's runner doc + id at build time so a
 				# redelivered task reuses the same doc (see L2 / on_build).
+				prev_enable_hooks = self.enable_hooks
 				self.enable_hooks = True
 				self.run_hooks('on_build', task_opts, sub='build')
-				self.enable_hooks = False
+				self.enable_hooks = prev_enable_hooks
 				profile = resolve_task_queue(task, task_opts)
 				sig = task.s(self.inputs, **task_opts).set(queue=profile)
 				task_id = sig.freeze().task_id

--- a/secator/runners/workflow.py
+++ b/secator/runners/workflow.py
@@ -106,6 +106,11 @@ class Workflow(Runner):
 				task_opts['aliases'] = [node.id, node.name]
 				if task.__name__ != node.name:
 					task_opts['aliases'].append(task.__name__)
+				# Mint the child task's runner doc + id at build time so a
+				# redelivered task reuses the same doc (see L2 / on_build).
+				self.enable_hooks = True
+				self.run_hooks('on_build', task_opts, sub='build')
+				self.enable_hooks = False
 				profile = resolve_task_queue(task, task_opts)
 				sig = task.s(self.inputs, **task_opts).set(queue=profile)
 				task_id = sig.freeze().task_id

--- a/tests/unit/test_on_build.py
+++ b/tests/unit/test_on_build.py
@@ -1,3 +1,4 @@
+import types
 import unittest
 
 
@@ -5,3 +6,75 @@ class TestOnBuildHookRegistration(unittest.TestCase):
     def test_on_build_is_a_valid_hook_name(self):
         from secator.runners._base import HOOKS
         assert 'on_build' in HOOKS
+
+
+class _FakeInsertResult:
+    def __init__(self, _id):
+        self.inserted_id = _id
+
+
+class _FakeCollection:
+    def __init__(self, name, sink):
+        self.name = name
+        self.sink = sink
+
+    def insert_one(self, doc):
+        _id = f'oid-{self.name}-{len(self.sink)}'
+        self.sink.append((self.name, doc))
+        return _FakeInsertResult(_id)
+
+
+class _FakeDB:
+    def __init__(self, sink):
+        self.sink = sink
+
+    def __getitem__(self, name):
+        return _FakeCollection(name, self.sink)
+
+
+class _FakeClient:
+    def __init__(self, sink):
+        self.main = _FakeDB(sink)
+
+
+def _patch_mongo(monkeypatch):
+    sink = []
+    import secator.hooks.mongodb as m
+    monkeypatch.setattr(m, 'get_mongodb_client', lambda: _FakeClient(sink))
+    return sink
+
+
+class _FakeParent:
+    """Minimal stand-in for a parent runner: on_build only reads .config.type."""
+    def __init__(self, parent_type):
+        self.config = types.SimpleNamespace(type=parent_type)
+
+
+class TestOnBuildMongo:
+    def test_workflow_parent_inserts_task_doc_and_stamps_task_id(self, monkeypatch):
+        from secator.hooks.mongodb import on_build
+        sink = _patch_mongo(monkeypatch)
+        spec = {'name': 'httpx', 'context': {'workspace_id': 'ws1'}}
+        on_build(_FakeParent('workflow'), spec)
+        assert sink[0][0] == 'tasks'                       # inserted into tasks collection
+        assert sink[0][1]['status'] == 'PENDING'
+        assert spec['context']['task_id'] == 'oid-tasks-0' # stamped back into spec context
+
+    def test_scan_parent_inserts_workflow_doc_and_stamps_workflow_id(self, monkeypatch):
+        from secator.hooks.mongodb import on_build
+        sink = _patch_mongo(monkeypatch)
+        spec = {'name': 'url_fuzz', 'context': {'workspace_id': 'ws1'}}
+        on_build(_FakeParent('scan'), spec)
+        assert sink[0][0] == 'workflows'
+        assert spec['context']['workflow_id'] == 'oid-workflows-0'
+
+    def test_chunk_spec_stamps_task_chunk_id_and_chunk_flags(self, monkeypatch):
+        from secator.hooks.mongodb import on_build
+        sink = _patch_mongo(monkeypatch)
+        spec = {'name': 'ffuf', 'chunk': 2, 'chunk_count': 5, 'context': {'workspace_id': 'ws1'}}
+        on_build(_FakeParent('task'), spec)
+        assert sink[0][0] == 'tasks'
+        doc = sink[0][1]
+        assert doc['has_parent'] is True
+        assert doc['chunk'] == 2 and doc['chunk_count'] == 5
+        assert spec['context']['task_chunk_id'] == 'oid-tasks-0'

--- a/tests/unit/test_on_build.py
+++ b/tests/unit/test_on_build.py
@@ -1,6 +1,16 @@
 import types
 import unittest
-from secator.hooks.mongodb import HOOKS as MONGO_HOOKS
+
+import pytest
+
+from secator.definitions import ADDONS_ENABLED
+
+# secator.hooks.mongodb imports pymongo, an optional addon NOT installed in the base
+# unit-test environment (CI). Guard the import so the module collects cleanly, and skip
+# the mongodb-dependent test classes below when the addon is absent. (The registration
+# and sqlite tests don't need pymongo and still run.)
+if ADDONS_ENABLED['mongodb']:
+    from secator.hooks.mongodb import HOOKS as MONGO_HOOKS
 
 
 class TestOnBuildHookRegistration(unittest.TestCase):
@@ -54,6 +64,7 @@ class _FakeParent:
         self.config = types.SimpleNamespace(type=parent_type)
 
 
+@pytest.mark.skipif(not ADDONS_ENABLED['mongodb'], reason='mongodb addon (pymongo) not installed')
 class TestOnBuildMongo:
     def test_workflow_parent_inserts_task_doc_and_stamps_task_id(self, monkeypatch):
         from secator.hooks.mongodb import on_build
@@ -132,6 +143,7 @@ def _restore_config_dirs():
     cfg.celery.result_backend = f'file://{real_dirs.celery_results}'
 
 
+@pytest.mark.skipif(not ADDONS_ENABLED['mongodb'], reason='mongodb addon (pymongo) not installed')
 class TestOnBuildWorkflowWiring(unittest.TestCase):
     """Wiring tests for on_build in a full Workflow canvas build.
 
@@ -198,6 +210,7 @@ class _RecordingClient:
         self.main = _RecordingDB(calls)
 
 
+@pytest.mark.skipif(not ADDONS_ENABLED['mongodb'], reason='mongodb addon (pymongo) not installed')
 class TestUpdateRunnerReusesPrebuiltDoc:
     def test_prebuilt_id_takes_update_one_branch(self, monkeypatch):
         import secator.hooks.mongodb as m
@@ -228,6 +241,7 @@ class TestUpdateRunnerReusesPrebuiltDoc:
             f'Expected no insert_one but got: {calls}'
 
 
+@pytest.mark.skipif(not ADDONS_ENABLED['mongodb'], reason='mongodb addon (pymongo) not installed')
 class TestOnBuildChunkWiring(unittest.TestCase):
     """Wiring tests for on_build during chunk-task canvas assembly.
 

--- a/tests/unit/test_on_build.py
+++ b/tests/unit/test_on_build.py
@@ -1,5 +1,6 @@
 import types
 import unittest
+from secator.hooks.mongodb import HOOKS as MONGO_HOOKS
 
 
 class TestOnBuildHookRegistration(unittest.TestCase):
@@ -22,6 +23,9 @@ class _FakeCollection:
         _id = f'oid-{self.name}-{len(self.sink)}'
         self.sink.append((self.name, doc))
         return _FakeInsertResult(_id)
+
+    def update_one(self, query, update):
+        pass
 
 
 class _FakeDB:
@@ -78,3 +82,31 @@ class TestOnBuildMongo:
         assert doc['has_parent'] is True
         assert doc['chunk'] == 2 and doc['chunk_count'] == 5
         assert spec['context']['task_chunk_id'] == 'oid-tasks-0'
+
+
+class TestOnBuildWorkflowWiring(unittest.TestCase):
+    def test_task_signatures_carry_task_id_from_on_build(self):
+        from secator.runners.workflow import Workflow
+        from secator.template import TemplateLoader
+        sink = []
+
+        import secator.hooks.mongodb as m
+        orig = m.get_mongodb_client
+        m.get_mongodb_client = lambda: _FakeClient(sink)
+        try:
+            config = TemplateLoader(name='workflow/host_recon')
+            wf = Workflow(
+                config,
+                inputs=['example.com'],
+                hooks=MONGO_HOOKS,
+                context={'workspace_id': 'ws1', 'drivers': ['mongodb']},
+            )
+            wf.build_celery_workflow()
+        finally:
+            m.get_mongodb_client = orig
+
+        # At least one task doc was inserted at build time...
+        assert any(coll == 'tasks' for coll, _ in sink), \
+            f'Expected tasks inserts but got: {[coll for coll, _ in sink]}'
+        # ...and every tasks insert has status PENDING.
+        assert all(doc['status'] == 'PENDING' for coll, doc in sink if coll == 'tasks')

--- a/tests/unit/test_on_build.py
+++ b/tests/unit/test_on_build.py
@@ -110,3 +110,49 @@ class TestOnBuildWorkflowWiring(unittest.TestCase):
             f'Expected tasks inserts but got: {[coll for coll, _ in sink]}'
         # ...and every tasks insert has status PENDING.
         assert all(doc['status'] == 'PENDING' for coll, doc in sink if coll == 'tasks')
+
+
+class TestOnBuildChunkWiring(unittest.TestCase):
+    def test_each_chunk_signature_carries_a_distinct_task_chunk_id(self):
+        from secator.celery import break_task
+        from secator.tasks import httpx
+        from secator.runners.task import Task
+        from secator.utils_test import mock_command, FIXTURES_TASKS
+
+        targets = ['https://a.com', 'https://b.com', 'https://c.com']
+
+        # Use flattened task hooks (same as Workflow does via self._hooks.get(Task, {}))
+        # MONGO_HOOKS is keyed by runner class (Scan/Workflow/Task); register_hooks
+        # looks up hooks.get(self.__class__) which won't match Task for an httpx
+        # subclass, so we flatten to the Task-level hook dict.
+        task_hooks = MONGO_HOOKS.get(Task, {})
+
+        # Subclass with input_chunk_size=1 so each target becomes its own chunk.
+        class ChunkedHttpx(httpx):
+            input_chunk_size = 1
+
+        sink = []
+        import secator.hooks.mongodb as m
+        orig = m.get_mongodb_client
+        m.get_mongodb_client = lambda: _FakeClient(sink)
+        try:
+            with mock_command(ChunkedHttpx, fixture=[FIXTURES_TASKS[httpx]] * len(targets)):
+                task = ChunkedHttpx(targets, sync=False, hooks=task_hooks,
+                                    context={'workspace_id': 'ws1', 'drivers': ['mongodb']})
+                task.has_children = True
+                workflow = break_task(task, {'name': 'httpx', 'sync': False}, results=[])
+        finally:
+            m.get_mongodb_client = orig
+
+        # Read chunk ids from the chunk signatures (more robust than reading the sink)
+        chunk_ids = [
+            sig.kwargs.get('opts', {}).get('context', {}).get('task_chunk_id')
+            for sig in workflow.tasks
+        ]
+        # one id per chunk, all present, all distinct
+        assert len(chunk_ids) == len(targets), \
+            f'Expected {len(targets)} chunk signatures, got {len(chunk_ids)}'
+        assert all(chunk_ids), \
+            f'Some chunk signatures are missing task_chunk_id: {chunk_ids}'
+        assert len(set(chunk_ids)) == len(chunk_ids), \
+            f'Chunk ids are not all distinct: {chunk_ids}'

--- a/tests/unit/test_on_build.py
+++ b/tests/unit/test_on_build.py
@@ -1,0 +1,7 @@
+import unittest
+
+
+class TestOnBuildHookRegistration(unittest.TestCase):
+    def test_on_build_is_a_valid_hook_name(self):
+        from secator.runners._base import HOOKS
+        assert 'on_build' in HOOKS

--- a/tests/unit/test_on_build.py
+++ b/tests/unit/test_on_build.py
@@ -212,3 +212,76 @@ class TestOnBuildChunkWiring(unittest.TestCase):
             f'Some chunk signatures are missing task_chunk_id: {chunk_ids}'
         assert len(set(chunk_ids)) == len(chunk_ids), \
             f'Chunk ids are not all distinct: {chunk_ids}'
+
+
+class TestOnBuildSqlite:
+    def test_sqlite_on_build_stamps_task_id(self, tmp_path, monkeypatch):
+        import secator.hooks.sqlite as sql
+
+        # Point the sqlite store at a temp DB by monkeypatching get_sqlite_conn
+        # to use a fresh in-memory connection, and capture executed SQL.
+        import sqlite3
+        import json
+
+        tmp_db = str(tmp_path / 'test.db')
+        conn = sqlite3.connect(tmp_db)
+        conn.execute("CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)")
+        conn.execute("CREATE TABLE IF NOT EXISTS workflows (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)")
+        conn.execute("CREATE TABLE IF NOT EXISTS scans (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)")
+        conn.commit()
+
+        monkeypatch.setattr(sql, 'get_sqlite_conn', lambda: conn)
+
+        spec = {'name': 'httpx', 'context': {'workspace_id': 'ws1'}}
+        sql.on_build(_FakeParent('workflow'), spec)
+
+        # id was stamped into the spec context
+        task_id = spec['context'].get('task_id')
+        assert task_id, f'Expected task_id to be stamped in context, got: {spec["context"]}'
+
+        # row was actually inserted into the tasks table
+        rows = conn.execute("SELECT id, data FROM tasks WHERE id=?", (task_id,)).fetchall()
+        assert len(rows) == 1, f'Expected 1 row in tasks for id {task_id}, got {len(rows)}'
+        doc = json.loads(rows[0][1])
+        assert doc['status'] == 'PENDING'
+
+    def test_sqlite_on_build_scan_parent_stamps_workflow_id(self, tmp_path, monkeypatch):
+        import secator.hooks.sqlite as sql
+        import sqlite3
+        import json
+
+        tmp_db = str(tmp_path / 'test.db')
+        conn = sqlite3.connect(tmp_db)
+        conn.execute("CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)")
+        conn.execute("CREATE TABLE IF NOT EXISTS workflows (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)")
+        conn.execute("CREATE TABLE IF NOT EXISTS scans (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)")
+        conn.commit()
+
+        monkeypatch.setattr(sql, 'get_sqlite_conn', lambda: conn)
+
+        spec = {'name': 'url_fuzz', 'context': {'workspace_id': 'ws1'}}
+        sql.on_build(_FakeParent('scan'), spec)
+
+        workflow_id = spec['context'].get('workflow_id')
+        assert workflow_id, f'Expected workflow_id stamped in context, got: {spec["context"]}'
+        rows = conn.execute("SELECT id FROM workflows WHERE id=?", (workflow_id,)).fetchall()
+        assert len(rows) == 1
+
+    def test_sqlite_on_build_chunk_stamps_chunk_id(self, tmp_path, monkeypatch):
+        import secator.hooks.sqlite as sql
+        import sqlite3
+
+        tmp_db = str(tmp_path / 'test.db')
+        conn = sqlite3.connect(tmp_db)
+        conn.execute("CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)")
+        conn.execute("CREATE TABLE IF NOT EXISTS workflows (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)")
+        conn.execute("CREATE TABLE IF NOT EXISTS scans (id TEXT PRIMARY KEY, workspace_id TEXT, data TEXT)")
+        conn.commit()
+
+        monkeypatch.setattr(sql, 'get_sqlite_conn', lambda: conn)
+
+        spec = {'name': 'ffuf', 'chunk': 2, 'chunk_count': 5, 'context': {'workspace_id': 'ws1'}}
+        sql.on_build(_FakeParent('task'), spec)
+
+        chunk_id = spec['context'].get('task_chunk_id')
+        assert chunk_id, f'Expected task_chunk_id stamped in context, got: {spec["context"]}'

--- a/tests/unit/test_on_build.py
+++ b/tests/unit/test_on_build.py
@@ -84,7 +84,67 @@ class TestOnBuildMongo:
         assert spec['context']['task_chunk_id'] == 'oid-tasks-0'
 
 
+def _fresh_mongo_hooks():
+    """Return a freshly-imported MONGO_HOOKS dict.
+
+    test_config.py's TestConfigEnv calls clear_modules(), which purges all
+    secator.* module objects from sys.modules and reimports them with a temp
+    SECATOR_DIRS_DATA.  After that reimport, the runner classes (Workflow,
+    Task, Scan) are *new* Python objects.  The module-level MONGO_HOOKS dict
+    captured at test-file import time still holds the *old* class objects as
+    keys.  Passing that stale dict as hooks= to the new Workflow/Task instances
+    means register_hooks() finds no matching key and registers nothing —
+    so on_build never fires.
+
+    We fix this by re-importing HOOKS from the live secator.hooks.mongodb
+    module (which always reflects the currently-loaded classes) and returning
+    it so setUp can store it as self.MONGO_HOOKS for use in each test body.
+    """
+    from secator.hooks.mongodb import HOOKS
+    return HOOKS
+
+
+def _restore_config_dirs():
+    """Restore CONFIG.dirs to the real data directory.
+
+    test_config.py's TestConfigEnv calls clear_modules() and reimports
+    secator.config with SECATOR_DIRS_DATA=/tmp/.secator/new, then deletes
+    /tmp/.secator in tearDown.  This leaves the global CONFIG singleton
+    pointing at a non-existent celery_results path, causing the Celery
+    filesystem backend to raise ImproperlyConfigured in any subsequent test
+    that builds a canvas.
+
+    We repair CONFIG by reconstructing Directories from the real data root
+    (read from the live SECATOR_DIRS_DATA env var, which test_config.py
+    restores in its own tearDown, or falling back to ~/.secator).
+    Directories is a Pydantic StrictModel; we use model_dump() to iterate it.
+    CONFIG.dirs is a DotMap (Config subclass) that accepts plain setattr.
+    """
+    import os
+    import secator.config as _cfg
+    from pathlib import Path
+
+    real_data = Path(os.environ.get('SECATOR_DIRS_DATA') or Path.home() / '.secator')
+    real_dirs = _cfg.Directories(data=real_data)
+    cfg = _cfg.CONFIG
+    for k, v in real_dirs.model_dump().items():
+        setattr(cfg.dirs, k, v)
+    cfg.celery.result_backend = f'file://{real_dirs.celery_results}'
+
+
 class TestOnBuildWorkflowWiring(unittest.TestCase):
+    """Wiring tests for on_build in a full Workflow canvas build.
+
+    These tests are hermetic against CONFIG pollution from test_config.py.
+    See _restore_config_dirs() and _fresh_mongo_hooks() for details.
+    """
+
+    def setUp(self):
+        _restore_config_dirs()
+        # Re-import HOOKS so keys match the currently-loaded runner classes
+        # (stale keys from the pre-clear_modules import won't match).
+        self.MONGO_HOOKS = _fresh_mongo_hooks()
+
     def test_task_signatures_carry_task_id_from_on_build(self):
         from secator.runners.workflow import Workflow
         from secator.template import TemplateLoader
@@ -98,7 +158,7 @@ class TestOnBuildWorkflowWiring(unittest.TestCase):
             wf = Workflow(
                 config,
                 inputs=['example.com'],
-                hooks=MONGO_HOOKS,
+                hooks=self.MONGO_HOOKS,
                 context={'workspace_id': 'ws1', 'drivers': ['mongodb']},
             )
             wf.build_celery_workflow()
@@ -169,6 +229,18 @@ class TestUpdateRunnerReusesPrebuiltDoc:
 
 
 class TestOnBuildChunkWiring(unittest.TestCase):
+    """Wiring tests for on_build during chunk-task canvas assembly.
+
+    These tests are hermetic against CONFIG pollution from test_config.py.
+    See _restore_config_dirs() and _fresh_mongo_hooks() for details.
+    """
+
+    def setUp(self):
+        _restore_config_dirs()
+        # Re-import HOOKS so keys match the currently-loaded runner classes
+        # (stale keys from the pre-clear_modules import won't match).
+        self.MONGO_HOOKS = _fresh_mongo_hooks()
+
     def test_each_chunk_signature_carries_a_distinct_task_chunk_id(self):
         from secator.celery import break_task
         from secator.tasks import httpx
@@ -178,10 +250,9 @@ class TestOnBuildChunkWiring(unittest.TestCase):
         targets = ['https://a.com', 'https://b.com', 'https://c.com']
 
         # Use flattened task hooks (same as Workflow does via self._hooks.get(Task, {}))
-        # MONGO_HOOKS is keyed by runner class (Scan/Workflow/Task); register_hooks
-        # looks up hooks.get(self.__class__) which won't match Task for an httpx
-        # subclass, so we flatten to the Task-level hook dict.
-        task_hooks = MONGO_HOOKS.get(Task, {})
+        # self.MONGO_HOOKS is keyed by the currently-loaded runner classes; re-importing
+        # Task here gives us the same object that MONGO_HOOKS uses as its Task key.
+        task_hooks = self.MONGO_HOOKS.get(Task, {})
 
         # Subclass with input_chunk_size=1 so each target becomes its own chunk.
         class ChunkedHttpx(httpx):

--- a/tests/unit/test_on_build.py
+++ b/tests/unit/test_on_build.py
@@ -112,6 +112,62 @@ class TestOnBuildWorkflowWiring(unittest.TestCase):
         assert all(doc['status'] == 'PENDING' for coll, doc in sink if coll == 'tasks')
 
 
+class _RecordingCollection:
+    def __init__(self, name, calls):
+        self.name = name
+        self.calls = calls
+
+    def insert_one(self, doc):
+        self.calls.append(('insert', self.name))
+        return _FakeInsertResult(f'{"a" * 24}')
+
+    def update_one(self, flt, update):
+        self.calls.append(('update', self.name, flt))
+
+
+class _RecordingDB:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def __getitem__(self, name):
+        return _RecordingCollection(name, self.calls)
+
+
+class _RecordingClient:
+    def __init__(self, calls):
+        self.main = _RecordingDB(calls)
+
+
+class TestUpdateRunnerReusesPrebuiltDoc:
+    def test_prebuilt_id_takes_update_one_branch(self, monkeypatch):
+        import secator.hooks.mongodb as m
+        calls = []
+        monkeypatch.setattr(m, 'get_mongodb_client', lambda: _RecordingClient(calls))
+
+        # A valid 24-hex-char ObjectId string (as on_build stamps into context).
+        valid_oid = 'a' * 24
+
+        # Stand-in runner whose context already has a task_id (as if on_build ran).
+        # Needs unique_name, status, config.name for get_runner_dbg(); last_updated_db
+        # is set by update_runner after a successful update_one.
+        runner = types.SimpleNamespace(
+            config=types.SimpleNamespace(type='task', name='httpx'),
+            context={'task_id': valid_oid},
+            unique_name='httpx-1',
+            status='RUNNING',
+            last_updated_db=None,
+            toDict=lambda: {'status': 'RUNNING', 'chunk': None,
+                            'context': {'task_id': valid_oid}},
+        )
+        m.update_runner(runner)
+
+        # Load-bearing assertions: an update happened on tasks, no insert happened.
+        assert any(c[0] == 'update' and c[1] == 'tasks' for c in calls), \
+            f'Expected an update_one on tasks but got: {calls}'
+        assert not any(c[0] == 'insert' for c in calls), \
+            f'Expected no insert_one but got: {calls}'
+
+
 class TestOnBuildChunkWiring(unittest.TestCase):
     def test_each_chunk_signature_carries_a_distinct_task_chunk_id(self):
         from secator.celery import break_task

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -135,6 +135,12 @@ class TestCommandRunner(unittest.TestCase):
 		# Run the command using mock_command
 		with mock_command(MyCommand, TARGETS, {}, fixture, 'run'):
 			for hook, mock in mock_hooks.items():
+				# 'on_build' is a build-time hook fired by a PARENT runner during
+				# Celery canvas assembly, not during the runner's own execution.
+				# It will never be called in a standalone Command/Task run.
+				if hook == 'on_build':
+					self.assertFalse(mock.called, f"Hook '{hook}' should NOT be called during runner execution")
+					continue
 				self.assertTrue(mock.called, f"Hook '{hook}' was not called")
 			self.assertEqual(mock_hooks['on_json_loaded'].call_count, 3)
 			self.assertGreaterEqual(mock_hooks['on_duplicate'].call_count, 1)


### PR DESCRIPTION
## What & why

Adds a build-time runner hook, **`on_build`**, so every child runner (workflow tasks and task chunks) gets a real MongoDB `_id` stamped into its Celery signature `context` **at canvas-build time**. At runtime, the existing `update_runner` hook finds that id already set and takes its `update_one` branch on the **same** document.

This is **L2** of the OOM/eviction-robustness effort. Today, a chunk/task gets its `task_id`/`task_chunk_id` only at runtime in the worker's memory; if the worker is OOM-killed and the task is redelivered (with `acks_late`), the replay has no id → `update_runner` inserts a **new** doc and **orphans** the original stuck one. That defeats any redelivery/abandon mechanism (it would finalize the wrong doc). `on_build` makes runner identity stable across redeliveries — the prerequisite the rest of the design (delivery semantics + abandon) builds on.

Bonus: the whole runner tree is now materialized as `PENDING` docs before execution.

## How

- New `on_build` hook name (`runners/_base.py`), fired by the **parent** via `run_hooks('on_build', ...)` while it assembles the canvas.
- Implemented **only by persistence drivers**: `hooks/mongodb.py` (real `ObjectId` via `insert_one`) and `hooks/sqlite.py` (uuid). Registered under Scan/Workflow/Task. **Notification drivers (api/discord) intentionally do NOT implement it** → no premature notifications.
- Fired in `Workflow.build_celery_workflow`/`process_task` (per task) and `celery.py:break_task` (per chunk), **before the signature is frozen**, with a save/restore `enable_hooks` toggle (the build path sets `enable_hooks=False`).
- Scan child workflows are intentionally **not** handled — they're built as full `Workflow` objects whose `on_init` already assigns `workflow_id`.

Production reality verified: real chunked tasks register `on_build` both at construction (`self._hooks.get(Task)`) and on worker unpickle (`__setstate__` base-class flatten), so the hook genuinely fires.

## Tests

New `tests/unit/test_on_build.py` (registration; mongodb/sqlite `on_build`; per-task + per-chunk wiring proving distinct stamped ids; and a regression proving a pre-built id drives `update_runner` to `update_one` with no second insert). `test_runners::test_hooks` updated to account for `on_build` being a build-time hook (not fired during a runner's own run). Full unit suite shows zero net-new failures vs. `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented build-time document initialization for task runners, enabling better tracking of child task and workflow execution while reducing duplicate database records.

* **Tests**
  * Added comprehensive test coverage for the new build-time initialization behavior across supported database backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->