### PR TITLE
fix(ai): fail closed when guardrail prompts are exhausted (H10)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -277,6 +277,10 @@ def check_guardrails(action: Dict, ctx: ActionContext):
 		if result.decision == "deny":
 			return f"Action denied after prompt: {result.reason}"
 
+	# fail closed: prompts exhausted with the decision still unresolved -> block (H10)
+	if result.decision == "ask":
+		return f"Action denied: guardrail check unresolved after {max_rounds} prompts"
+
 	return None
 
 

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -986,5 +986,22 @@ class TestRunBatch(unittest.TestCase):
         self.assertIsInstance(results[0], Warning)
 
 
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestCheckGuardrailsFailClosed(unittest.TestCase):
+	"""H10: prompts exhausted with the decision still 'ask' must fail CLOSED (deny)."""
+
+	def test_unresolved_after_max_rounds_denies(self):
+		from secator.ai.actions import check_guardrails_sync
+		# permission engine that never resolves: always 'ask', no shell/target/path layer
+		res = MagicMock(decision="ask", shell_command="", targets=[], paths=[], reason="needs approval")
+		engine = MagicMock()
+		engine.check_action.return_value = res
+		ctx = ActionContext(targets=['t.com'], model='m')
+		ctx.permission_engine = engine
+		denial, _items = check_guardrails_sync({"action": "shell", "command": "x"}, ctx)
+		self.assertIsNotNone(denial, "exhausted-but-unresolved guardrail must deny, not return None")
+		self.assertIn("unresolved", denial)
+
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
## Finding H10 — guardrail ask-exhaustion fails open

**Root cause:** `check_guardrails(action, ctx)` loops re-checking the permission decision, bounded by `max_rounds` (5). If the loop exits because the cap was hit while `result.decision` is still `"ask"` (unresolved), control fell through to `return None`. A `None` return means "no denial", so the caller let the **un-approved action proceed** — fail-open.

**Fix:** After the loop, if the decision is still `"ask"`, return a denial string (`"Action denied: guardrail check unresolved after {max_rounds} prompts"`) so the action is blocked. Fail-**closed**.

- Explicit `deny` paths already return inside the loop; an `allow`/no-rule action exits with `decision == "allow"`, skips the new guard, and proceeds as before.
- Surgical: one post-loop guard, no behavior change to resolved cases.

**Validation:** `test_ai_actions.py` 61/61 pass, incl. a new test driving an always-`"ask"` engine past the cap and asserting a denial (not `None`).

## Extra issues surfaced (flagged, not fixed)
- **Other ask layers fail open on unexpected answers:** the shell/target/path blocks only deny when `response is None or answer == "deny"`; any other value (typo/unknown choice) falls through to approval. Worth tightening to `answer in {"allow","allow_all"}`.
- **`parse_failed` shell path returns `None`** (un-parseable command the user didn't explicitly deny proceeds) — separate fail-open smell, flagged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNjPggRSVZ2xnLb7ZxWP5H