### PR TITLE
fix(nuclei): disable chunking and auto-set bulk_size to reach max RPS

### DIFF
--- a/secator/tasks/nuclei.py
+++ b/secator/tasks/nuclei.py
@@ -37,7 +37,7 @@ class nuclei(VulnMulti):
 	file_flag = '-l'
 	input_flag = '-u'
 	json_flag = '-jsonl'
-	input_chunk_size = 20
+	input_chunk_size = -1
 	opts = {
 		'automatic_scan': {'is_flag': True, 'short': 'as', 'help': 'Automatic web scan using wappalyzer technology detection to tags mapping'},  # noqa: E501
 		'bulk_size': {'type': int, 'short': 'bs', 'help': 'Maximum number of hosts to be analyzed in parallel per template'},  # noqa: E501
@@ -152,6 +152,13 @@ class nuclei(VulnMulti):
 			self.cmd += ' -ts'
 			self.cmd += f' -elog {output_folder}/{self.fqn}_error.json'
 			self.cmd += f' -tlog {output_folder}/{self.fqn}_trace.json'
+
+		# Auto-set bulk_size to input count when not explicitly provided.
+		# nuclei's default bulk_size is 25, which limits parallelism on large host lists
+		# and prevents saturating the configured rate limit.
+		bulk_size = self.get_opt_value('bulk_size')
+		if not bulk_size and self.inputs:
+			self.run_opts['bulk_size'] = len(self.inputs)
 
 	@staticmethod
 	def id_extractor(item):


### PR DESCRIPTION
Two issues prevented nuclei from reaching its configured rate limit on large host lists:

1. `input_chunk_size=20` caused Celery to split hosts into 20-host chunks. The `chunk_rate_limit` feature then divided the rate limit by the chunk count (e.g. 150 / 50 chunks = 3 req/s per instance).
2. nuclei's default `bulk_size=25` limited host parallelism per template, preventing rate saturation on large lists.

Fix: set `input_chunk_size=-1` (no chunking) and auto-compute `bulk_size=len(inputs)` in `on_init` when not explicitly provided.

Closes #1089

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted input batching behavior for nuclei tasks.
  * Automatic concurrent processing configuration now scales with input list size, improving performance on large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->