### PR TITLE
feat(runners): redact sensitive task options from serialized/printed state

### DIFF
--- a/secator/cli_helper.py
+++ b/secator/cli_helper.py
@@ -104,6 +104,7 @@ def decorate_command_options(opts):
 			conf.pop('process', None)
 			conf.pop('pre_process', None)
 			conf.pop('requires_sudo', None)
+			conf.pop('sensitive', None)
 			conf.pop('prefix', None)
 			choices = conf.pop('choices', None)
 			applies_to = conf.pop('applies_to', None)

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -1,4 +1,3 @@
-import copy
 import gc
 import json
 import logging
@@ -333,28 +332,6 @@ class Runner:
 			logger.warning('Could not resolve sensitive option names for %s (redaction may be incomplete): %s', getattr(self, 'unique_name', self), e)  # noqa: E501
 		self._sensitive_opt_names_cache = names
 		return names
-
-	@staticmethod
-	def _redact_sensitive(obj, sensitive):
-		"""Recursively mask sensitive option values in a serialized structure (in place).
-
-		Masks the ``default``/``value`` fields of any option-conf dict keyed by a sensitive
-		opt name, and any scalar held directly under a sensitive opt name. Callers must pass
-		a COPY — never the live config — since this mutates ``obj``.
-		"""
-		if isinstance(obj, dict):
-			for k, v in obj.items():
-				if k in sensitive:
-					if isinstance(v, dict):
-						for field in ('default', 'value'):
-							if v.get(field):
-								v[field] = REDACTED_OPT_VALUE
-					elif v and not isinstance(v, (list, dict)):
-						obj[k] = REDACTED_OPT_VALUE
-				Runner._redact_sensitive(v, sensitive)
-		elif isinstance(obj, list):
-			for v in obj:
-				Runner._redact_sensitive(v, sensitive)
 
 	@property
 	def resolved_opts(self):
@@ -1044,17 +1021,10 @@ class Runner:
 				'warnings': [w.toDict() for w in self.warnings],
 			}
 		)
-		# Redact sensitive opt values that also surface as serialized config/opts metadata
-		# (notably an option's `default`, e.g. ai.api_key defaults to CONFIG.addons.ai.api_key
-		# -> the *platform* key would otherwise land in every runner doc). run_opts is already
-		# redacted via resolved_opts. Operate on copies so the live config is never mutated.
-		sensitive = self.sensitive_opt_names
-		if sensitive:
-			data['config'] = copy.deepcopy(data['config'])
-			Runner._redact_sensitive(data['config'], sensitive)
-			if data.get('opts'):
-				data['opts'] = copy.deepcopy(data['opts'])
-				Runner._redact_sensitive(data['opts'], sensitive)
+		# Note: serialized config/opts intentionally not scrubbed. An option's `default` must
+		# never be a secret by convention (tasks use `passed or CONFIG.addons.*` at runtime,
+		# not a config-sourced default), so config/opts carry no secret. The user-supplied
+		# value is redacted where it actually lands: run_opts (resolved_opts) and the cmd.
 		return data
 
 	def run_hooks(self, hook_type, *args, sub='hooks'):

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -39,6 +39,10 @@ HOOKS = [
 
 VALIDATORS = ['validate_input', 'validate_item']
 
+# Placeholder substituted for option values flagged ``sensitive: True`` in any
+# serialized/printed runner state (see Runner.sensitive_opt_names).
+REDACTED_OPT_VALUE = '[REDACTED]'
+
 
 def format_runner_name(runner):
 	"""Format runner name."""
@@ -285,8 +289,53 @@ class Runner:
 		return config
 
 	@property
+	def sensitive_opt_names(self):
+		"""Names of options flagged ``sensitive: True`` in their definition.
+
+		Sensitive option values are redacted from any serialized/printed runner state
+		(``toDict()``, debug echoes, the built command string) so a user-supplied secret
+		(e.g. a BYO addon API key) never lands in the Mongo runner doc, the API response,
+		``--driver api`` egress, or logs. The value still travels in-flight to the worker.
+
+		Resolved once and memoized. Sources, unioned defensively:
+		- a direct task instance's own ``opts``/``meta_opts`` (Command / PythonRunner),
+		- the task classes referenced by this runner's config tree (Task / Workflow / Scan,
+		  which carry no ``opts`` of their own).
+		"""
+		cached = getattr(self, '_sensitive_opt_names_cache', None)
+		if cached is not None:
+			return cached
+		names = set()
+
+		def collect(holder):
+			for attr in ('opts', 'meta_opts'):
+				confs = getattr(holder, attr, None)
+				if isinstance(confs, dict):
+					names.update(k for k, v in confs.items() if isinstance(v, dict) and v.get('sensitive'))
+
+		collect(self)
+		try:
+			from secator.runners.task import Task
+			from secator.tree import build_runner_tree, get_flat_node_list
+			for node in get_flat_node_list(build_runner_tree(self.config)):
+				if node.type != 'task':
+					continue
+				try:
+					collect(Task.get_task_class(node.name))
+				except Exception:
+					continue
+		except Exception:
+			pass
+		self._sensitive_opt_names_cache = names
+		return names
+
+	@property
 	def resolved_opts(self):
-		return {k: v for k, v in self.run_opts.items() if v is not None and not k.startswith('print_') and not k.endswith('_')}  # noqa: E501
+		opts = {k: v for k, v in self.run_opts.items() if v is not None and not k.startswith('print_') and not k.endswith('_')}  # noqa: E501
+		sensitive = self.sensitive_opt_names
+		if sensitive:
+			opts = {k: (REDACTED_OPT_VALUE if (k in sensitive and v) else v) for k, v in opts.items()}
+		return opts
 
 	@property
 	def resolved_print_opts(self):

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -1,3 +1,4 @@
+import copy
 import gc
 import json
 import logging
@@ -322,12 +323,38 @@ class Runner:
 					continue
 				try:
 					collect(Task.get_task_class(node.name))
-				except Exception:
+				except ValueError:
+					# Unknown task name in this node: skip it, but keep scanning the rest.
 					continue
-		except Exception:
-			pass
+		except Exception as e:
+			# Discovery failed for the whole tree: we can't enumerate sensitive opts, so
+			# redaction may be incomplete. Surface it loudly rather than failing silently
+			# (a silent miss here would let a secret through into serialized/printed state).
+			logger.warning('Could not resolve sensitive option names for %s (redaction may be incomplete): %s', getattr(self, 'unique_name', self), e)  # noqa: E501
 		self._sensitive_opt_names_cache = names
 		return names
+
+	@staticmethod
+	def _redact_sensitive(obj, sensitive):
+		"""Recursively mask sensitive option values in a serialized structure (in place).
+
+		Masks the ``default``/``value`` fields of any option-conf dict keyed by a sensitive
+		opt name, and any scalar held directly under a sensitive opt name. Callers must pass
+		a COPY — never the live config — since this mutates ``obj``.
+		"""
+		if isinstance(obj, dict):
+			for k, v in obj.items():
+				if k in sensitive:
+					if isinstance(v, dict):
+						for field in ('default', 'value'):
+							if v.get(field):
+								v[field] = REDACTED_OPT_VALUE
+					elif v and not isinstance(v, (list, dict)):
+						obj[k] = REDACTED_OPT_VALUE
+				Runner._redact_sensitive(v, sensitive)
+		elif isinstance(obj, list):
+			for v in obj:
+				Runner._redact_sensitive(v, sensitive)
 
 	@property
 	def resolved_opts(self):
@@ -1017,6 +1044,17 @@ class Runner:
 				'warnings': [w.toDict() for w in self.warnings],
 			}
 		)
