### PR TITLE
fix(ai): correlate permission prompts by prompt_uuid to stop stale auto-approval (H7)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -216,6 +216,8 @@ def check_guardrails(action: Dict, ctx: ActionContext):
 				value=result.shell_command,
 				reason=result.reason,
 				engine=ctx.permission_engine,
+				# unique id per prompt so its remote poll matches only its own answer (H7)
+				prompt_uuid=str(uuid.uuid4()),
 			)
 			if is_remote:
 				yield ctx.backend.build_pending_prompt(**ask_kwargs)
@@ -239,6 +241,7 @@ def check_guardrails(action: Dict, ctx: ActionContext):
 				value=target,
 				command=cmd_display,
 				engine=ctx.permission_engine,
+				prompt_uuid=str(uuid.uuid4()),
 			)
 			if is_remote:
 				yield ctx.backend.build_pending_prompt(**ask_kwargs)
@@ -261,6 +264,7 @@ def check_guardrails(action: Dict, ctx: ActionContext):
 					value=path,
 					command=cmd_display,
 					engine=ctx.permission_engine,
+					prompt_uuid=str(uuid.uuid4()),
 				)
 				if is_remote:
 					yield ctx.backend.build_pending_prompt(**ask_kwargs)

--- a/secator/ai/interactivity.py
+++ b/secator/ai/interactivity.py
@@ -103,18 +103,25 @@ class RemoteBackend(InteractivityBackend):
 
 		The caller must yield this item so it gets stored in the workspace
 		(via runner hooks) before calling ask_user(), which will poll for the answer.
+
+		``prompt_uuid`` (from context) is stamped into ``extra_data`` so the poll
+		can match THIS exact prompt, not a stale earlier answer (H7).
 		"""
 		from secator.output_types import Ai
+		extra_data = {
+			"permission_type": context.get("permission_type", ""),
+			"value": context.get("value", ""),
+		}
+		prompt_uuid = context.get("prompt_uuid")
+		if prompt_uuid:
+			extra_data["prompt_uuid"] = prompt_uuid
 		return Ai(
 			content=question,
 			ai_type=prompt_type,
 			status="pending",
 			choices=choices,
 			session_id=session_id,
-			extra_data={
-				"permission_type": context.get("permission_type", ""),
-				"value": context.get("value", ""),
-			},
+			extra_data=extra_data,
 			_timestamp=time.time(),
 		)
 
@@ -136,25 +143,15 @@ class RemoteBackend(InteractivityBackend):
 		return {"answer": answer}
 
 	def _poll_for_answer(self, session_id, prompt_type, prompt_uuid=None):
-		"""Poll DB for the answer to the SPECIFIC pending prompt until timeout.
+		"""Poll the DB for the answer to THIS specific prompt until timeout.
 
-		The query MUST be scoped to the exact prompt the worker is currently
-		blocked on — identified by ``prompt_uuid`` (stamped into the pending doc's
-		``extra_data.prompt_uuid`` before it was persisted). Matching only on
-		``{session_id, status:"answered"}`` is a bug: a multi-turn conversation
-		accumulates *previously* answered follow-up docs, so an unscoped query
-		returns a STALE answer immediately, the worker re-injects that old answer
-		as a brand-new prompt, re-runs the whole turn, asks again, re-matches the
-		same stale doc — an infinite respawn loop that re-runs scans and burns
-		tokens. Scoping on ``prompt_uuid`` makes the poll resolve only THIS
-		prompt's own answer (and time out only THIS prompt's doc).
+		Scoped by ``prompt_uuid``; without it an unscoped query returns a stale
+		earlier answer and respawns the turn in a loop (H7).
 		"""
 		base = {
 			"_type": "ai",
 			"ai_type": prompt_type,
-			# Correlate by the runner context's session_id: it's auto-stamped on
-			# every persisted item (item._context = self.context), so it's always
-			# present — unlike the top-level session_id field.
+			# session_id is auto-stamped on every persisted item (item._context)
 			"_context.session_id": session_id,
 		}
 		if prompt_uuid:
@@ -162,9 +159,11 @@ class RemoteBackend(InteractivityBackend):
 
 		elapsed = 0
 		while elapsed < self.timeout:
-			results = self.query_engine.search({**base, "status": "answered"}, limit=1)
+			results = self.query_engine.search({**base, "status": "answered"})
 			if results:
