### PR TITLE
fix(ai): make history trim/compact tool-pair-aware to avoid orphan tool messages (H2)

### DIFF
--- a/secator/ai/history.py
+++ b/secator/ai/history.py
@@ -208,11 +208,17 @@ class ChatHistory:
             Trimmed list of messages.
         """
         from litellm.utils import trim_messages
+        from secator.ai.utils import _strip_leading_orphan_tools
         from secator.rich import console
         from secator.output_types import Warning
 
         original_count = len(self.messages)
         trimmed = trim_messages(self.messages, max_tokens=max_tokens)
+
+        # litellm drops the OLDEST messages with no tool-pairing awareness, so the
+        # kept window can START with an orphan tool_result whose assistant(tool_calls)
+        # parent was dropped — Anthropic/OpenAI reject that. Drop leading orphans.
+        _strip_leading_orphan_tools(trimmed)
         dropped = original_count - len(trimmed)
 
         if dropped:
@@ -381,9 +387,14 @@ class ChatHistory:
             to_summarize = rest
             to_keep = []
 
-        from secator.ai.utils import call_llm
+        from secator.ai.utils import call_llm, _strip_leading_orphan_tools
         from secator.rich import console
         from secator.utils import format_token_count
+
+        # The blind keep_last tail cut can leave to_keep STARTING with a tool_result
+        # whose assistant(tool_calls) parent fell into to_summarize — strip those so
+        # the rebuilt window never begins on an orphan tool_result.
+        _strip_leading_orphan_tools(to_keep)
 
         # Calculate target summary size based on available context
         context_window = get_context_window(model)

--- a/secator/ai/utils.py
+++ b/secator/ai/utils.py
@@ -14,18 +14,50 @@ from secator.utils import format_token_count
 _llm_initialized = False
 
 
-def _repair_orphan_tool_uses(messages: List[Dict]) -> int:
-	"""Insert synthetic tool_result messages for orphan assistant tool_use blocks.
+def _strip_leading_orphan_tools(messages: List[Dict]) -> int:
+	"""Drop leading 'tool' (tool_result) messages with no preceding tool_use.
 
-	Anthropic rejects requests where an assistant tool_use block is not
-	immediately followed by a matching tool_result. Mutates `messages` in place.
+	Truncation/compaction drops the OLDEST messages with no tool-pairing
+	awareness, so the kept window can START with a tool_result whose
+	assistant(tool_calls) parent was dropped. Anthropic/OpenAI reject such a
+	leading orphan tool_result ("tool_result without matching tool_use").
+	System messages are preserved; we scan past them and drop the run of
+	leading 'tool' messages that follows. Mutates `messages` in place.
 
 	Args:
 		messages: List of message dicts in litellm/OpenAI format.
 
 	Returns:
-		Number of synthetic tool_results inserted.
+		Number of leading orphan tool messages removed.
 	"""
+	i = 0
+	while i < len(messages) and messages[i].get("role") == "system":
+		i += 1
+	removed = 0
+	while i < len(messages) and messages[i].get("role") == "tool":
+		messages.pop(i)
+		removed += 1
+	return removed
+
+
+def _repair_orphan_tool_uses(messages: List[Dict]) -> int:
+	"""Repair orphan tool_use/tool_result pairing for Anthropic/OpenAI.
+
+	Two defects are fixed (both mutate `messages` in place):
+	- LEADING orphan tool_results: a kept window starting with a tool_result
+	  whose assistant(tool_calls) parent was trimmed away (see
+	  `_strip_leading_orphan_tools`).
+	- FORWARD orphan tool_uses: an assistant tool_use block not immediately
+	  followed by a matching tool_result (synthesize an acknowledged result).
+
+	Args:
+		messages: List of message dicts in litellm/OpenAI format.
+
+	Returns:
+		Number of messages removed or synthetic tool_results inserted.
+	"""
+	# Leading orphan tool_results have no parent in this window — drop them.
+	repaired = _strip_leading_orphan_tools(messages)
 	inserted = 0
 	i = 0
 	while i < len(messages):
@@ -69,7 +101,7 @@ def _repair_orphan_tool_uses(messages: List[Dict]) -> int:
 			j += len(to_insert)
 
 		i = j
-	return inserted
+	return repaired + inserted
 
 
 def init_llm(api_key: Optional[str] = None):

--- a/tests/unit/test_ai_tokens.py
+++ b/tests/unit/test_ai_tokens.py
@@ -418,5 +418,73 @@ class TestAiRateLimitTermination(unittest.TestCase):
 		self.assertIn("Rate limit", errors[-1].message)
 
 
