### PR TITLE
fix(ai): default-safe target/path guardrail dimensions (M6)

### DIFF
--- a/secator/ai/guardrails.py
+++ b/secator/ai/guardrails.py
@@ -611,9 +611,10 @@ class PermissionEngine:
 		if result.decision in ("deny", "ask"):
 			return result
 
-		# Step 2: Check targets (only if target rules are configured)
+		# Step 2: Check targets. M6: always enforce when targets exist — a missing
+		# catch-all must fall to ask (via _check_values "No rule"), never default-allow.
 		targets_to_check = self._extract_targets(action)
-		if targets_to_check and self._has_rules_for("target"):
+		if targets_to_check:
 			target_result = self._check_values("target", targets_to_check)
 			if target_result.decision == "deny":
 				return target_result
@@ -628,7 +629,7 @@ class PermissionEngine:
 		if action_type == "shell":
 			command = action.get("command", "")
 			paths_with_access = detect_paths_with_access(command)
-			if paths_with_access and (self._has_rules_for("read") or self._has_rules_for("write")):
+			if paths_with_access:  # M6: always enforce — no read/write rule must ask, not allow
 				# Check each path with its correct access type
 				ask_paths = []
 				for path, access in paths_with_access:
@@ -669,14 +670,6 @@ class PermissionEngine:
 			return result
 
 		return PermissionResult(decision="deny", reason=f"No matching rule for {action_type}")
-
-	def _has_rules_for(self, rule_type: str) -> bool:
-		"""Check if any rules exist for the given rule type."""
-		for category in ("allow", "deny", "ask"):
-			for rt, _ in self.rules[category]:
-				if rt == rule_type:
-					return True
-		return any(rt == rule_type for rt, _ in self.runtime_allow)
 
 	def _check_action_type(self, action_type: str, action: Dict) -> PermissionResult:
 		"""Check if the action type is allowed/denied/ask.

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -239,6 +239,13 @@ class TestPermissionEngine(unittest.TestCase):
 		self.assertEqual(result.decision, "ask")
 		self.assertIn("10.5.2.3", result.targets)
 
+	def test_target_no_catchall_asks_not_allows(self):
+		"""M6: with no target rule/catch-all configured, an unknown target must ask (fail-safe), not silently allow."""
+		engine = self._make_engine(allow=["task(*)"])  # no target(...) rule in any category
+		result = engine.check_action({"action": "task", "name": "nmap", "targets": ["10.5.2.3"]})
+		self.assertEqual(result.decision, "ask")
+		self.assertIn("10.5.2.3", result.targets)
+
 	def test_task_target_validation(self):
 		engine = self._make_engine(
 			allow=["task(*)", "target({targets})"],


### PR DESCRIPTION
## Finding — M6: Target/path enforcement is opt-in (default-allow)

Severity High-ish / P1 (Security). In the AI guardrail `PermissionEngine`, some
enforcement dimensions (target, read/write path) only took effect when a rule
for that dimension was configured. Removing a catch-all config line
(e.g. `ask: target(*)`) flipped that dimension to **default-allow** — the check
was skipped and the action silently fell through to ALLOW instead of ask/deny.
This is fail-open.

## Root cause

`secator/ai/guardrails.py`, `PermissionEngine.check_action`:

- Step 2 (targets): `if targets_to_check and self._has_rules_for("target")` — the
  `_has_rules_for` gate skipped the entire target check when no target rule
  existed, so unknown targets were allowed.
- Step 3 (paths): `if paths_with_access and (self._has_rules_for("read") or
  self._has_rules_for("write"))` — same fail-open for read/write paths.

Confirmed against the code: with `allow=["task(*)"]` and no `target(...)` rule,
`check_action({"action":"task","name":"nmap","targets":["10.5.2.3"]})` returned
`allow` before this change.

## Fix

Drop both `_has_rules_for` gates so a dimension is always evaluated when there
are values to check. When no rule matches, the existing `_check_value` returns a
`"No rule for ..."` result which `check_action` / `_check_values` already resolve
to **`ask`** (the established fail-safe default in this file) — so the fix reuses
the existing decision model rather than introducing a new one. Behavior is
unchanged when the catch-all IS present (the gate was already True then). The
now-unused `_has_rules_for` helper is removed. Net diff: +11 / -11.

## Tests

Added `test_target_no_catchall_asks_not_allows` proving an unknown target now
**asks** (not allows) when no target catch-all is configured. It uses a `task`
action so it does not depend on the `shfmt`/`safecmd` shell parser (absent
locally).

Baseline vs after (`tests/unit/test_ai_guardrails.py`, venv):
- Before: **55 failed, 74 passed**
- After:  **55 failed, 75 passed** (+1 = the new test)
- The 55 failures are pre-existing/environmental (missing `shfmt` → `safecmd`
  parse failures in `TestEdgeCases`), identical set before and after — verified
  by diffing the failing-test names. No regression.

Note: the path-dimension fix is the same mechanism; it cannot be exercised by a
passing local test because path detection also needs `shfmt`, which short-circuits
shell actions to `ask` at step 1 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)