### PR TITLE
fix(output): display full node id instead of task name

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -638,7 +638,7 @@ class Command(Runner):
 	def print_description(self):
 		"""Print description"""
 		if self.sync and not self.has_children and self.caller and self.description and self.print_cmd:
-			self._print(f'\n[bold gold3]:wrench: {self.description} [dim cyan]({self.config.name})[/][/] ...', rich=True)
+			self._print(f'\n[bold gold3]:wrench: {self.description} [dim cyan]({self.config.node_id})[/][/] ...', rich=True)
 
 	def print_command(self):
 		"""Print command."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sync-mode task/client log output to show the node ID instead of the name, making identity details more consistent in displayed status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->