+@unittest.skipUnless(HAS_AI, 'ai addon required')
+class TestAiToolPairTrim(unittest.TestCase):
+	"""Trim/compaction must not leave a leading orphan tool_result (H2).
+
+	litellm trim_messages and the blind keep_last tail cut drop the OLDEST
+	messages with no tool-pairing awareness, so the kept window can START with a
+	tool_result whose assistant(tool_calls) parent was dropped — which
+	Anthropic/OpenAI reject. The fix strips those leading orphans.
+	"""
+
+	def test_strip_leading_orphan_tools_keeps_system(self):
+		from secator.ai.utils import _strip_leading_orphan_tools
+		msgs = [
+			{"role": "system", "content": "s"},
+			{"role": "tool", "tool_call_id": "t1", "content": "{}"},
+			{"role": "tool", "tool_call_id": "t2", "content": "{}"},
+			{"role": "user", "content": "u"},
+		]
+		removed = _strip_leading_orphan_tools(msgs)
+		self.assertEqual(removed, 2)
+		self.assertEqual([m["role"] for m in msgs], ["system", "user"])
+
+	def test_repair_handles_leading_orphan_tool(self):
+		from secator.ai.utils import _repair_orphan_tool_uses
+		msgs = [
+			{"role": "tool", "tool_call_id": "t1", "content": "{}"},
+			{"role": "user", "content": "u"},
+		]
+		n = _repair_orphan_tool_uses(msgs)
+		self.assertEqual(n, 1)
+		self.assertEqual(msgs[0]["role"], "user")
+
+	def test_trim_strips_leading_orphan_tool(self):
+		"""After litellm drops the assistant parent, trim() removes the orphan tool."""
+		history = ChatHistory(model="test-model")
+		history.add_system("sys")
+		history.add_assistant_with_tool_calls(None, [{"id": "t1", "function": {"name": "noop", "arguments": "{}"}}])
+		history.add_tool_result("noop", "t1", "{}")
+		history.add_user("u1")
+		history.add_assistant("a1")
+		# Simulate litellm dropping the oldest (assistant parent) but keeping its tool_result.
+		simulated = [history.messages[0], history.messages[2], history.messages[3], history.messages[4]]
+		with patch('litellm.utils.trim_messages', return_value=simulated):
+			out = history.trim(100)
+		nonsys = [m for m in out if m["role"] != "system"]
+		self.assertEqual(nonsys[0]["role"], "user")
+		self.assertFalse(any(m["role"] == "tool" for m in out))
+
+	def test_compact_strips_leading_orphan_tool_in_kept_tail(self):
+		"""keep_last tail cut that starts on a tool_result is repaired."""
+		history = ChatHistory(model="test-model")
+		history.add_system("sys")
+		history.add_user("u1")
+		history.add_assistant_with_tool_calls(None, [{"id": "t1", "function": {"name": "noop", "arguments": "{}"}}])
+		history.add_tool_result("noop", "t1", "{}")
+		history.add_assistant("a2")
+		history.add_user("u2")
+
+		fake = {"content": "summary", "usage": None}
+		with patch('secator.ai.utils.call_llm', return_value=fake):
+			with patch('secator.ai.history.get_context_window', return_value=8000):
+				history.compact("test-model", keep_last=3)
+
+		nonsys = [m for m in history.messages if m["role"] != "system"]
+		self.assertIn(nonsys[0]["role"], ("user", "assistant"))
+		self.assertFalse(any(m["role"] == "tool" for m in history.messages))
+
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
## Finding

**H2** — truncation/compaction splits `tool_call`↔`tool_result` pairs, producing a leading orphan `tool` message that Anthropic/OpenAI reject with a 400 ("tool_result without matching tool_use"), which kills long AI sessions.

## Root cause

`max_tokens_total` defaults to 100000 (>0), so `ChatHistory.to_messages()` runs litellm `trim_messages` every iteration. litellm drops the OLDEST messages with **no tool-pairing awareness**, so the kept window can START with a `tool` (tool_result) message whose preceding `assistant(tool_calls)` was dropped → a **leading orphan tool message**. `ChatHistory.compact()`'s blind `keep_last=N` tail cut has the same defect (the kept tail can begin on a `tool` whose parent fell into the summarized half). The existing `_repair_orphan_tool_uses` only fixed the FORWARD case (assistant tool_calls missing a result), never a leading orphan tool.

## Fix

- Added `_strip_leading_orphan_tools()` in `secator/ai/utils.py`: preserves system messages, then drops the run of leading `tool` messages that have no parent in the window.
- Extended `_repair_orphan_tool_uses()` to call it first, so the existing `call_llm` safety-net/retry path also repairs leading orphans (count is included in the return value).
- `ChatHistory.trim()` (history.py) now strips leading orphan tools after `trim_messages`.
- `ChatHistory.compact()` strips leading orphan tools from the kept tail (`to_keep`) before rebuilding, so the rebuilt window never begins on an orphan tool_result. System prompt and tool_call_id↔tool pairing are preserved.

## Validation

- `python3 -m py_compile secator/ai/history.py secator/ai/utils.py` — OK.
- `pytest tests/unit/test_ai_tokens.py -q` → 19 passed, 1 failed. The single failure (`test_loop_sums_token_usage`, 100 vs 600) is **pre-existing on base** (`ai-resiliency`), unrelated to this change.
- Added `TestAiToolPairTrim` (4 focused tests): the helper keeps system + drops leading tools; `_repair_orphan_tool_uses` repairs a leading orphan; `trim()` and `compact()` each, given a history that would otherwise leave a leading `tool`, repair so the first non-system message is a valid `user`/`assistant`.

## Extra issues surfaced

None directly observed beyond H2. Note (not fixed here): the pre-existing `test_loop_sums_token_usage` failure on base suggests the end-to-end loop token-accounting (multi-turn summation) may have regressed independently — worth a separate look, but out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNjPggRSVZ2xnLb7ZxWP5H