+		# Redact sensitive opt values that also surface as serialized config/opts metadata
+		# (notably an option's `default`, e.g. ai.api_key defaults to CONFIG.addons.ai.api_key
+		# -> the *platform* key would otherwise land in every runner doc). run_opts is already
+		# redacted via resolved_opts. Operate on copies so the live config is never mutated.
+		sensitive = self.sensitive_opt_names
+		if sensitive:
+			data['config'] = copy.deepcopy(data['config'])
+			Runner._redact_sensitive(data['config'], sensitive)
+			if data.get('opts'):
+				data['opts'] = copy.deepcopy(data['opts'])
+				Runner._redact_sensitive(data['opts'], sensitive)
 		return data
 
 	def run_hooks(self, hook_type, *args, sub='hooks'):

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -297,14 +297,13 @@ class Runner:
 		(e.g. a BYO addon API key) never lands in the Mongo runner doc, the API response,
 		``--driver api`` egress, or logs. The value still travels in-flight to the worker.
 
-		Resolved once and memoized. Sources, unioned defensively:
+		Sources, unioned:
 		- a direct task instance's own ``opts``/``meta_opts`` (Command / PythonRunner),
 		- the task classes referenced by this runner's config tree (Task / Workflow / Scan,
 		  which carry no ``opts`` of their own).
 		"""
-		cached = getattr(self, '_sensitive_opt_names_cache', None)
-		if cached is not None:
-			return cached
+		from secator.loader import discover_tasks
+		from secator.tree import build_runner_tree, get_flat_node_list
 		names = set()
 
 		def collect(holder):
@@ -313,24 +312,12 @@ class Runner:
 				if isinstance(confs, dict):
 					names.update(k for k, v in confs.items() if isinstance(v, dict) and v.get('sensitive'))
 
-		collect(self)
-		try:
-			from secator.runners.task import Task
-			from secator.tree import build_runner_tree, get_flat_node_list
-			for node in get_flat_node_list(build_runner_tree(self.config)):
-				if node.type != 'task':
-					continue
-				try:
-					collect(Task.get_task_class(node.name))
-				except ValueError:
-					# Unknown task name in this node: skip it, but keep scanning the rest.
-					continue
-		except Exception as e:
-			# Discovery failed for the whole tree: we can't enumerate sensitive opts, so
-			# redaction may be incomplete. Surface it loudly rather than failing silently
-			# (a silent miss here would let a secret through into serialized/printed state).
-			logger.warning('Could not resolve sensitive option names for %s (redaction may be incomplete): %s', getattr(self, 'unique_name', self), e)  # noqa: E501
-		self._sensitive_opt_names_cache = names
+		collect(self)  # a direct Command / PythonRunner instance carries its own opts
+		task_classes = {cls.__name__: cls for cls in discover_tasks()}
+		for node in get_flat_node_list(build_runner_tree(self.config)):
+			cls = task_classes.get(node.name.split('/')[0]) if node.type == 'task' else None
+			if cls:
+				collect(cls)
 		return names
 
 	@property

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -668,30 +668,14 @@ class Command(Runner):
 			self._print(cmd_str, rich=True)
 		opts_display = self.cmd_options
 		if self._has_sensitive_cmd_opts:
-			opts_display = self._redact_cmd_options(self.cmd_options)
+			# Mask the user-supplied value of sensitive opts in the debug echo. The conf's
+			# `default` is never a secret (see toDict note in _base), so it needs no masking.
+			opts_display = {
+				name: ({**oc, 'value': REDACTED_OPT_VALUE} if oc.get('conf', {}).get('sensitive') else oc)
+				for name, oc in self.cmd_options.items()
+			}
 		self.debug('command', obj={'cmd': cmd_display}, sub='start')
 		self.debug('options', obj=opts_display, sub='start')
-
-	@staticmethod
-	def _redact_cmd_options(cmd_options):
-		"""Mask both the resolved value and the (possibly secret) `default` of sensitive opts.
-
-		The option's `default` can itself be a secret — e.g. ai.api_key defaults to the
-		platform key — so masking only the top-level `value` would still leak it via the
-		`conf.default` field in debug output.
-		"""
-		redacted = {}
-		for name, oc in cmd_options.items():
-			conf = oc.get('conf', {})
-			if conf.get('sensitive'):
-				new_conf = {**conf}
-				for field in ('default', 'value'):
-					if new_conf.get(field):
-						new_conf[field] = REDACTED_OPT_VALUE
-				redacted[name] = {**oc, 'value': REDACTED_OPT_VALUE, 'conf': new_conf}
-			else:
-				redacted[name] = oc
-		return redacted
 
 	def handle_file_not_found(self, exc):
 		"""Handle case where binary is not found.

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -39,6 +39,15 @@ class Command(Runner):
 	cmd_redacted = None
 	_has_sensitive_cmd_opts = False
 
