### PR TITLE
fix(config): SECATOR_ADDONS_* invalid key override breaks Secator totally

### DIFF
--- a/secator/config.py
+++ b/secator/config.py
@@ -883,6 +883,9 @@ class Config(DotMap):
 			key = var[len(prefix):]  # remove prefix
 			path = self._resolve_env_key(key)
 			if path is None:
+				# Unknown / invalid override key: skip it (don't let one bad env var break the config).
+				if print_errors:
+					console.print(f'[bold orange1]{var} (unknown config key, ignored)[/]')
 				continue
 			self.set(path, os.environ[var], set_partial=False)
 			if not self.validate(print_errors=False) and print_errors:
@@ -905,21 +908,19 @@ class Config(DotMap):
 		if key in self._keymap:
 			return '.'.join(k.lower() for k in self._keymap[key])
 
-		# Otherwise, find the longest keymap prefix that resolves to a dict field, then resolve the
-		# remaining dynamic segments under it.
+		# Otherwise, find the longest keymap prefix that resolves to a *dynamic* dict field (one typed
+		# as a Dict in the schema, e.g. tasks.overrides / wordlists.defaults), then resolve the
+		# remaining dynamic segments under it. Typed sub-models (e.g. addons, celery) are dicts at
+		# runtime too, but have a fixed schema (extra='forbid'): an unknown sub-key there is invalid
+		# and must be skipped, not written (else it would clobber the typed model with a plain dict).
 		best = None
 		for map_key, path_parts in self._keymap.items():
 			if not key.startswith(map_key + '_'):
 				continue
-			target = self
-			try:
-				for part in path_parts:
-					target = target[part]
-			except (KeyError, TypeError):
+			if not Config._is_dynamic_dict_path(path_parts):
 				continue
-			if isinstance(target, MutableMapping) and not isinstance(target, str):
-				if best is None or len(map_key) > len(best[0]):
-					best = (map_key, path_parts)
+			if best is None or len(map_key) > len(best[0]):
+				best = (map_key, path_parts)
 		if best is None:
 			return None
 
@@ -938,6 +939,35 @@ class Config(DotMap):
 
 		# Generic single-level dynamic dict (e.g. wordlists.defaults): the remainder is the leaf key.
 		return f'{dotted_prefix}.{remainder}'
+
+	@staticmethod
+	def _is_dynamic_dict_path(path_parts):
+		"""Return True if a config path points to a dynamic ``Dict`` field in the schema.
+
+		Walks the ``SecatorConfig`` field annotations along ``path_parts``. A path resolves to a
+		dynamic dict (arbitrary keys allowed, e.g. ``tasks.overrides`` / ``wordlists.defaults``) when
+		its annotation is a typing ``Dict``; it resolves to a typed sub-model (fixed schema, e.g.
+		``addons``) when its annotation is a ``BaseModel`` subclass. Unknown keys are not dynamic.
+
+		Args:
+			path_parts (list[str]): Dotted config path components (e.g. ['tasks', 'overrides']).
+
+		Returns:
+			bool: True if the path is a dynamic ``Dict`` field.
+		"""
+		import typing
+		model = SecatorConfig
+		annotation = None
+		for part in path_parts:
+			fields = getattr(model, 'model_fields', None)
+			if not fields or part not in fields:
+				return False
+			annotation = fields[part].annotation
+			if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+				model = annotation
+			else:
+				model = None  # leaf or container; no further sub-models to walk
+		return typing.get_origin(annotation) is dict
 
 	@staticmethod
 	def _match_task_name(remainder):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -128,6 +128,31 @@ class TestConfig(unittest.TestCase):
 		config = self._parse_with_env(SECATOR_CELERY_TASK_MAX_TIMEOUT='999')
 		self.assertEqual(config.celery.task_max_timeout, 999)
 
