### PR TITLE
fix: dynamic task import order causing SyntaxError with external tasks

### DIFF
--- a/secator/loader.py
+++ b/secator/loader.py
@@ -140,6 +140,7 @@ def discover_external_tasks():
 
 			# console.print(f'Checking that {module} contains task {task_name}')
 			if not hasattr(module, task_name):
+				sys.modules.pop(module_name, None)
 				console.print(f'[bold orange1]Could not load external task "{task_name}" from module {path.name}[/] ({path})')
 				continue
 			cls = getattr(module, task_name)
@@ -155,6 +156,7 @@ def discover_external_tasks():
 			cls.__external__ = True
 			output.append(cls)
 		except Exception as e:
+			sys.modules.pop(module_name, None)
 			console.print(f'[bold red]Could not load external module {path.name}. Reason: {str(e)}.[/] ({path})')
 	sys.dont_write_bytecode = prev_state
 	return output

--- a/secator/loader.py
+++ b/secator/loader.py
@@ -8,13 +8,14 @@ from pathlib import Path
 import glob
 import importlib
 import inspect
+import re
 import sys
 
 
 def _file_has_hooks(path):
 	"""Check if a Python file contains a HOOKS variable (driver indicator)."""
 	try:
-		return 'HOOKS =' in path.read_text()
+		return bool(re.search(r'\bHOOKS\s*=', path.read_text()))
 	except Exception:
 		return False
 
@@ -76,7 +77,9 @@ def get_configs_by_type(type):
 @cache
 def discover_tasks():
 	"""Find all secator tasks (internal + external)."""
-	return discover_internal_tasks() + discover_external_tasks()
+	external = discover_external_tasks()
+	internal = discover_internal_tasks()
+	return external + internal
 
 
 @cache
@@ -140,6 +143,14 @@ def discover_external_tasks():
 				console.print(f'[bold orange1]Could not load external task "{task_name}" from module {path.name}[/] ({path})')
 				continue
 			cls = getattr(module, task_name)
+			if not inspect.isclass(cls):
+				# cls is a module reference, not a class — likely caused by a circular
+				# import (e.g. the file does `from secator.tasks import <task_name>`
+				# while secator.tasks is still initialising).  Clean up sys.modules so
+				# the entry doesn't shadow the real task later.
+				sys.modules.pop(module_name, None)
+				console.print(f'[bold orange1]Could not load external task "{task_name}" from {path.name}: not a class[/] ({path})')
+				continue
 			debug(f'[bold green]Successfully loaded external task "{task_name}"[/] ({path})', sub='loader')
 			cls.__external__ = True
 			output.append(cls)

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -449,6 +449,7 @@ class TestDiscoverExternalTasksSkipsDriversAndExporters(unittest.TestCase):
         result = discover_external_tasks()
         result_names = [cls.__name__ for cls in result]
         self.assertNotIn('skiptest_nonclass', result_names)
+        self.assertNotIn('secator.tasks.skiptest_nonclass', sys.modules)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -54,6 +54,11 @@ class TestFileDetectionHelpers(unittest.TestCase):
         f = self._tmp_file('hooks_yes.py', 'HOOKS = {}\n')
         self.assertTrue(_file_has_hooks(f))
 
+    def test_file_has_hooks_no_space_true(self):
+        from secator.loader import _file_has_hooks
+        f = self._tmp_file('hooks_nospace.py', 'HOOKS={}\n')
+        self.assertTrue(_file_has_hooks(f))
+
     def test_file_has_hooks_false(self):
         from secator.loader import _file_has_hooks
         f = self._tmp_file('hooks_no.py', 'class Foo:\n    pass\n')
@@ -417,6 +422,15 @@ class TestDiscoverExternalTasksSkipsDriversAndExporters(unittest.TestCase):
         result_names = [cls.__name__ for cls in result]
         self.assertNotIn('skiptest_driver', result_names)
 
+    def test_driver_files_hooks_no_space_not_loaded_as_tasks(self):
+        """Files containing 'HOOKS=' (no space) are excluded from task discovery."""
+        path = self.template_dir / 'skiptest_nospace.py'
+        path.write_text('HOOKS={}\n')
+        from secator.loader import discover_external_tasks
+        result = discover_external_tasks()
+        result_names = [cls.__name__ for cls in result]
+        self.assertNotIn('skiptest_nospace', result_names)
+
     def test_exporter_files_not_loaded_as_tasks(self):
         """Files containing '(Exporter)' are excluded from task discovery."""
         path = self.template_dir / 'skiptest_exporter.py'
@@ -425,6 +439,16 @@ class TestDiscoverExternalTasksSkipsDriversAndExporters(unittest.TestCase):
         result = discover_external_tasks()
         result_names = [cls.__name__ for cls in result]
         self.assertNotIn('SkipTestExporter', result_names)
+
+    def test_non_class_task_attribute_not_loaded(self):
+        """Files where the task attribute is not a class are excluded from task discovery."""
+        path = self.template_dir / 'skiptest_nonclass.py'
+        # The file has an attribute with the module's own name but it's not a class
+        path.write_text('skiptest_nonclass = "not a class"\n')
+        from secator.loader import discover_external_tasks
+        result = discover_external_tasks()
+        result_names = [cls.__name__ for cls in result]
+        self.assertNotIn('skiptest_nonclass', result_names)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix SyntaxError and wrong-class import when using external tasks with the universal install script.

Swap `discover_tasks()` order to load external tasks before internal ones, add `inspect.isclass()` guard in `discover_external_tasks()`, and strengthen `_file_has_hooks()` with a regex.

Fixes #1190

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of task hooks in external driver and task files
  * Enhanced error handling and validation when loading malformed external tasks
  
* **Tests**
  * Added unit tests for task discovery edge cases, including non-standard hook definitions and invalid task attributes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->