+	@property
+	def cmd_for_display(self):
+		"""The command to show/serialize: redacted when it carries a sensitive opt, else the real cmd.
+
+		Use this anywhere the command is emitted (printed, streamed, persisted, dry-run Info).
+		Never use it to execute — the subprocess must run `self.cmd` with the real value.
+		"""
+		return self.cmd_redacted if self._has_sensitive_cmd_opts else self.cmd
+
 	# Tags
 	tags = []
 	# Meta options
@@ -265,7 +274,7 @@ class Command(Runner):
 		res = super().toDict()
 		res.update(
 			{
-				'cmd': self.cmd_redacted if self._has_sensitive_cmd_opts else self.cmd,
+				'cmd': self.cmd_for_display,
 				'cwd': self.cwd,
 				'return_code': self.return_code,
 			}
@@ -473,7 +482,7 @@ class Command(Runner):
 			if self.dry_run:
 				self.print_description()
 				self.print_command()
-				yield Info(message=self.cmd)
+				yield Info(message=self.cmd_for_display)
 				return
 
 			# Abort if no inputs
@@ -494,7 +503,7 @@ class Command(Runner):
 
 			# In remote worker mode, stream description and cmd back to the client
 			if IN_WORKER and self.print_cmd:
-				cmd_str = _s(self.cmd)
+				cmd_str = _s(self.cmd_for_display)
 				if self.chunk and self.chunk_count:
 					cmd_str += f' ({self.chunk}/{self.chunk_count})'
 				if self.description:
@@ -650,7 +659,7 @@ class Command(Runner):
 
 	def print_command(self):
 		"""Print command."""
-		cmd_display = self.cmd_redacted if self._has_sensitive_cmd_opts else self.cmd
+		cmd_display = self.cmd_for_display
 		if self.print_cmd:
 			icon = self.run_opts.get('print_cmd_icon', self.print_cmd_icon)
 			cmd_str = f'{icon} [bold green]{_s(cmd_display)}[/]'
@@ -659,12 +668,30 @@ class Command(Runner):
 			self._print(cmd_str, rich=True)
 		opts_display = self.cmd_options
 		if self._has_sensitive_cmd_opts:
-			opts_display = {
-				name: ({**oc, 'value': REDACTED_OPT_VALUE} if oc.get('conf', {}).get('sensitive') else oc)
-				for name, oc in self.cmd_options.items()
-			}
+			opts_display = self._redact_cmd_options(self.cmd_options)
 		self.debug('command', obj={'cmd': cmd_display}, sub='start')
 		self.debug('options', obj=opts_display, sub='start')
+
+	@staticmethod
+	def _redact_cmd_options(cmd_options):
+		"""Mask both the resolved value and the (possibly secret) `default` of sensitive opts.
+
+		The option's `default` can itself be a secret — e.g. ai.api_key defaults to the
+		platform key — so masking only the top-level `value` would still leak it via the
+		`conf.default` field in debug output.
+		"""
+		redacted = {}
+		for name, oc in cmd_options.items():
+			conf = oc.get('conf', {})
+			if conf.get('sensitive'):
+				new_conf = {**conf}
+				for field in ('default', 'value'):
+					if new_conf.get(field):
+						new_conf[field] = REDACTED_OPT_VALUE
+				redacted[name] = {**oc, 'value': REDACTED_OPT_VALUE, 'conf': new_conf}
+			else:
+				redacted[name] = oc
+		return redacted
 
 	def handle_file_not_found(self, exc):
 		"""Handle case where binary is not found.
@@ -1159,7 +1186,12 @@ class Command(Runner):
 				value = preprocessor(value)
 			if process and processor:
 				value = processor(value)
-		debug('got opt value', obj={'name': opt_name, 'value': value, 'aliases': opt_names, 'values': opt_values}, obj_after=False, sub='init.options', verbose=True)  # noqa: E501
+		if isinstance(opt_conf, dict) and opt_conf.get('sensitive'):
+			log_value = REDACTED_OPT_VALUE if value else value
+			log_values = [REDACTED_OPT_VALUE if v else v for v in opt_values]
+		else:
+			log_value, log_values = value, opt_values
+		debug('got opt value', obj={'name': opt_name, 'value': log_value, 'aliases': opt_names, 'values': log_values}, obj_after=False, sub='init.options', verbose=True)  # noqa: E501
 		return value
 
 	def _build_cmd(self):

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -20,6 +20,7 @@ from secator.definitions import IN_WORKER, OPT_NOT_SUPPORTED, OPT_PIPE_INPUT, OP
 from secator.config import CONFIG
 from secator.output_types import Info, Warning, Error, Stat
 from secator.runners import Runner
+from secator.runners._base import REDACTED_OPT_VALUE
 from secator.template import TemplateLoader
 from secator.utils import debug, rich_escape as _s, signal_to_name
 
@@ -32,6 +33,11 @@ class Command(Runner):
 
 	# Base cmd
 	cmd = None
+
+	# Redacted copy of `cmd` for serialization/printing (sensitive opt values masked).
+	# Only diverges from `cmd` when the command carries a `sensitive: True` option.
+	cmd_redacted = None
+	_has_sensitive_cmd_opts = False
 
 	# Tags
 	tags = []
@@ -238,6 +244,8 @@ class Command(Runner):
 		# Add sudo to command if it is required
 		if self.requires_sudo:
 			self.cmd = f'sudo {self.cmd}'
+			if self._has_sensitive_cmd_opts:
+				self.cmd_redacted = f'sudo {self.cmd_redacted}'
 
 		# Build item loaders
 		instance_func = getattr(self, 'item_loader', None)
@@ -257,7 +265,7 @@ class Command(Runner):
 		res = super().toDict()
 		res.update(
 			{
-				'cmd': self.cmd,
+				'cmd': self.cmd_redacted if self._has_sensitive_cmd_opts else self.cmd,
 				'cwd': self.cwd,
 				'return_code': self.return_code,
 			}
@@ -642,14 +650,21 @@ class Command(Runner):
 
 	def print_command(self):
 		"""Print command."""
+		cmd_display = self.cmd_redacted if self._has_sensitive_cmd_opts else self.cmd
 		if self.print_cmd:
 			icon = self.run_opts.get('print_cmd_icon', self.print_cmd_icon)
-			cmd_str = f'{icon} [bold green]{_s(self.cmd)}[/]'
+			cmd_str = f'{icon} [bold green]{_s(cmd_display)}[/]'
 			if self.sync and self.chunk and self.chunk_count:
 				cmd_str += f' [dim gray11]({self.chunk}/{self.chunk_count})[/]'
 			self._print(cmd_str, rich=True)
-		self.debug('command', obj={'cmd': self.cmd}, sub='start')
-		self.debug('options', obj=self.cmd_options, sub='start')
+		opts_display = self.cmd_options
+		if self._has_sensitive_cmd_opts:
+			opts_display = {
+				name: ({**oc, 'value': REDACTED_OPT_VALUE} if oc.get('conf', {}).get('sensitive') else oc)
+				for name, oc in self.cmd_options.items()
+			}
+		self.debug('command', obj={'cmd': cmd_display}, sub='start')
+		self.debug('options', obj=opts_display, sub='start')
 
 	def handle_file_not_found(self, exc):
 		"""Handle case where binary is not found.
@@ -1191,6 +1206,7 @@ class Command(Runner):
 
 		opts = self.run_hooks('on_cmd_opts', opts, sub='init')
 
+		opts_str_redacted = ''
 		if opts:
 			for opt_conf in opts.values():
 				conf = opt_conf['conf']
@@ -1202,15 +1218,24 @@ class Command(Runner):
 					continue
 				if conf.get('requires_sudo', False):
 					self.requires_sudo = True
-				opts_str += ' ' + Command._build_opt_str(opt_conf)
+				opt_str = ' ' + Command._build_opt_str(opt_conf)
+				opts_str += opt_str
+				if conf.get('sensitive', False):
+					self._has_sensitive_cmd_opts = True
+					opts_str_redacted += ' ' + Command._build_opt_str(opt_conf, redact=True)
+				else:
+					opts_str_redacted += opt_str
 				if '{target}' in opts_str:
 					opts_str = opts_str.replace('{target}', self.inputs[0])
+					opts_str_redacted = opts_str_redacted.replace('{target}', self.inputs[0])
 		self.cmd_options = opts
-		self.cmd += opts_str
+		cmd_base = self.cmd
+		self.cmd = cmd_base + opts_str
+		self.cmd_redacted = (cmd_base + opts_str_redacted) if self._has_sensitive_cmd_opts else self.cmd
 
 	@staticmethod
-	def _build_opt_str(opt):
-		"""Build option string."""
+	def _build_opt_str(opt, redact=False):
+		"""Build option string. When ``redact`` is set, mask the value (used for sensitive opts)."""
 		conf = opt['conf']
 		shlex_quote = conf.get('shlex', True)
 		value = opt['value']
@@ -1222,6 +1247,8 @@ class Command(Runner):
 				opts_str += f'{opt_name}'
 			elif val is None:
 				continue
+			elif redact:
+				opts_str += f'{opt_name} {REDACTED_OPT_VALUE} '
 			else:
 				if shlex_quote:
 					val = shlex.quote(str(val))

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -29,8 +29,6 @@ from secator.ai.session import save_history, show_session_picker, replay_session
 from secator.ai.utils import call_llm, init_llm, setup_ai, format_llm_status
 
 
-DEFAULT_API_KEY = CONFIG.addons.ai.api_key
-
 
 @task()
 class ai(PythonRunner):
@@ -44,8 +42,15 @@ class ai(PythonRunner):
 		"prompt": {"type": str, "default": "", "short": "p", "help": "Prompt"},
 		"mode": {"type": str, "default": "", "help": "Mode: attack or chat"},
 		"model": {"type": str, "default": CONFIG.addons.ai.default_model, "help": "LLM model"},
-		"api_key": {"type": str, "default": DEFAULT_API_KEY, "sensitive": True, "help": "API key for LLM provider"},
-		"api_base": {"type": str, "default": CONFIG.addons.ai.api_base, "help": "API base URL"},
+		# Never set a secret/CONFIG value as a task-option `default`: secator-api
+		# serves task opts (including defaults) to the UI, so a CONFIG default
+		# would leak the platform's LLM API key into the runner form. Default to
+		# empty; the task falls back to CONFIG.addons.ai.* at runtime in
+		# _init_options (api_key = passed or CONFIG.addons.ai.api_key). The
+		# user-supplied value is still `sensitive` so it's redacted from serialized
+		# runner state (run_opts/cmd) even though it's never a default.
+		"api_key": {"type": str, "default": "", "sensitive": True, "help": "API key for LLM provider (defaults to configured key)"},  # noqa: E501
+		"api_base": {"type": str, "default": "", "help": "API base URL (defaults to configured base)"},
 		"sensitive": {"is_flag": True, "default": True, "help": "Encrypt sensitive data"},
 		"max_iterations": {"type": int, "default": 10, "help": "Max iterations"},
 		"temperature": {"type": float, "default": 0.7, "help": "LLM temperature"},
@@ -414,8 +419,8 @@ class ai(PythonRunner):
 		self.is_subagent = self.get_opt_value("subagent")
 		self.model = self.get_opt_value("model")
 		self.intent_model = self.get_opt_value("intent_model")
-		self.api_base = self.get_opt_value("api_base")
-		self.api_key = self.get_opt_value("api_key")
+		self.api_base = self.get_opt_value("api_base") or CONFIG.addons.ai.api_base
+		self.api_key = self.get_opt_value("api_key") or CONFIG.addons.ai.api_key
 		self.sensitive = self.get_opt_value("sensitive")
 		self.mode = self.get_opt_value("mode")
 		self.max_tokens_total = self.get_opt_value("max_tokens_total")

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -29,7 +29,6 @@ from secator.ai.session import save_history, show_session_picker, replay_session
 from secator.ai.utils import call_llm, init_llm, setup_ai, format_llm_status
 
 
-
 @task()
 class ai(PythonRunner):
 	"""AI-powered penetration testing assistant (attack or chat mode)."""

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -44,7 +44,7 @@ class ai(PythonRunner):
 		"prompt": {"type": str, "default": "", "short": "p", "help": "Prompt"},
 		"mode": {"type": str, "default": "", "help": "Mode: attack or chat"},
 		"model": {"type": str, "default": CONFIG.addons.ai.default_model, "help": "LLM model"},
-		"api_key": {"type": str, "default": DEFAULT_API_KEY, "help": "API key for LLM provider"},
+		"api_key": {"type": str, "default": DEFAULT_API_KEY, "sensitive": True, "help": "API key for LLM provider"},
 		"api_base": {"type": str, "default": CONFIG.addons.ai.api_base, "help": "API base URL"},
 		"sensitive": {"is_flag": True, "default": True, "help": "Encrypt sensitive data"},
 		"max_iterations": {"type": int, "default": 10, "help": "Max iterations"},

--- a/tests/unit/test_sensitive_opts.py
+++ b/tests/unit/test_sensitive_opts.py
@@ -1,0 +1,92 @@
+import logging
+import unittest
+
+from secator.runners import Command
+from secator.runners._base import REDACTED_OPT_VALUE
+from secator.runners.task import Task
+from secator.template import TemplateLoader
+from secator.utils import setup_logging
+
+level = logging.ERROR
+setup_logging(level)
+
+
+class SensitiveCmd(Command):
+	"""Ad-hoc command exposing one sensitive opt (token) and one plain opt (level)."""
+	cmd = 'sensitivecmd'
+	opts = {
+		'token': {'type': str, 'sensitive': True, 'help': 'auth token'},
+		'level': {'type': int, 'help': 'verbosity'},
+	}
+
+
+class PlainCmd(Command):
+	"""Control command with no sensitive opts — must be completely unaffected."""
+	cmd = 'plaincmd'
+	opts = {
+		'level': {'type': int, 'help': 'verbosity'},
+	}
+
+
+class TestSensitiveCommandOpts(unittest.TestCase):
+	def setUp(self):
+		self.maxDiff = None
+
+	def _build(self, cls, **opts):
+		return cls('example.com', sync=True, print_cmd=False, run=False, **opts)
+
+	def test_executed_cmd_keeps_secret(self):
+		"""The real command (run by the subprocess) must contain the true value."""
+		t = self._build(SensitiveCmd, token='SECRET123', level=5)
+		self.assertIn('SECRET123', t.cmd)
+		self.assertIn('-token SECRET123', t.cmd)
+
+	def test_redacted_cmd_masks_secret(self):
+		"""cmd_redacted (used for toDict/printing) masks only the sensitive value."""
+		t = self._build(SensitiveCmd, token='SECRET123', level=5)
+		self.assertTrue(t._has_sensitive_cmd_opts)
+		self.assertNotIn('SECRET123', t.cmd_redacted)
+		self.assertIn(f'-token {REDACTED_OPT_VALUE}', t.cmd_redacted)
+		self.assertIn('-level 5', t.cmd_redacted)  # non-sensitive opt untouched
+
+	def test_todict_cmd_and_run_opts_redacted(self):
+		"""Persisted/serialized state (toDict) leaks neither via cmd nor run_opts."""
+		t = self._build(SensitiveCmd, token='SECRET123', level=5)
+		d = t.toDict()
+		self.assertNotIn('SECRET123', d['cmd'])
+		self.assertEqual(d['run_opts'].get('token'), REDACTED_OPT_VALUE)
+		self.assertEqual(d['run_opts'].get('level'), 5)
+
+	def test_sensitive_opt_names(self):
+		t = self._build(SensitiveCmd, token='SECRET123', level=5)
+		self.assertEqual(t.sensitive_opt_names, {'token'})
+
+	def test_plain_cmd_unaffected(self):
+		"""A command with no sensitive opts: cmd_redacted == cmd, flag off, nothing masked."""
+		t = self._build(PlainCmd, level=5)
+		self.assertFalse(t._has_sensitive_cmd_opts)
+		self.assertEqual(t.cmd, t.cmd_redacted)
+		self.assertEqual(t.sensitive_opt_names, set())
+		self.assertEqual(t.toDict()['run_opts'].get('level'), 5)
+
+	def test_empty_sensitive_value_not_masked(self):
+		"""An unset/empty sensitive opt is left as-is in run_opts (no secret -> no false mask)."""
+		t = self._build(SensitiveCmd, token='', level=5)
+		self.assertEqual(t.toDict()['run_opts'].get('token'), '')
+
+
+class TestSensitiveRunnerOpts(unittest.TestCase):
+	"""The redaction must also apply at the composite-runner level (Task/Workflow/Scan),
+	which carries no opts of its own and resolves sensitivity from its config tree."""
+
+	def test_task_runner_redacts_ai_api_key(self):
+		cfg = TemplateLoader(input={'name': 'ai', 'type': 'task'})
+		r = Task(cfg, inputs=['hi'], run_opts={'api_key': 'SECRET123', 'model': 'x'})
+		self.assertEqual(r.sensitive_opt_names, {'api_key'})
+		d = r.toDict()
+		self.assertEqual(d['run_opts'].get('api_key'), REDACTED_OPT_VALUE)
+		self.assertEqual(d['run_opts'].get('model'), 'x')
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/unit/test_sensitive_opts.py
+++ b/tests/unit/test_sensitive_opts.py
@@ -1,14 +1,10 @@
-import logging
 import unittest
+import unittest.mock
 
 from secator.runners import Command
 from secator.runners._base import REDACTED_OPT_VALUE
 from secator.runners.task import Task
 from secator.template import TemplateLoader
-from secator.utils import setup_logging
-
-level = logging.ERROR
-setup_logging(level)
 
 
 class SensitiveCmd(Command):
@@ -74,6 +70,34 @@ class TestSensitiveCommandOpts(unittest.TestCase):
 		t = self._build(SensitiveCmd, token='', level=5)
 		self.assertEqual(t.toDict()['run_opts'].get('token'), '')
 
+	def test_print_command_masks_secret(self):
+		"""print_command() (the user-visible logging path) must not emit the real secret."""
+		t = SensitiveCmd('example.com', token='SECRET123', level=5, sync=True, print_cmd=True, run=False)
+		with unittest.mock.patch.object(t, '_print') as mock_print:
+			t.print_command()
+		printed = ' '.join(str(c.args[0]) for c in mock_print.call_args_list)
+		self.assertNotIn('SECRET123', printed)
+		self.assertIn('REDACTED', printed)  # substring: rich-escaping may render it as \[REDACTED\]
+
+	def test_dry_run_info_masks_secret(self):
+		"""The dry-run emission path (yields Info(message=cmd)) must use the redacted command."""
+		t = SensitiveCmd('example.com', token='SECRET123', level=5, sync=True, dry_run=True, print_cmd=False)
+		messages = ' '.join(str(getattr(item, 'message', '')) for item in t)
+		self.assertNotIn('SECRET123', messages)
+		self.assertIn(REDACTED_OPT_VALUE, messages)
+
+	def test_redact_cmd_options_masks_nested_default(self):
+		"""Debug echo of cmd_options must mask both the value and a secret-bearing `default`."""
+		cmd_options = {
+			'token': {'name': '-token', 'value': 'SECRET123',
+					  'conf': {'sensitive': True, 'default': 'PLATFORM_DEFAULT'}},
+			'level': {'name': '-level', 'value': 5, 'conf': {}},
+		}
+		out = Command._redact_cmd_options(cmd_options)
+		self.assertEqual(out['token']['value'], REDACTED_OPT_VALUE)
+		self.assertEqual(out['token']['conf']['default'], REDACTED_OPT_VALUE)
+		self.assertEqual(out['level'], cmd_options['level'])  # untouched
+
 
 class TestSensitiveRunnerOpts(unittest.TestCase):
 	"""The redaction must also apply at the composite-runner level (Task/Workflow/Scan),
@@ -86,6 +110,19 @@ class TestSensitiveRunnerOpts(unittest.TestCase):
 		d = r.toDict()
 		self.assertEqual(d['run_opts'].get('api_key'), REDACTED_OPT_VALUE)
 		self.assertEqual(d['run_opts'].get('model'), 'x')
+
+	def test_serialized_config_does_not_leak_sensitive_default(self):
+		"""An option's `default` can be a platform secret (ai.api_key defaults to the
+		configured key). It must not survive into toDict()['config'] / ['opts']."""
+		import json
+		from secator.tasks.ai import ai
+		with unittest.mock.patch.dict(ai.opts['api_key'], {'default': 'PLATFORM_SECRET_XYZ'}):
+			cfg = TemplateLoader(input={'name': 'ai', 'type': 'task'})
+			r = Task(cfg, inputs=['hi'], run_opts={'api_key': 'USER_SECRET_ABC'})
+			d = r.toDict()
+		blob = json.dumps(d, default=str)
+		self.assertNotIn('PLATFORM_SECRET_XYZ', blob)
+		self.assertNotIn('USER_SECRET_ABC', blob)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_sensitive_opts.py
+++ b/tests/unit/test_sensitive_opts.py
@@ -86,18 +86,6 @@ class TestSensitiveCommandOpts(unittest.TestCase):
 		self.assertNotIn('SECRET123', messages)
 		self.assertIn(REDACTED_OPT_VALUE, messages)
 
-	def test_redact_cmd_options_masks_nested_default(self):
-		"""Debug echo of cmd_options must mask both the value and a secret-bearing `default`."""
-		cmd_options = {
-			'token': {'name': '-token', 'value': 'SECRET123',
-					  'conf': {'sensitive': True, 'default': 'PLATFORM_DEFAULT'}},
-			'level': {'name': '-level', 'value': 5, 'conf': {}},
-		}
-		out = Command._redact_cmd_options(cmd_options)
-		self.assertEqual(out['token']['value'], REDACTED_OPT_VALUE)
-		self.assertEqual(out['token']['conf']['default'], REDACTED_OPT_VALUE)
-		self.assertEqual(out['level'], cmd_options['level'])  # untouched
-
 
 class TestSensitiveRunnerOpts(unittest.TestCase):
 	"""The redaction must also apply at the composite-runner level (Task/Workflow/Scan),
