### PR TITLE
fix(ai): bound retries on persistent rate-limit to prevent infinite loop (H1)

### DIFF
--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -4,7 +4,6 @@ import json
 import uuid
 from itertools import groupby
 from pathlib import Path
-from time import sleep
 from typing import Generator
 
 from secator.config import CONFIG
@@ -339,6 +338,7 @@ class ai(PythonRunner):
 		iteration = 0
 		query_extensions = 0
 		empty_streak = 0
+		rate_limit_streak = 0
 		self._context_warnings_shown = set()
 
 		while iteration < self.max_iterations:
@@ -372,6 +372,9 @@ class ai(PythonRunner):
 				msg = format_llm_status(token_count, ctx_window, by_role)
 				with maybe_status(msg, spinner="dots"):
 					result = call_llm(messages, self.model, self.temp, self.api_base, self.api_key, tools=self.tool_schemas)
+
+				# reset rate-limit guard on success
+				rate_limit_streak = 0
 
 				content = result["content"]
 				tool_calls = result.get("tool_calls", [])
@@ -481,9 +484,14 @@ class ai(PythonRunner):
 
 			except Exception as e:
 				if isinstance(e, litellm.RateLimitError):
-					yield Warning(message="Rate limit exceeded - waiting 5s and retry in the next iteration")
-					iteration -= 1
-					sleep(5)
+					# call_llm already backed off (~2/4/8s); don't re-sleep. Bound consecutive
+					# 429s so a persistent rate limit can't spin forever; let iteration advance.
+					rate_limit_streak += 1
+					if rate_limit_streak >= 4:
+						yield Error(message="Rate limit exceeded on 4 consecutive attempts - aborting. Check your provider quota/billing.")
+						self._save_history()
+						return
+					yield Warning(message=f"Rate limit exceeded (attempt {rate_limit_streak}/4) - retrying in the next iteration")
 					continue
 				elif isinstance(e, litellm.AuthenticationError):
 					yield Error(message=str(e))

--- a/tests/unit/test_ai_tokens.py
+++ b/tests/unit/test_ai_tokens.py
@@ -361,5 +361,62 @@ class TestAiTokenAccountingEndToEnd(unittest.TestCase):
 		self.assertAlmostEqual(task.context["ai_cost"], 0.0025)
 
 
+@unittest.skipUnless(HAS_AI, 'ai addon required')
+class TestAiRateLimitTermination(unittest.TestCase):
+	"""A persistent 429 must terminate the loop after a bounded number of failures (H1)."""
+
+	def _make_loop_task(self, max_iterations):
+		task = _make_task()
+		task.inputs = []
+		task.model = "test-model"
+		task.intent_model = "test-model"
+		task.temp = 0.7
+		task.api_base = None
+		task.api_key = "key"
+		task.max_iterations = max_iterations
+		task.max_tokens_total = 100000
+		task.max_workers = 1
+		task.is_subagent = True
+		task.verbose = False
+		task.dry_run = False
+		task.mode = "chat"
+		task.scope = "workspace"
+		task.results = []
+		task.encryptor = None
+		task.tool_schemas = []
+		task.permission_engine = None
+		task.dangerous = True
+		task.interactive = "auto"
+		task._sync = True
+		task.session_id = "s"
+		task._reports_folder = None
+		task.debug = lambda *a, **k: None
+		task.add_result = lambda *a, **k: None
+		from secator.ai.interactivity import create_backend
+		task.backend = create_backend("auto")
+		return task
+
+	def test_persistent_rate_limit_aborts_bounded(self):
+		"""A 429 on every call_llm aborts after 4 attempts, regardless of max_iterations."""
+		import litellm
+		from secator.output_types import Error
+
+		task = self._make_loop_task(max_iterations=50)
+		calls = {"n": 0}
+
+		def always_rate_limited(*args, **kwargs):
+			calls["n"] += 1
+			raise litellm.RateLimitError("rate limited", "openai", "test-model")
+
+		with _loop_patches(task, always_rate_limited):
+			results = list(task._run_loop())
+
+		# bounded by the 4-consecutive-429 cap, not the 50-iteration budget
+		self.assertEqual(calls["n"], 4)
+		errors = [r for r in results if isinstance(r, Error)]
+		self.assertTrue(errors, "expected an Error to be yielded on abort")
+		self.assertIn("Rate limit", errors[-1].message)
+
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
**Finding:** H1 (High) — persistent rate-limit causes an effectively infinite loop.

