### PR TITLE
fix(ai): token-count fallback when LLM usage missing (M5)

### DIFF
--- a/secator/ai/utils.py
+++ b/secator/ai/utils.py
@@ -224,6 +224,41 @@ def init_llm(api_key: Optional[str] = None):
 	_llm_initialized = True
 
 
+def _estimate_usage(model: str, messages: List[Dict], content: str, tool_calls) -> Dict:
+	"""M5: estimate tokens when the provider omits `usage`, so calls are never unmetered.
+
+	Uses litellm's own token counter for the model in use — prompt tokens from the
+	request messages, completion tokens from the response text (+ any tool-call
+	name/arguments). Returns the same shape as the real-usage dict (cost unknown).
+	"""
+	import litellm
+
+	def _count(**kw):
+		try:
+			return litellm.token_counter(model=model, **kw) or 0
+		except Exception:
+			return 0
+
+	prompt_tokens = _count(messages=messages)
+	completion_text = content or ""
+	for tc in tool_calls or []:
+		fn = tc.get("function", {}) if isinstance(tc, dict) else getattr(tc, "function", None)
+		if isinstance(fn, dict):
+			name, args = fn.get("name", ""), fn.get("arguments", "")
+		elif fn is not None:
+			name, args = getattr(fn, "name", ""), getattr(fn, "arguments", "")
+		else:
+			name, args = "", ""
+		completion_text += f" {name} {args}"
+	completion_tokens = _count(text=completion_text)
+	return {
+		"tokens": prompt_tokens + completion_tokens,
+		"prompt_tokens": prompt_tokens,
+		"completion_tokens": completion_tokens,
+		"cost": None,
+	}
+
+
 def call_llm(
 	messages: List[Dict],
 	model: str,
@@ -311,6 +346,12 @@ def call_llm(
 			"completion_tokens": getattr(response.usage, "completion_tokens", None),
 			"cost": cost,
 		}
+	else:
+		# M5: usage missing/empty (streaming, some models) — estimate so the call
+		# is still metered instead of silently counting 0 tokens.
+		usage = _estimate_usage(model, kwargs["messages"], content, getattr(message, 'tool_calls', None))
+		console.print(Warning(
+			message=f"LLM response missing usage; estimated ~{usage['tokens']} tokens for metering."))
 
 	# Get tool calls
 	tool_calls = getattr(message, 'tool_calls', None) or []

--- a/tests/unit/test_ai_utils.py
+++ b/tests/unit/test_ai_utils.py
@@ -82,15 +82,18 @@ class TestCallLLM(unittest.TestCase):
         self.assertEqual(result["tool_calls"], [])
         mock_completion.assert_called_once()
 
+    @patch('litellm.token_counter')
     @patch('litellm.completion')
-    def test_call_llm_no_usage(self, mock_completion):
-        """Response without usage data."""
+    def test_call_llm_no_usage_estimates_tokens(self, mock_completion, mock_token_counter):
+        """M5: response without usage still yields a non-zero estimated token count."""
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Response"
         mock_response.choices[0].message.tool_calls = None
         mock_response.usage = None
         mock_completion.return_value = mock_response
+        # prompt (messages=...) then completion (text=...)
+        mock_token_counter.side_effect = [42, 8]
 
         from secator.ai.utils import call_llm
         result = call_llm(
@@ -99,7 +102,11 @@ class TestCallLLM(unittest.TestCase):
         )
 
         self.assertEqual(result["content"], "Response")
-        self.assertIsNone(result["usage"])
+        self.assertIsNotNone(result["usage"])
+        self.assertEqual(result["usage"]["tokens"], 50)
+        self.assertEqual(result["usage"]["prompt_tokens"], 42)
+        self.assertEqual(result["usage"]["completion_tokens"], 8)
+        self.assertIsNone(result["usage"]["cost"])
         self.assertEqual(result["tool_calls"], [])
 
     @patch('litellm.completion')


### PR DESCRIPTION
## Finding — M5: Silent under-billing when \`usage\` absent (Medium / P2)

\`call_llm\` in \`secator/ai/utils.py\` read \`response.usage\` only when present:

\`\`\`python
if hasattr(response, 'usage') and response.usage:
    ... response.usage.total_tokens ...
\`\`\`

If a provider/response omits \`usage\` (streaming, some models, error paths), the
whole token-accounting block was skipped, \`usage\` stayed \`None\`, and downstream
metering (the \`tokens\`/\`cost\` in \`tasks/ai.py\`) counted **0** — the LLM call was
effectively free/unmetered, defeating billing and the token-quota guardrails.

## The gap
\`secator/ai/utils.py:302\` (pre-fix line) — happy path only; no fallback branch.

## Fix
- New \`else\` branch (happy path byte-for-byte unchanged): when \`response.usage\`
  is missing/empty, estimate tokens and populate the same \`usage\` dict shape.
- Estimation uses **\`litellm.token_counter\`** (litellm 1.83.7, already used in
  \`secator/ai/history.py\`) — prompt tokens from the request \`messages\`, completion
  tokens from the response text (+ tool-call name/arguments). Failures degrade to 0
  rather than raising.
- Emits a \`Warning\` (\`console.print(Warning(...))\`, matching the existing pattern)
  noting usage was estimated, so it's observable; the call never fails.
- Small local helper \`_estimate_usage(...)\` (DRY) — no signature changes to callers.

## Tests
- \`tests/unit/test_ai_utils.py\`: **baseline 20 passed → after 20 passed**. The old
  \`test_call_llm_no_usage\` (asserted \`usage is None\`) is replaced by
  \`test_call_llm_no_usage_estimates_tokens\`, which mocks \`litellm.token_counter\`
  and asserts a non-zero estimated token count (prompt+completion) with \`cost=None\`.
- \`test_ai_loop.py\` has 9 pre-existing, environmental failures (shfmt/safecmd
  parser missing on PATH — "shell command not approved"); identical before/after,
  not caused by this change.

## Extra findings (flagged, NOT fixed here)
- **M4** \`secator/ai/utils.py:302\` — \`litellm.BadRequestError\` is in the
  \`retryable\` tuple, so non-transient 400s get retried 3×. (Next Lane C item.)
- **M3** \`secator/tasks/ai.py:58-59,366\` + \`secator/ai/history.py:194-216\` —
  flat \`max_tokens_total\` trim ignores the model's actual context window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)