### PR TITLE
perf(dedup): run duplicate check only on the outermost runner

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -138,7 +138,17 @@ class Runner:
 		self.raise_on_error = self.run_opts.get('raise_on_error', False)
 
 		# Runner toggles
+		# Duplicate check should run ONCE, on the outermost runner only. A nested runner
+		# (has_parent=True) — e.g. a task inside a workflow, or a workflow inside a scan —
+		# would otherwise re-run the dedup at every nesting level, which on scans with
+		# 10,000s of findings is a real runtime toll for no benefit: results aggregate up to
+		# the outermost runner (descendant findings flow into its self.results via the
+		# yielder), so its single mark_duplicates() pass already covers every descendant's
+		# findings. We therefore disable the check for nested runners by default, while still
+		# respecting an explicit `enable_duplicate_check` override if the caller set one.
 		self.enable_duplicate_check = self.run_opts.get('enable_duplicate_check', self.enable_duplicate_check)
+		if self.has_parent and 'enable_duplicate_check' not in self.run_opts:
+			self.enable_duplicate_check = False
 		self.enable_profiles = self.run_opts.get('enable_profiles', True)
 		self.enable_reports = self.run_opts.get('enable_reports', not self.sync) and not self.dry_run and not self.no_process and not self.no_poll  # noqa: E501
 		self.enable_hooks = self.run_opts.get('enable_hooks', True) and not self.dry_run and not self.no_process  # noqa: E501

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -138,16 +138,8 @@ class Runner:
 		self.raise_on_error = self.run_opts.get('raise_on_error', False)
 
 		# Runner toggles
-		# Duplicate check should run ONCE, on the outermost runner only. A nested runner
-		# (has_parent=True) — e.g. a task inside a workflow, or a workflow inside a scan —
-		# would otherwise re-run the dedup at every nesting level, which on scans with
-		# 10,000s of findings is a real runtime toll for no benefit: results aggregate up to
-		# the outermost runner (descendant findings flow into its self.results via the
-		# yielder), so its single mark_duplicates() pass already covers every descendant's
-		# findings. We therefore disable the check for nested runners by default, while still
-		# respecting an explicit `enable_duplicate_check` override if the caller set one.
 		self.enable_duplicate_check = self.run_opts.get('enable_duplicate_check', self.enable_duplicate_check)
-		if self.has_parent and 'enable_duplicate_check' not in self.run_opts:
+		if self.has_parent and 'enable_duplicate_check' not in self.run_opts:  # disable duplicate check on children runners
 			self.enable_duplicate_check = False
 		self.enable_profiles = self.run_opts.get('enable_profiles', True)
 		self.enable_reports = self.run_opts.get('enable_reports', not self.sync) and not self.dry_run and not self.no_process and not self.no_poll  # noqa: E501

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -918,3 +918,36 @@ class TestIsOwnSource(unittest.TestCase):
 			cmd.unique_name = 'nmap'
 			cmd.results.append(chunk_error)
 			self.assertEqual(cmd.self_errors, [chunk_error])
+
+
+class TestDuplicateCheckGating(unittest.TestCase):
+	"""Duplicate check must run only on the outermost runner.
+
+	A nested runner (has_parent=True) — a task inside a workflow, or a workflow inside
+	a scan — must NOT run its own dedup pass; the outermost runner does it once over its
+	fully-aggregated results. See Runner.__init__ in secator/runners/_base.py.
+	"""
+
+	def test_outermost_runner_dedups(self):
+		"""An outermost runner (has_parent defaults to False) keeps the duplicate check on."""
+		cmd = MyCommand(TARGETS)
+		self.assertFalse(cmd.has_parent)
+		self.assertTrue(cmd.enable_duplicate_check)
+
+	def test_nested_runner_does_not_dedup(self):
+		"""A nested runner (has_parent=True) has its duplicate check disabled by default."""
+		cmd = MyCommand(TARGETS, has_parent=True)
+		self.assertTrue(cmd.has_parent)
+		self.assertFalse(cmd.enable_duplicate_check)
+
+	def test_nested_runner_respects_explicit_enable_override(self):
+		"""An explicit enable_duplicate_check=True override wins even when nested."""
+		cmd = MyCommand(TARGETS, has_parent=True, enable_duplicate_check=True)
+		self.assertTrue(cmd.has_parent)
+		self.assertTrue(cmd.enable_duplicate_check)
+
+	def test_outermost_runner_respects_explicit_disable_override(self):
+		"""An explicit enable_duplicate_check=False override wins on an outermost runner."""
+		cmd = MyCommand(TARGETS, enable_duplicate_check=False)
+		self.assertFalse(cmd.has_parent)
+		self.assertFalse(cmd.enable_duplicate_check)


