### PR TITLE
fix(exporters): handle serialized dicts in MarkdownExporter for AI reports

### DIFF
--- a/secator/exporters/markdown.py
+++ b/secator/exporters/markdown.py
@@ -10,7 +10,14 @@ class MarkdownExporter(Exporter):
 		if not ai_items:
 			return
 
-		sections = [item.content for item in ai_items if item.content]
+		# report.data['results']['ai'] holds serialized dicts, not Ai objects, so
+		# read `content` defensively (handle both dict and OutputType forms).
+		def _content(item):
+			if isinstance(item, dict):
+				return item.get('content')
+			return getattr(item, 'content', None)
+
+		sections = [c for item in ai_items if (c := _content(item))]
 		if not sections:
 			return
 


### PR DESCRIPTION
The MarkdownExporter (run for every AI task report) did `item.content` over `report.data[\"results\"][\"ai\"]`, which holds **serialized dicts**, not `Ai` objects — raising `AttributeError: 'dict' object has no attribute 'content'` and failing the export for all ai-task runs.

Fix: read `content` defensively (dict `.get` or object `getattr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5vSjfkBuGAAHdKxHS3ySm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown report generation to handle content more reliably.
  * The exporter now supports multiple result shapes and skips empty entries, reducing the chance of missing or broken output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->