### PR TITLE
fix(ai): make shell guardrail wrapper-aware and fix destructive-command deny (C2, H6)

### DIFF
--- a/secator/ai/guardrails.py
+++ b/secator/ai/guardrails.py
@@ -26,6 +26,13 @@ WRITE_COMMANDS = frozenset({"tee", "cp", "mv", "sed", "awk", "dd", "install", "m
 # Execute-type commands
 EXECUTE_COMMANDS = frozenset({"python", "python3", "bash", "sh", "node", "ruby", "perl", "gcc", "g++", "make", "go"})
 
+# Exec-wrappers run a *different* command passed as args (`timeout 60 rm -rf /`),
+# so we peel the wrapper and check the INNER command, not the allow-listed name (C2).
+EXEC_WRAPPERS = frozenset({
+	"timeout", "xargs", "env", "nice", "ionice", "nohup", "stdbuf",
+	"setsid", "sudo", "doas", "watch", "time", "chroot", "unbuffer",
+})
+
 
 def parse_rule(rule: str) -> Tuple[str, List[str]]:
 	"""Parse a rule string like 'target(10.0.0.1,example.com)' into (type, patterns).
@@ -226,21 +233,19 @@ def extract_command_targets(command: str) -> List[str]:
 	return targets
 
 
-def _extract_cmd_names(command: str) -> List[str]:
-	"""Extract command names from a shell command using safecmd's bash parser.
+def _parse_subcommands(command: str) -> List[List[str]]:
+	"""Parse a shell command into sub-command token lists via safecmd's parser.
 
 	Uses shfmt (via safecmd) to properly parse pipes, &&, ||, ;, subshells,
-	and command substitutions. Returns empty list if parsing fails (caller
+	and command substitutions. Returns an empty list if parsing fails (caller
 	should prompt the user to approve the whole command).
 
 	Args:
 		command: Full shell command string
 
 	Returns:
-		List of command name strings (first token of each sub-command),
-		or empty list if parsing fails.
+		List of token lists, one per sub-command, or [] if parsing fails.
 	"""
-	import re
 	try:
 		from safecmd.bashxtract import extract_commands
 	except ImportError:
@@ -252,9 +257,55 @@ def _extract_cmd_names(command: str) -> List[str]:
 		# starts the next line (e.g. "cmd1\n| cmd2" -> "cmd1 | cmd2")
 		command = re.sub(r'\s*\n\s*(\||\&\&|\|\|)', r' \1', command)
 		cmds, ops, redirects = extract_commands(command)
-		return [c[0] for c in cmds if c]
+		return [c for c in cmds if c]
 	except Exception:
 		return []
+
+
+def _extract_cmd_names(command: str) -> List[str]:
+	"""Extract command names (first token of each sub-command); [] on parse failure."""
+	return [c[0] for c in _parse_subcommands(command)]
+
+
+def _is_wrapper_operand(token: str) -> bool:
+	"""Heuristic: is this token a wrapper operand (numeric duration / KEY=VALUE), not the inner cmd?"""
+	if re.fullmatch(r'\d+(?:\.\d+)?[smhd]?', token):
+		return True
+	if re.fullmatch(r'[A-Za-z_][A-Za-z0-9_]*=.*', token):
+		return True
+	return False
+
+
+def _peel_wrapper(args: List[str]) -> List[str]:
+	"""Strip leading exec-wrapper binaries to reach the inner command's tokens.
+
+	Bare `env`/`sudo` (no inner command) is returned as-is so it's still checked by name.
+	"""
+	tokens = args
+	for _ in range(len(args)):  # bounded peels (guards against pathological nesting)
+		if not tokens:
+			return tokens
+		name = tokens[0].rsplit('/', 1)[-1]
+		if name not in EXEC_WRAPPERS:
+			return tokens
+		rest = tokens[1:]
+		i = 0
+		while i < len(rest):
+			tok = rest[i]
+			if tok.startswith('-') or _is_wrapper_operand(tok):
+				i += 1
+				continue
+			break
+		if i >= len(rest):
+			return tokens  # wrapper with no inner command — check it by name
+		tokens = rest[i:]
+	return tokens
+
+
+def _match_command_glob(command: str, pattern: str) -> bool:
+	"""Anchored glob match where '*' does NOT cross '/' (so `rm -rf /*` spares `rm -rf /tmp/x`)."""
+	regex = ''.join('[^/]*' if ch == '*' else re.escape(ch) for ch in pattern)
+	return re.fullmatch(regex, command) is not None
 
 
 def _resolve_path(path: str, cwd: str = "") -> str:
@@ -639,8 +690,8 @@ class PermissionEngine:
 			command = action.get("command", "")
 			if not command.strip():
 				return PermissionResult(decision="deny", reason="Empty command")
-			cmd_names = _extract_cmd_names(command)
-			if not cmd_names:
+			subcommands = _parse_subcommands(command)
+			if not subcommands:
 				# Parse failure — prompt user for the whole command
 				return PermissionResult(
 					decision="ask",
@@ -649,7 +700,16 @@ class PermissionEngine:
 				)
 			most_restrictive = None
 			unmatched = []
-			for cmd_name in cmd_names:
+			for args in subcommands:
+				# peel exec-wrappers so the INNER command is checked, not the wrapper name (C2)
+				inner = _peel_wrapper(args)
+				if not inner:
+					continue
+				cmd_name = inner[0]
+				# multi-word denies (e.g. "rm -rf /*") match the full peeled command; names via _check_value (H6)
+				denied = self._match_shell_command_deny(inner)
+				if denied:
+					return PermissionResult(decision="deny", reason=f"Denied by rule: shell({denied})")
 				result = self._check_value("shell", cmd_name)
 				if result.decision == "deny":
 					# Distinguish explicit deny rules from "no matching rule" default
@@ -678,6 +738,19 @@ class PermissionEngine:
 		elif action_type in ("query", "follow_up", "add_finding"):
 			return PermissionResult(decision="allow", reason=f"{action_type} is always allowed")
 		return PermissionResult(decision="deny", reason=f"Unknown action type: {action_type}")
+
+	def _match_shell_command_deny(self, tokens: List[str]) -> str:
+		"""Return a multi-word shell deny pattern (e.g. "rm -rf /*") hit by these tokens, else "" (H6)."""
+		cmd_str = ' '.join(tokens)
+		for rt, patterns in self.rules["deny"]:
+			if rt != "shell":
+				continue
+			for pattern in patterns:
+				if ' ' not in pattern:
+					continue  # single-token denies are handled by name in _check_value
+				if _match_command_glob(cmd_str, pattern):
+					return pattern
+		return ""
 
 	def _check_value(self, rule_type: str, value: str) -> PermissionResult:
 		"""Check a single value. Order: deny > allow > ask > deny.

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -610,6 +610,55 @@ class TestDefaultPermissions(unittest.TestCase):
 		self.assertEqual(result.decision, "ask")
 		self.assertIn("rm", result.shell_command)
 
+	# === Exec-wrapper laundering (C2) + destructive deny (H6) ===
+
+	def test_timeout_wrapper_does_not_launder_destructive_rm(self):
+		"""`timeout 60 rm -rf /` must NOT auto-allow via the timeout wrapper (C2 + H6)."""
+		engine = self._engine()
+		result = engine.check_action({"action": "shell", "command": "timeout 60 rm -rf /"})
+		self.assertEqual(result.decision, "deny")
+
+	def test_xargs_wrapper_does_not_launder_inner_command(self):
+		"""`xargs ... rm ...` must not auto-allow via the xargs wrapper (C2)."""
+		engine = self._engine()
+		result = engine.check_action({"action": "shell", "command": "xargs -I{} rm -rf {}"})
+		# Inner rm is unknown (not root-destructive) -> prompt, never silent allow.
+		self.assertEqual(result.decision, "ask")
+
+	def test_timeout_wrapper_restores_interpreter_ask_gate(self):
+		"""Wrapping an interpreter (`timeout 60 bash -c ...`) must keep the ask gate (C2)."""
+		engine = self._engine()
+		result = engine.check_action({"action": "shell", "command": "timeout 60 bash -c 'rm -rf /'"})
+		self.assertEqual(result.decision, "ask")
+
+	def test_sudo_wrapper_does_not_launder_destructive_rm(self):
+		"""`sudo rm -rf /` must be denied, not laundered through sudo (C2 + H6)."""
+		engine = self._engine()
+		result = engine.check_action({"action": "shell", "command": "sudo rm -rf /"})
+		self.assertEqual(result.decision, "deny")
+
+	def test_destructive_root_rm_denied(self):
+		"""Bare `rm -rf /` (and one level under /) must be denied (H6)."""
+		engine = self._engine()
+		self.assertEqual(
+			engine.check_action({"action": "shell", "command": "rm -rf /"}).decision, "deny")
+		self.assertEqual(
+			engine.check_action({"action": "shell", "command": "rm -rf /etc"}).decision, "deny")
+
+	def test_scoped_rm_still_prompts_not_denied(self):
+		"""Scoped `rm -rf /tmp/x` is not catastrophic -> prompt (not silent allow/deny) (H6)."""
+		engine = self._engine()
+		result = engine.check_action({"action": "shell", "command": "rm -rf /tmp/data/x"})
+		self.assertEqual(result.decision, "ask")
+
+	def test_wrapper_preserves_allowed_inner_command(self):
+		"""`timeout 60 curl ...` must not regress: curl stays allowed at the action level."""
+		engine = self._engine(targets=["10.0.0.1"])
+		# Inner curl is allow-listed; the unknown URL target is what triggers the ask,
+		# proving the wrapper was peeled and curl recognised (not denied).
+		result = engine.check_action({"action": "shell", "command": "timeout 60 curl http://10.0.0.1/x"})
+		self.assertEqual(result.decision, "allow")
+
 	# === Should NOT trigger approval (allow) ===
 
 	def test_read_file_in_workspace(self):


### PR DESCRIPTION
## Findings

- **C2 (Critical) — exec-wrapper laundering.** Allow-listed wrapper binaries (`timeout`, `xargs`, `sudo`, `env`, `nice`, ...) execute an arbitrary inner command, but the engine only checked the wrapper's *name* token. So `timeout 60 rm -rf /` parsed to name `timeout` (allowed) and ran under `shell=True` with **no prompt**, also defeating the `bash`/`python` → `ask` gate.
- **H6 (High) — `shell(rm -rf /*)` deny was a no-op.** The deny entry `rm -rf /*` is a multi-word payload, but shell rules were matched against the single command-name token `rm`, which never equals `rm -rf /*`. The flagship destructive-delete protection silently did nothing.

## Root cause

One root cause: the shell branch of `PermissionEngine._check_action_type` checked only `cmd_name = c[0]` (the first token) of each parsed sub-command — so wrapped inner commands were invisible and multi-word deny payloads could never match.

## Fix (one change covers both)

In `secator/ai/guardrails.py`:

1. **Wrapper-aware checking (C2).** Added `EXEC_WRAPPERS` and `_peel_wrapper()`, which strips leading wrapper binaries (plus their flags / numeric operands / `KEY=VALUE` assignments, recursively) to reach the **inner** command. `_check_action_type` now checks the peeled inner command instead of the wrapper name. Reuses the existing safecmd parse via a new shared `_parse_subcommands()` helper.
2. **Destructive-payload deny actually fires (H6).** Multi-word shell deny entries are now matched against the full (wrapper-peeled) command string with `/`-boundary-aware globbing (`_match_command_glob`, where `*` does not cross `/`). So `rm -rf /` and `rm -rf /etc` are **denied**, while a scoped `rm -rf /tmp/x` falls through to the normal name-based check (which prompts). Single-token denies (`dd`, `mkfs`, `env`, `printenv`) keep matching by command name via `_check_value`.

**Chosen model (documented in code):** multi-word deny entries = anchored, path-boundary-aware match against the full command string; single-token entries = name match. `secator/config.py` is **unchanged** — the existing deny strings now actually fire, and the `timeout`/`xargs` allow entries are safe because inner commands are checked.

## DRY note

Both bugs share the single root cause (first-token-only checking), so they are fixed once: `_parse_subcommands()` is the single parse path (refactored out of `_extract_cmd_names`, reused by the wrapper-peeling logic), and the new behavior threads through the existing `_check_value` deny/allow/ask ordering rather than duplicating it.

## Validation

- `python3 -m py_compile secator/ai/guardrails.py secator/config.py` — clean.
- Extended `tests/unit/test_ai_guardrails.py` (`TestDefaultPermissions`, real default config) with 7 cases: `timeout 60 rm -rf /` → deny, `xargs -I{} rm -rf {}` → ask (no longer auto-allow), `timeout 60 bash -c ...` → ask (interpreter gate restored), `sudo rm -rf /` → deny, `rm -rf /` / `rm -rf /etc` → deny, scoped `rm -rf /tmp/x` → ask, and `timeout 60 curl ...` → allow (no regression of allowed inner commands).
- Full file: **125 passed** (118 prior + 7 new), including the pre-existing `rm -rf /tmp/data → ask` test which the path-boundary-aware deny preserves.

## Extra issues surfaced

- **`xargs ... rm ...` only reaches `ask`, not `deny`.** Because xargs feeds the operand (`{}`) from stdin, the peeled inner command is `rm -rf {}`, which doesn't match the root-anchored `rm -rf /*`, so it prompts rather than hard-denies. Acceptable (no longer auto-allowed), but worth noting the deny only fires when the destructive root path is literal in the command.
- **`_is_wrapper_operand` heuristic is conservative.** Wrapper option-values that are neither numeric nor `KEY=VALUE` (e.g. `xargs -I {}` with a space, an exotic `--flag value`) can cause the operand to be mistaken for the inner command — this fails *safe* (lands on an unknown token → `ask`), but could over-prompt on unusual wrapper invocations.
- **Wrapper list is allow-list-shaped.** New wrapper-style binaries (e.g. `flock`, `runuser`, `script`, `proxychains`, `firejail`) are not in `EXEC_WRAPPERS`, so a future allow-listed wrapper outside this set would reintroduce the same laundering class. Consider deriving wrappers from a maintained set or classifying them.
- **`shell(env)` is both a wrapper and a deny entry.** Bare `env` (env dump / exfil) is correctly denied, but `env FOO=bar somecmd` now peels to `somecmd` — intended, but means `env` used purely as a wrapper bypasses the `env` deny by design. Flagged for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNjPggRSVZ2xnLb7ZxWP5H