+	def test_env_override_unknown_addon_key_does_not_break_config(self):
+		"""An invalid SECATOR_ADDONS_* key is ignored and leaves the typed addons model intact (#1204).
+
+		Previously this clobbered the typed `addons` model with a plain dict, so attribute access like
+		CONFIG.addons.ai.api_key raised AttributeError at import time and bricked the whole CLI.
+		"""
+		from secator.config import Config
+		config = self._parse_with_env(SECATOR_ADDONS_NONEXISTENT_URL='test')
+		self.assertIsNotNone(config)
+		self.assertIsInstance(config, Config)
+		# Typed addon models stay attribute-accessible (not replaced by a plain dict).
+		self.assertIsInstance(config.addons, Config)
+		self.assertEqual(config.addons.ai.api_key, config.addons.ai.api_key)  # no AttributeError
+		self.assertIsInstance(config.addons.mongodb.url, str)
+		# The bogus key was not written anywhere.
+		self.assertNotIn('nonexistent', config.addons.toDict())
+
+	def test_env_override_valid_addon_key_still_works(self):
+		"""A valid SECATOR_ADDONS_* override applies and keeps the typed addons model intact."""
+		from secator.config import Config
+		config = self._parse_with_env(SECATOR_ADDONS_MONGODB_URL='mongodb://example:27017')
+		self.assertEqual(config.addons.mongodb.url, 'mongodb://example:27017')
+		self.assertIsInstance(config.addons, Config)
+		self.assertEqual(config.addons.ai.api_key, config.addons.ai.api_key)  # no AttributeError
+
 	def test_set_workspace_profiles(self):
 		"""Test setting per-workspace default profiles via comma-separated string."""
 		from secator.config import Config


### PR DESCRIPTION
## Problem

```
SECATOR_ADDONS_NONEXISTENT_URL=test secator x -h
```

crashes secator **at import time**:

```
File ".../secator/tasks/ai.py", line 32, in <module>
    DEFAULT_API_KEY = CONFIG.addons.ai.api_key
AttributeError: 'dict' object has no attribute 'ai'
```

A single bad `SECATOR_*` env var bricks the entire CLI.

## Root cause

`Config.apply_env_overrides` maps `SECATOR_<DOTTED_KEY>` env vars onto the config tree. For dynamic dict fields (e.g. `tasks.overrides`, `wordlists.defaults`) it resolves a keymap prefix and writes the remaining segments as dict sub-keys.

The resolver `_resolve_env_key` decided "is this a dynamic dict" via a **runtime** check: `isinstance(target, MutableMapping)`. But every typed sub-model (`addons`, `celery`, ...) is a `DotMap` (a `dict` subclass) at runtime, so it matched that check too. So `ADDONS_NONEXISTENT_URL` resolved to `addons.nonexistent_url`, and `set()` -> `_set_dict_key` did `updated = dict(existing_dict)` and wrote it back — **replacing the typed `addons` model with a plain `dict`**. Plain dicts have no attribute access, so `CONFIG.addons.ai.api_key` then raised at import time.

## Fix

Gate dynamic-dict resolution on the **schema**, not the runtime type. New helper `Config._is_dynamic_dict_path` walks `SecatorConfig`'s pydantic field annotations and only treats a path as dynamic when its annotation is a typing `Dict` (e.g. `tasks.overrides`, `wordlists.defaults`), not when it's a `BaseModel` sub-model (e.g. `addons` — a `StrictModel` with `extra='forbid'`).

An unknown override key under a typed model now resolves to `None` and is **skipped with a warning** (`<VAR> (unknown config key, ignored)`), leaving the typed config (`addons.ai`, `addons.mongodb`, ...) fully intact and attribute-accessible.

## Behavior after fix

- `SECATOR_ADDONS_NONEXISTENT_URL=test secator x -h` — runs cleanly; warns and ignores the bad key.
- `SECATOR_ADDONS_MONGODB_URL=...` (valid typed override) — still applies, `addons` stays typed.
- `SECATOR_TASKS_OVERRIDES_NMAP_MAX_TIMEOUT=500` (valid dynamic dict) — still works.

## Tests

Extends `tests/unit/test_config.py`:
- `test_env_override_unknown_addon_key_does_not_break_config` — reproduces #1204; asserts the parse doesn't raise, `addons` stays a typed `Config`/DotMap, attribute access (`addons.ai.api_key`, `addons.mongodb.url`) works, and the bogus key is not written.
- `test_env_override_valid_addon_key_still_works` — a valid `SECATOR_ADDONS_*` override applies and keeps the typed model intact.

All 44 tests in `tests/unit/test_config.py` pass; `flake8 secator/config.py` is clean.

Fixes #1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5vSjfkBuGAAHdKxHS3ySm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration loading now gracefully skips invalid environment variable overrides instead of breaking initialization.
  * Enhanced handling of dynamic configuration fields to better validate addon-related keys.
  * Improved error messages when unknown configuration keys are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->