-				return results[0].get("answer")
+				# resolve against the newest answered doc as a backstop against stale answers
+				newest = max(results, key=lambda r: r.get("_timestamp", 0))
+				return newest.get("answer")
 			sleep(self.poll_interval)
 			elapsed += self.poll_interval
 		# Timeout: flip ONLY this prompt's still-pending doc to timed_out, so a

--- a/tests/unit/test_ai_interactivity.py
+++ b/tests/unit/test_ai_interactivity.py
@@ -140,6 +140,69 @@ class TestRemoteBackend(unittest.TestCase):
 		self.assertEqual(update_query.get("extra_data.prompt_uuid"), "abc-123")
 		self.assertEqual(update_query.get("status"), "pending")
 
+	def test_build_pending_prompt_stamps_permission_prompt_uuid(self):
+		"""A permission pending doc carries its prompt_uuid in extra_data."""
+		from secator.ai.interactivity import RemoteBackend
+		backend = RemoteBackend(timeout=60, query_engine=MagicMock())
+		item = backend.build_pending_prompt(
+			"Shell `nmap` requires approval", ["allow", "deny"], "session1",
+			prompt_type="permission", permission_type="shell", value="nmap",
+			prompt_uuid="uuid-shell",
+		)
+		self.assertEqual(item.extra_data.get("prompt_uuid"), "uuid-shell")
+		self.assertEqual(item.extra_data.get("permission_type"), "shell")
+		self.assertEqual(item.ai_type, "permission")
+		self.assertEqual(item.status, "pending")
+
+	@patch('secator.ai.interactivity.sleep')
+	def test_later_permission_layer_does_not_resolve_from_earlier_allow(self, mock_sleep):
+		"""H7: a later guardrail layer must not auto-resolve from an earlier 'allow'."""
+		from secator.ai.interactivity import RemoteBackend
+
+		# Fake "DB": one answered doc from the FIRST (shell) layer only.
+		answered_db = [{
+			"_type": "ai", "ai_type": "permission", "status": "answered",
+			"_context": {"session_id": "session1"},
+			"extra_data": {"prompt_uuid": "uuid-shell"},
+			"answer": "allow", "_timestamp": 100.0,
+		}]
+
+		def fake_search(query, *args, **kwargs):
+			# Honor prompt_uuid scoping like a real backend would.
+			want_uuid = query.get("extra_data.prompt_uuid")
+			out = []
+			for d in answered_db:
+				if d.get("status") != query.get("status"):
+					continue
+				if want_uuid is not None and d["extra_data"].get("prompt_uuid") != want_uuid:
+					continue
+				out.append(d)
+			return out
+
+		mock_engine = MagicMock()
+		mock_engine.search.side_effect = fake_search
+		backend = RemoteBackend(timeout=5, query_engine=mock_engine, poll_interval=5)
+
+		# First (shell) layer resolves to its own answered "allow".
+		first = backend._poll_for_answer("session1", "permission", prompt_uuid="uuid-shell")
+		self.assertEqual(first, "allow")
+
+		# Second (target) layer must NOT pick up the shell layer's "allow".
+		second = backend._poll_for_answer("session1", "permission", prompt_uuid="uuid-target")
+		self.assertIsNone(second)
+
+	def test_poll_returns_newest_answered_doc(self):
+		"""Defense in depth: resolve against the NEWEST answered doc by _timestamp."""
+		from secator.ai.interactivity import RemoteBackend
+		mock_engine = MagicMock()
+		mock_engine.search.return_value = [
+			{"answer": "stale", "_timestamp": 100.0},
+			{"answer": "fresh", "_timestamp": 200.0},
+		]
+		backend = RemoteBackend(timeout=60, query_engine=mock_engine, poll_interval=0.01)
+		result = backend._poll_for_answer("session1", "permission", prompt_uuid="abc-123")
+		self.assertEqual(result, "fresh")
+
 	@patch('secator.ai.interactivity.sleep')
 	def test_ask_user_returns_on_second_poll(self, mock_sleep):
 		from secator.ai.interactivity import RemoteBackend


### PR DESCRIPTION
## Finding: H7 (High — guardrail bypass)

Permission prompts poll for their answer **without a `prompt_uuid`**, so a poll resolves against ANY earlier answered permission doc.

## Root cause

The canary work added `prompt_uuid` correlation for **follow_up** prompts (in `tasks/ai.py`, where the follow_up pending doc is built) precisely so a poll can't resolve against a previously-answered doc. **Permission prompts were left unscoped.**

In `interactivity.py`, the permission poll matched:

```
{_type:"ai", ai_type:"permission", _context.session_id, status:"answered"}  (limit=1, no sort, no prompt_uuid)
```