@@ -110,19 +98,6 @@ class TestSensitiveRunnerOpts(unittest.TestCase):
 		d = r.toDict()
 		self.assertEqual(d['run_opts'].get('api_key'), REDACTED_OPT_VALUE)
 		self.assertEqual(d['run_opts'].get('model'), 'x')
-
-	def test_serialized_config_does_not_leak_sensitive_default(self):
-		"""An option's `default` can be a platform secret (ai.api_key defaults to the
-		configured key). It must not survive into toDict()['config'] / ['opts']."""
-		import json
-		from secator.tasks.ai import ai
-		with unittest.mock.patch.dict(ai.opts['api_key'], {'default': 'PLATFORM_SECRET_XYZ'}):
-			cfg = TemplateLoader(input={'name': 'ai', 'type': 'task'})
-			r = Task(cfg, inputs=['hi'], run_opts={'api_key': 'USER_SECRET_ABC'})
-			d = r.toDict()
-		blob = json.dumps(d, default=str)
-		self.assertNotIn('PLATFORM_SECRET_XYZ', blob)
-		self.assertNotIn('USER_SECRET_ABC', blob)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Adds a `sensitive: True` option meta-flag (a sibling of the existing `internal` flag). An option value flagged sensitive is masked with `[REDACTED]` everywhere runner state is **persisted, serialized, or printed**, while the real value still travels in-flight to the worker and runs in the actual subprocess.