## Root cause
In `secator/tasks/ai.py`, the main loop's exception handler did, for `litellm.RateLimitError`:

```python
iteration -= 1
sleep(5)
continue
```

Decrementing `iteration` pins the loop counter, so a *persistent* 429 (exhausted quota, billing block, provider throttle) never advances toward `max_iterations` and spins forever — bounded only by the 3h K8s Job deadline — holding a worker slot the whole time. `call_llm` in `secator/ai/utils.py` *already* retries 429 (up to 3×, ~2/4/8s exponential backoff) before re-raising, so the outer `sleep(5)` was redundant double-waiting.

## Fix
`secator/tasks/ai.py`, rate-limit handler region only:
- Stop pinning the counter — removed `iteration -= 1` so a 429 lets the iteration advance.
- Added a bounded **consecutive-429 guard** (`rate_limit_streak`, mirroring the existing `empty_streak` pattern): hard-abort with a clear `Error` after 4 consecutive rate-limit failures, then `_save_history()` + return. The streak resets to 0 on any successful `call_llm`, so transient throttling is forgiven; only a *persistent* 429 trips the abort. This bounds termination at `min(4, max_iterations)` **independent of `max_iterations`** (which is user-settable and can be raised by modes / query extensions).
- Removed the redundant outer `sleep(5)`; backoff is preserved inside `call_llm`. Dropped the now-orphaned `from time import sleep` import.
- `AuthenticationError` / `APIConnectionError` handling left untouched.

`secator/ai/utils.py` `call_llm` retry/backoff already provides the spacing between attempts (2/4/8s) and was left as-is — no change needed.

## Validation
- `python3 -m py_compile secator/tasks/ai.py secator/ai/utils.py` → OK.
- New focused test `tests/unit/test_ai_tokens.py::TestAiRateLimitTermination::test_persistent_rate_limit_aborts_bounded` reuses the existing `_loop_patches` harness, patches `call_llm` to raise `RateLimitError` on every call with `max_iterations=50`, drives the real `_run_loop`, and asserts the loop calls `call_llm` exactly **4** times (the consecutive-429 cap, far below the 50-iteration budget) and ends with a rate-limit abort `Error` — i.e. it provably terminates instead of looping unbounded. Passes.
- No new regressions: pre-existing failures on the base branch (`test_ai_loop.py` guardrail/e2e tests and `test_ai_tokens.py::test_loop_sums_token_usage`) are unchanged with vs. without this patch (verified by stash/compare).

## Extra issues surfaced
Noted in adjacent code; **not fixed here** (separate PRs / other lanes):
- **Pre-existing test failures on `ai-resiliency`** (not introduced by this PR, flagged for triage): in `tests/unit/test_ai_loop.py`, 9 guardrail/e2e tests fail with `Action denied: shell command not approved` (e.g. `TestGuardrailsAutoMode::test_allowed_command_passes`, `TestMainLoopAutoE2E::test_multi_turn_auto_loop`), and `tests/unit/test_ai_tokens.py::TestAiTokenAccountingEndToEnd::test_loop_sums_token_usage` asserts 600 but gets 100. These look like guardrail/loop drift, owned by other regions.
- **Empty-response handling** (`empty_streak`) hard-stops after 3 with `return` (no saved abort Error type distinction) — consistent with this fix's pattern, but worth confirming it's the intended UX.
- **`call_llm` retryable set** (`utils.py`) lumps `BadRequestError` and generic `APIError` into the same retry/backoff path as transient 429s — a permanently malformed request will still burn 3 backoff attempts (~6s) before surfacing. Candidate to split non-retryable client errors out.
- **`query_extensions` / mode configs raise `max_iterations` at runtime** — independent of this fix (the new guard is mode-independent), but a reminder that the iteration budget is not a tight upper bound on wall-clock by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNjPggRSVZ2xnLb7ZxWP5H