### PR TITLE
fix(ai): sanitize LLM-supplied subagent opts to prevent guardrail bypass (C1)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -385,6 +385,46 @@ def _is_heavy_runner(runner_type: str, name: str, opts: dict = None) -> bool:
 	return profile in _HEAVY_PROFILES
 
 
+# Framework control/security keys the LLM must never set on a spawned sub-runner
+# (esp. `dangerous`, which skips the permission engine). Task/workflow scan opts
+# (nmap ports, httpx rate_limit, ...) are not control keys and pass through.
+_FORBIDDEN_CHILD_OPT_KEYS = frozenset({
+	"dangerous",
+	"interactive",
+	"hooks",
+	"sync",
+	"subagent",
+	"tty",
+	"dry_run",
+	"exporters",
+	"enable_reports",
+})
+
+# Cap a spawned subagent's iteration budget so it can't be told to loop unbounded.
+_MAX_CHILD_ITERATIONS = 25
+
+
+def _sanitize_child_opts(opts: Any) -> Dict:
+	"""Drop LLM-settable control/security keys from sub-runner opts; clamp max_iterations."""
+	if not isinstance(opts, dict):
+		return {}
+	clean = {}
+	for key, value in opts.items():
+		k = str(key)
+		if k in _FORBIDDEN_CHILD_OPT_KEYS or k.startswith("print_"):
+			continue
+		clean[key] = value
+	# Clamp the AI-subagent iteration budget (bool is an int subclass — drop it).
+	mi = clean.get("max_iterations")
+	if isinstance(mi, bool):
+		clean.pop("max_iterations", None)
+	elif isinstance(mi, (int, float)):
+		clean["max_iterations"] = max(1, min(int(mi), _MAX_CHILD_ITERATIONS))
+	elif mi is not None:
+		clean.pop("max_iterations", None)
+	return clean
+
+
 def _run_runner(action: Dict, ctx: ActionContext, runner_type: str) -> Generator:
 	"""Execute a secator task or workflow.
 
@@ -395,13 +435,17 @@ def _run_runner(action: Dict, ctx: ActionContext, runner_type: str) -> Generator
 	"""
 	name = action.get("name", "")
 	targets = action.get("targets", ctx.targets)
-	opts = action.get("opts", {})
+	# drop LLM-set control keys (notably `dangerous`) before they reach the child
+	opts = _sanitize_child_opts(action.get("opts", {}))
 	context = _get_result_context(action, ctx)
 
 	# Force subagent flags when spawning an AI task from a parent AI task
 	if runner_type == "task" and name.lower() == "ai":
 		opts["subagent"] = True
 		opts["interactive"] = False
+
+	# defense in depth: a spawned runner is never dangerous (CLI --dangerous unaffected)
+	opts["dangerous"] = False
 
 	if runner_type == "task":
 		tpl = TemplateLoader(input={'type': 'task', 'name': name})

--- a/secator/ai/tools.py
+++ b/secator/ai/tools.py
@@ -37,7 +37,7 @@ TOOL_SCHEMAS = {
 					},
 					"opts": {
 						"type": "object",
-						"description": "Optional task-specific options (e.g. ports, rate_limit, timeout)."
+						"description": "Optional task-specific options (e.g. ports, rate_limit). Control/security flags are ignored."
 					}
 				},
 				"required": ["name", "targets"]
@@ -63,7 +63,7 @@ TOOL_SCHEMAS = {
 					},
 					"opts": {
 						"type": "object",
-						"description": "Optional workflow options (e.g. profiles)."
+						"description": "Optional workflow options (e.g. profiles). Control/security flags are ignored."
 					}
 				},
 				"required": ["name", "targets"]

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -10,7 +10,8 @@ if ADDONS_ENABLED['ai']:
 	from secator.ai.actions import (
 		ActionContext, dispatch_action, _handle_follow_up, _handle_shell,
 		_handle_query, _handle_add_finding, _run_runner, _decrypt_dict,
-		_build_hooks_from_context, _coerce_finding_fields
+		_build_hooks_from_context, _coerce_finding_fields, _sanitize_child_opts,
+		_MAX_CHILD_ITERATIONS
 	)
 	from secator.output_types import Ai, Error, Info, Warning, Vulnerability, Url
 
@@ -408,6 +409,97 @@ class TestRunRunner(unittest.TestCase):
 
 		_, kwargs = mock_task_cls.call_args
 		self.assertEqual(kwargs.get('context', {}).get('session_id'), 'from-context')