so it returned the first/any earlier answered permission doc. Concretely:

- Within a single multi-layer guardrail check (`shell` → `target` → `path`), once the **first** layer is answered "allow", every **later** layer's poll instantly returns that stale "allow" and is auto-approved — the user never sees or can deny the later layers.
- Across turns, a brand-new permission prompt can resolve against an **old** approval.

This is a guardrail bypass, not just a glitch.

## Fix (mirrors the follow_up correlation; DRY)

1. **`actions.py` (permission-ask region):** stamp a fresh `prompt_uuid = str(uuid.uuid4())` into each permission `ask_kwargs` — **one per layer/iteration** (the shell ask, each target ask, each path ask) — so an earlier "allow" can't satisfy a later layer's poll. Reuses the exact `uuid` + `prompt_uuid` mechanism the follow_up path already uses (`tasks/ai.py` stamps `extra_data["prompt_uuid"]`).
2. **`interactivity.py` `build_pending_prompt`:** persist that `prompt_uuid` into the pending doc's `extra_data` so the poll can correlate on `extra_data.prompt_uuid` when the doc round-trips on read.
3. **`interactivity.py` `_poll_for_answer`:** already threaded `prompt_uuid` into the query (shared with follow_up); additionally resolve against the **newest** answered doc by `_timestamp` (defense in depth) instead of an arbitrary `limit=1` row.

Net effect: each guardrail layer polls for **only its own** answer and times out on its own doc; a prior "allow" can no longer leak forward.

## secator-api follow-up needed?

**Low-priority follow-up — flagged, not fixed here (different repo, out of scope this round).**

The answer-write path lives in `secator-api` (`crud.answer_ai_prompt`, which flips the "latest pending" doc to `answered`). For full correctness it should:

- **Preserve `extra_data.prompt_uuid`** on the answered doc (it already does if it does an in-place status update on the existing pending doc — which preserves `extra_data` — but this should be confirmed).
- Ideally **target the specific `prompt_uuid`** rather than "latest pending" for the session.

In practice permission prompts are issued **sequentially** (the worker blocks on each), so only one pending permission doc exists per session at a time and "latest pending" resolves to the right one — which is why this is low priority rather than blocking. Worth a confirming change in `secator-api` for robustness against any future concurrent-pending scenario.

## Validation

- `python3 -m py_compile secator/ai/interactivity.py secator/ai/actions.py` — OK.
- `tests/unit/test_ai_interactivity.py` — 22/22 pass, including new focused tests:
  - `test_later_permission_layer_does_not_resolve_from_earlier_allow` — the **H7 regression**: two sequential permission asks in one session; the first (shell) is answered "allow"; the second (target) polls with its own `prompt_uuid` and does NOT auto-resolve from the first's answered doc (it polls for its own uuid and times out).
  - `test_build_pending_prompt_stamps_permission_prompt_uuid` — pending permission doc carries `extra_data.prompt_uuid`.
  - `test_poll_returns_newest_answered_doc` — newest-by-`_timestamp` defense in depth.
- Pre-existing failures in `test_ai_guardrails.py` (50) and `test_ai_loop.py` (9) are present on the clean base branch too (verified via stash) — not introduced by this change.

## Extra issues surfaced

(Spotted near the permission region — **not fixed here**, flagging for the relevant lanes/owners.)

1. **Possible guardrail bypass on round exhaustion** (`check_guardrails`, `actions.py`): the prompt loop is capped at `max_rounds = 5`. If `result.decision` is still `"ask"` when the cap is hit, the function falls through to `return None` (= no denial), so the action proceeds **despite an unresolved "ask"**. A fail-closed default (deny when still "ask" after the cap) seems safer. Looks adjacent to the C3/H5/M10 cluster.
2. **`_poll_for_answer` now does an unbounded `search`** (I removed `limit=1` to enable newest-by-`_timestamp`). With `prompt_uuid` scoping the result set is tiny, but the legacy/no-uuid path (any caller that doesn't pass a `prompt_uuid`) could return many session docs per poll iteration. Mitigated by the newest-pick; a backend-side sort + `limit=1` would be cleaner but requires a change in `secator/query/` (out of region).
3. **`allow_all` vs `allow` are treated identically** in `RemoteBackend.ask_user` / `_add_permission_rules` — both just add a single runtime allow rule and return `{"answer":"allow"}`. If `allow_all` is meant to grant a broader/session-wide scope, that semantic is currently missing (UX/authz gap). Minor, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNjPggRSVZ2xnLb7ZxWP5H