This lets users pass **their own addon API keys** through the existing options channel — e.g. the `ai` task's `api_key` (now marked sensitive) — without the secret ever landing in the Mongo runner doc, API responses, `--driver api` egress, or logs.

## Why

We want users to bring their own secrets (BYO addon keys, etc.) per run. The opts channel already carries these to the worker and persists runner state — but it persisted the secret in plaintext. Rather than build a separate config-override channel, we keep secrets on the opts channel and make the **data model** secret-aware. (Design: `docs/superpowers/specs/2026-06-29-sensitive-options-and-per-run-overrides-design.md` in `gke-admin`.)

## Leak surfaces covered

1. **`toDict()` `run_opts`** — Mongo runner doc, API responses, `--driver api` egress (`_base.Runner.resolved_opts`).
2. **The built command string** — a secret passed as a CLI flag (`--api-key X`) is masked in the `cmd` that `toDict()` and `print_command` expose, while the executed subprocess keeps the real value.
3. **Debug / console echoes** of the command and its options.

## Accepted, non-user-facing exposures (out of scope, by design)

- The value still rides the Redis broker message transiently (same as the existing external-keys vault).
- If a task passes a secret as a CLI flag, it appears in worker process args (`ps`); tasks that read the secret from an env var avoid this.

## Changes