+
+
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestSanitizeChildOpts(unittest.TestCase):
+	"""Tests for _sanitize_child_opts (C1: LLM-supplied subagent opts allow-list)."""
+
+	def test_strips_dangerous_and_control_keys(self):
+		opts = {
+			'dangerous': True, 'interactive': 'local', 'hooks': {'x': 1},
+			'sync': False, 'subagent': True, 'tty': True, 'dry_run': True,
+			'exporters': ['csv'], 'enable_reports': False,
+		}
+		clean = _sanitize_child_opts(opts)
+		self.assertEqual(clean, {})
+
+	def test_strips_print_star_keys(self):
+		clean = _sanitize_child_opts({'print_cmd': True, 'print_item': False, 'print_anything': 1})
+		self.assertEqual(clean, {})
+
+	def test_keeps_benign_task_opts(self):
+		clean = _sanitize_child_opts({'ports': '80,443', 'rate_limit': 100, 'mode': 'attack'})
+		self.assertEqual(clean, {'ports': '80,443', 'rate_limit': 100, 'mode': 'attack'})
+
+	def test_clamps_max_iterations(self):
+		clean = _sanitize_child_opts({'max_iterations': 9999})
+		self.assertEqual(clean['max_iterations'], _MAX_CHILD_ITERATIONS)
+		clean = _sanitize_child_opts({'max_iterations': 5})
+		self.assertEqual(clean['max_iterations'], 5)
+		# bool / non-numeric max_iterations is dropped (bool is an int subclass)
+		self.assertNotIn('max_iterations', _sanitize_child_opts({'max_iterations': True}))
+		self.assertNotIn('max_iterations', _sanitize_child_opts({'max_iterations': 'lots'}))
+
+	def test_non_dict_returns_empty(self):
+		self.assertEqual(_sanitize_child_opts(None), {})
+		self.assertEqual(_sanitize_child_opts('dangerous'), {})
+
+	@patch('secator.ai.actions.TemplateLoader')
+	@patch('secator.ai.actions.Task')
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_run_runner_neutralizes_dangerous_and_interactive(self, mock_build_hooks, mock_task_cls, _mock_tpl):
+		"""C1: an LLM emitting opts={'dangerous': True, 'interactive': 'local'} must NOT
+		propagate either into the spawned child's run_opts — dangerous is forced False
+		and interactive (a control key) is stripped."""
+		mock_build_hooks.return_value = {}
+		mock_runner = MagicMock()
+		mock_runner.id = 'runner123'
+		mock_runner.reports_folder = None
+		mock_runner.__iter__.return_value = iter([])
+		mock_task_cls.return_value = mock_runner
+
+		ctx = ActionContext(targets=['t.com'], model='m', context={'workspace_id': 'ws1'})
+		action = {
+			'action': 'task', 'name': 'nmap', 'targets': ['10.0.0.1'],
+			'opts': {'dangerous': True, 'interactive': 'local', 'ports': '80'},
+		}
+
+		list(_run_runner(action, ctx, 'task'))
+
+		_, kwargs = mock_task_cls.call_args
+		run_opts = kwargs.get('run_opts', {})
+		self.assertEqual(run_opts.get('dangerous'), False)
+		self.assertNotEqual(run_opts.get('interactive'), 'local')
+		# benign task opt still passes through
+		self.assertEqual(run_opts.get('ports'), '80')
+
+	@patch('secator.ai.actions.TemplateLoader')
+	@patch('secator.ai.actions.Task')
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_run_runner_ai_subagent_forced_flags_over_llm_opts(self, mock_build_hooks, mock_task_cls, _mock_tpl):
+		"""Spawning an `ai` subagent with hostile opts: subagent forced True,
+		interactive forced False, dangerous forced False regardless of LLM input."""
+		mock_build_hooks.return_value = {}
+		mock_runner = MagicMock()
+		mock_runner.id = 'runner123'
+		mock_runner.reports_folder = None
+		mock_runner.__iter__.return_value = iter([])
+		mock_task_cls.return_value = mock_runner
+
+		ctx = ActionContext(targets=['t.com'], model='m', context={'workspace_id': 'ws1'})
+		action = {
+			'action': 'task', 'name': 'ai', 'targets': ['10.0.0.1'],
+			'opts': {'dangerous': True, 'interactive': 'local', 'subagent': False},
+		}
+
+		list(_run_runner(action, ctx, 'task'))
+
+		_, kwargs = mock_task_cls.call_args
+		run_opts = kwargs.get('run_opts', {})
+		self.assertEqual(run_opts.get('dangerous'), False)
+		self.assertEqual(run_opts.get('interactive'), False)
+		self.assertEqual(run_opts.get('subagent'), True)
 
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')