### PR DESCRIPTION
## Problem

A task that's part of a workflow, and a workflow that's part of a scan, each ran their **own** duplicate check. So in a scan with 10,000s of findings the dedup ran **redundantly at every nesting level** — a real toll on scan runtime for no benefit.

## Where dedup was triggered per-level

The active dedup is the in-memory `Runner.mark_duplicates()` (`secator/runners/_base.py`), called from `mark_completed()` (on `on_end`). It is gated by `self.enable_duplicate_check`. The existing build code already disabled it for some nested runners but **not all**:

- `task.py` (Task → child command task): `enable_duplicate_check = False` ✅
- `workflow.py` (Workflow → child tasks): `enable_duplicate_check = False` ✅
- `celery.py` chunking (task → chunk sigs): `enable_duplicate_check = False` ✅
- `scan.py` (Scan → child **workflows**): sets `has_parent = True` but **never** disables the check → **each workflow inside a scan still deduped, then the scan deduped again.** That was the redundant path.

## The gate added

`secator/runners/_base.py` (right after `enable_duplicate_check` is resolved in `Runner.__init__`):

```python
self.enable_duplicate_check = self.run_opts.get('enable_duplicate_check', self.enable_duplicate_check)
if self.has_parent and 'enable_duplicate_check' not in self.run_opts:
    self.enable_duplicate_check = False
```

Any **nested** runner (`has_parent=True`) disables its duplicate check by default; the **outermost** runner (scan, or a standalone workflow/task with no parent) runs it **once**. An explicit `enable_duplicate_check` override (e.g. via the Python API) is still respected — `enable_duplicate_check` is not a CLI/config opt, so it is never present in a top-level user's run_opts by accident.

## Correctness: the outermost runner still covers all descendant findings

`mark_duplicates()` operates on `self.results`. In `Runner.__iter__`, the runner loops `self.yielder()` and calls `_process_item()` → `add_result()` for every item; in async mode the yielder streams **all descendant results** up via `CeleryData.iter_results`. So a scan's `self.results` contains every finding produced by all its workflows and their tasks. Its single `mark_duplicates()` pass therefore groups and dedups the **full aggregated** set — nothing a child would have caught is lost by skipping the child's pass.

`has_parent` is reliable for this: `workflow.py` sets `has_parent=True` for workflows under a scan/parent, `scan.py` sets `has_parent=True` for workflows it builds, and `celery.py` sets it for chunked sub-tasks; it defaults to `False` (`run_opts.get('has_parent', False)`) for the outermost runner.

## Tests

Added `TestDuplicateCheckGating` in `tests/unit/test_runners.py`:
- outermost runner (`has_parent=False`) → `enable_duplicate_check` True
- nested runner (`has_parent=True`) → `enable_duplicate_check` False
- nested + explicit `enable_duplicate_check=True` → respected (True)
- outermost + explicit `enable_duplicate_check=False` → respected (False)

`tests/unit/test_runners.py` is green (43 passed); `flake8` clean for the changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5vSjfkBuGAAHdKxHS3ySm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nested runner operations now avoid duplicate checks by default, reducing unnecessary repeated work.
  * Explicit duplicate-check settings are now respected consistently, including for nested runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->