### PR TITLE
fix(ai): close the answer/timeout race and stop stale pending docs accumulating (M10)

### DIFF
--- a/secator/ai/interactivity.py
+++ b/secator/ai/interactivity.py
@@ -115,6 +115,10 @@ class RemoteBackend(InteractivityBackend):
 		prompt_uuid = context.get("prompt_uuid")
 		if prompt_uuid:
 			extra_data["prompt_uuid"] = prompt_uuid
+		# A new prompt for this session supersedes any older still-pending one
+		# (e.g. a worker that died mid-poll). Expire them BEFORE this doc is
+		# persisted so only the current prompt stays live (M10).
+		self._expire_stale_pending(session_id)
 		return Ai(
 			content=question,
 			ai_type=prompt_type,
@@ -157,22 +161,65 @@ class RemoteBackend(InteractivityBackend):
 		if prompt_uuid:
 			base["extra_data.prompt_uuid"] = prompt_uuid
 
+		answered_query = {**base, "status": "answered"}
 		elapsed = 0
 		while elapsed < self.timeout:
-			results = self.query_engine.search({**base, "status": "answered"})
-			if results:
-				# resolve against the newest answered doc as a backstop against stale answers
-				newest = max(results, key=lambda r: r.get("_timestamp", 0))
-				return newest.get("answer")
+			answer = self._resolve_answer(answered_query)
+			if answer is not None:
+				return answer
 			sleep(self.poll_interval)
 			elapsed += self.poll_interval
-		# Timeout: flip ONLY this prompt's still-pending doc to timed_out, so a
+		# One final search before giving up: the user may have answered during
+		# the last sleep (or between the last search and now). Without this the
+		# answer is silently stranded (M10).
+		answer = self._resolve_answer(answered_query)
+		if answer is not None:
+			return answer
+		# Timeout: atomically flip ONLY a doc that is STILL pending, so a
 		# concurrent/older pending doc for the same session isn't disturbed.
-		self.query_engine.update(
+		# If the answer landed in the race window the doc is already 'answered'
+		# and this no-ops (modified == 0) — re-read rather than abandon it (M10).
+		modified = self.query_engine.update(
 			{**base, "status": "pending"},
 			{"$set": {"status": "timed_out"}}
 		)
+		if not modified:
+			answer = self._resolve_answer(answered_query)
+			if answer is not None:
+				return answer
 		return None
+
+	def _resolve_answer(self, answered_query):
+		"""Return the newest answered doc's answer, or None if none answered.
+
+		Resolving against the newest by ``_timestamp`` is a backstop against
+		stale answers.
+		"""
+		results = self.query_engine.search(answered_query)
+		if not results:
+			return None
+		newest = max(results, key=lambda r: r.get("_timestamp", 0))
+		return newest.get("answer")
+
+	def _expire_stale_pending(self, session_id):
+		"""Mark any older still-pending prompt for this session as timed_out.
+
+		Called when a NEW prompt starts (before it is persisted), so it only
+		affects prior prompts. Stops stale 'pending' docs from accumulating —
+		a worker that dies mid-poll otherwise leaves the UI 'thinking' forever
+		and lets crud.answer_ai_prompt's "latest pending" collide (M10).
+		FLAG: a DB-layer TTL index on pending Ai docs is the durable follow-up.
+		"""
+		if not self.query_engine:
+			return
+		self.query_engine.update(
+			{
+				"_type": "ai",
+				"_context.session_id": session_id,
+				"status": "pending",
+			},
+			{"$set": {"status": "timed_out"}},
+		)
 
 	@staticmethod
 	def _add_permission_rules(engine, ptype, value):

--- a/tests/unit/test_ai_interactivity.py
+++ b/tests/unit/test_ai_interactivity.py
@@ -219,6 +219,71 @@ class TestRemoteBackend(unittest.TestCase):
 		self.assertEqual(result["answer"], "option B")
 		self.assertEqual(mock_sleep.call_count, 1)
 
+	@patch('secator.ai.interactivity.sleep')
+	def test_answer_in_final_window_is_not_lost_to_timeout(self, mock_sleep):
+		"""M10: an answer landing in the last sleep window is returned, not lost.
+
+		The poll loop sees only 'pending' until the loop exits, then the answer
+		appears. The final post-loop search must pick it up rather than abandon
+		the turn.
+		"""
+		from secator.ai.interactivity import RemoteBackend
+		answered_doc = [{"answer": "landed late", "_timestamp": 100.0}]
+
+		def fake_search(query, *args, **kwargs):
+			# Answer only becomes visible AFTER the single poll iteration.
+			return list(answered_doc) if mock_sleep.call_count >= 1 else []
+
+		mock_engine = MagicMock()
+		mock_engine.search.side_effect = fake_search
+		mock_engine.update.return_value = 0
+		backend = RemoteBackend(timeout=5, query_engine=mock_engine, poll_interval=5)
+
+		result = backend.ask_user("What next?", [], "session1", prompt_uuid="abc-123")
+
+		self.assertIsNotNone(result)
+		self.assertEqual(result["answer"], "landed late")
+
+	@patch('secator.ai.interactivity.sleep')
+	def test_timeout_noop_flip_rereads_answer(self, mock_sleep):
+		"""M10: if the timeout flip modifies 0 rows, re-read the answer."""
+		from secator.ai.interactivity import RemoteBackend
+		# Empty during the loop AND at the first final search, then the answer
+		# appears right as we attempt the (no-op) flip.
+		searches = [[], [], [{"answer": "raced in", "_timestamp": 1.0}]]
+		mock_engine = MagicMock()
+		mock_engine.search.side_effect = lambda *a, **k: searches.pop(0) if searches else []
+		mock_engine.update.return_value = 0  # nothing pending -> already answered
+		backend = RemoteBackend(timeout=5, query_engine=mock_engine, poll_interval=5)
+
+		result = backend._poll_for_answer("session1", "permission", prompt_uuid="abc-123")
+		self.assertEqual(result, "raced in")
+
+	def test_build_pending_prompt_expires_prior_pending(self):
+		"""M10: starting a new prompt marks prior still-pending docs stale."""
+		from secator.ai.interactivity import RemoteBackend
+		mock_engine = MagicMock()
+		backend = RemoteBackend(timeout=60, query_engine=mock_engine)
+
+		backend.build_pending_prompt(
+			"Target x requires approval", ["allow", "deny"], "session1",
+			prompt_type="permission", permission_type="target", value="x",
+			prompt_uuid="uuid-new",
+		)
+
+		# An update flipping this session's pending docs to timed_out must fire.
+		mock_engine.update.assert_called_once()
+		flip_query, flip_update = mock_engine.update.call_args[0]
+		self.assertEqual(flip_query.get("_context.session_id"), "session1")
+		self.assertEqual(flip_query.get("status"), "pending")
+		self.assertEqual(flip_update, {"$set": {"status": "timed_out"}})
+
+	def test_expire_stale_pending_noop_without_engine(self):
+		"""No query engine -> no crash, no update."""
+		from secator.ai.interactivity import RemoteBackend
+		backend = RemoteBackend(timeout=60, query_engine=None)
+		backend._expire_stale_pending("session1")  # must not raise
+
 
 class TestCreateBackend(unittest.TestCase):
 	"""Verify create_backend factory."""


### PR DESCRIPTION
## Finding

**M10 — channel hygiene** in `RemoteBackend` (`secator/ai/interactivity.py`). Two self-contained robustness bugs in the remote AI prompt poll/timeout path.

## Root cause

1. **Timeout race strands a just-submitted answer.** `_poll_for_answer` exited the loop on `elapsed >= timeout` with NO final search, then flipped `{...status:"pending"} -> "timed_out"`. If the user answered during the last `sleep` (or between the last search and the flip), the doc was already `answered`; the pending->timed_out update no-op'd but the worker still returned `None` and abandoned the turn — the answer was silently lost.
2. **Stale `pending` docs accumulate.** A worker that dies mid-poll leaves a `pending` doc forever (UI shows perpetual "thinking"), and `crud.answer_ai_prompt`'s "latest pending" can collide with stale pendings.

## Fix

- **Answer/timeout race:** added one final scoped `status:"answered"` search after the loop before giving up. The timeout flip was already filtered on `status:"pending"` (atomic in Mongo); now we capture its modified-count and, when it no-ops (0 rows -> the doc is already `answered`), re-read the answer instead of returning `None`. Factored the newest-by-`_timestamp` resolution into `_resolve_answer`.
- **Stale pendings:** `build_pending_prompt` now calls `_expire_stale_pending(session_id)` before the new doc is persisted, flipping any older still-`pending` doc for that session to `timed_out`. Sequential layers stay safe (each prior layer is already `answered` before the next prompt is built), and the new doc isn't in the DB yet so it can't self-clobber. Guards on a missing `query_engine`.
- `prompt_uuid` scoping (H7) is preserved throughout.

**FLAG (follow-up, NOT done here):** a DB-layer TTL index on pending `Ai` docs is the durable reaper — belongs to the DB layer, out of scope for this in-file fix. Noted inline in `_expire_stale_pending`.

## Validation

- `python3 -m py_compile secator/ai/interactivity.py` — OK
- `pytest tests/unit/test_ai_interactivity.py -q` — **26 passed**
- Added focused tests: (a) an answer landing in the final window is returned, not lost to timeout; (b) a no-op timeout flip re-reads the raced-in answer; (c) starting a new prompt marks prior still-pending docs stale; (d) `_expire_stale_pending` no-ops without an engine.

## Extra issues surfaced

None observed in the owned file beyond M10. (No C3/H3/H5 evidence in `interactivity.py`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNjPggRSVZ2xnLb7ZxWP5H