### PR DESCRIPTION
## Finding: C1 (Critical) — LLM can disable all guardrails on a spawned subagent

### Root cause
In `secator/ai/actions.py`, `_run_runner` read `opts = action.get("opts", {})` — and that `opts` is **LLM-supplied and freeform** (in `tools.py` the `run_task`/`run_workflow` `opts` is `{"type": "object"}` with no property restriction). `_run_runner` only force-set `subagent`/`interactive` for `name=="ai"`, then spread `**opts` straight into the child `run_opts`. The child task does `self.dangerous = self.get_opt_value("dangerous")` and `if self.dangerous: denial = None`, skipping **all** permission checks. So a model — or prompt-injected target output — emitting `run_task(name="ai", targets=[...], opts={"dangerous": true})` spawns a child that bypasses every guardrail (arbitrary shell, any target, any path).

### Fix
1. **`_sanitize_child_opts(opts)`** — a single helper that drops the framework control/security keys the parent owns (`dangerous`, `interactive`, `hooks`, `sync`, `subagent`, `tty`, `dry_run`, `exporters`, `enable_reports`, and any `print_*`) and clamps `max_iterations` to a safe bound (`_MAX_CHILD_ITERATIONS = 25`). Task/workflow-specific scan options (e.g. nmap `ports`, httpx `rate_limit`) are **not** control keys and pass through, so scans are unaffected.
2. **Force `opts["dangerous"] = False`** on every spawned runner — defense-in-depth, so even if a control key slipped through, the child can never re-enable a guardrail bypass.
3. Schema descriptions in `tools.py` now document that control flags are ignored.

### Why this is the right boundary
The neutralization happens **spawn-side** in `_run_runner` (the trust boundary where untrusted LLM/tool-call input becomes a child runner's config), **not** by touching the `self.dangerous` logic in `tasks/ai.py`. That keeps the legitimate operator-facing `--dangerous` CLI escape hatch intact for a human running secator directly, while making it impossible for an LLM (or injected output) to set it on a child it spawns.

### Validation
- `python3 -m py_compile secator/ai/actions.py secator/ai/tools.py` — clean.
- New focused tests in `tests/unit/test_ai_actions.py` (`TestSanitizeChildOpts`): strips dangerous/control/`print_*` keys, keeps benign opts, clamps/drops `max_iterations`, non-dict → `{}`, plus two `_run_runner` integration tests asserting `opts={"dangerous": true, "interactive": "local"}` yields a child `run_opts` with `dangerous=False` and no `interactive="local"` (and the `ai`-subagent path forces `subagent=True`, `interactive=False`, `dangerous=False`).
- `pytest tests/unit/test_ai_actions.py tests/unit/test_ai_tools.py tests/unit/test_ai_safety.py` → **92 passed**.

## Extra issues surfaced
- **Deny-list vs. strict allow-list (deliberate deviation):** the brief suggested a strict allow-list of LLM-settable keys. A strict allow-list would strip every task-specific scan option (nmap `ports`, httpx `rate_limit`, …) and break the AI's core ability to drive scans. I implemented a **deny-list of framework control/security keys + forced `dangerous=False`** instead — same security outcome at the spawn boundary, without degrading functionality. Flagging for reviewer awareness.
- **`run_shell` remains the broadest hole:** C1 is fixed, but the AI `run_shell` action executes arbitrary commands gated only by the permission engine. Worth a separate hardening pass (outside this PR's owned region).
- **`hooks` via `run_opts` is theoretical here** (the real `hooks` is a separate `runner_cls(..., hooks=...)` kwarg built from context, not from `opts`), but it stays in the deny-list as defense-in-depth in case `run_opts` ever forwards a `hooks` key.
- **No parent-posture propagation field:** `ActionContext` carries no `dangerous` field, so the child is forced non-dangerous unconditionally (the safe default). Letting a dangerous parent spawn dangerous children would need explicit, separately-reviewed plumbing — intentionally not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNjPggRSVZ2xnLb7ZxWP5H