- **`runners/_base.py`** — `Runner.sensitive_opt_names` (resolved from the runner's own `opts`/`meta_opts` or, for `Task`/`Workflow`/`Scan`, from its config tree's task classes; memoized) + redaction in `resolved_opts`. New `REDACTED_OPT_VALUE` constant.
- **`runners/command.py`** — build a redacted command alongside the real one; emit it from `toDict()` and `print_command`. **No behavior change for tasks without a sensitive opt** (`cmd_redacted == cmd`, flag off).
- **`cli_helper.py`** — drop the `sensitive` key before building click options (it's not a click param).
- **`tasks/ai.py`** — mark `api_key` `sensitive: True`.
- **`tests/unit/test_sensitive_opts.py`** — both leak surfaces (run_opts + cmd) for a Command task, the `Task`-runner path (ai `api_key`), and the non-sensitive no-op path.

## Testing

- New `test_sensitive_opts.py`: 7 passing.
- `test_command.py`, `test_python_runner.py`, `test_ai_task_opts.py`: green (33 total).
- `flake8` clean on all changed files.
- Verified `secator x ai --help` still builds the `--api-key` option (the `sensitive` key no longer breaks click).
- Manually verified: executed cmd keeps the real secret; `toDict()`/printed cmd and `run_opts` are masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sensitive option values are now automatically hidden in displayed and serialized command/runner output.
  * Secret fields such as API keys are marked to stay masked wherever they appear.

* **Bug Fixes**
  * Prevented sensitive option metadata from being treated like a regular command option.
  * Improved command printing so secret values are no longer exposed in logs or debug output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->