### PR TITLE
fix(ai): cap subagent recursion depth & per-turn fan-out (H4)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -2,6 +2,7 @@
 import json
 import os
 import subprocess
+import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, fields
@@ -34,6 +35,7 @@ class ActionContext:
 	scope: str = "workspace"
 	results: Optional[List[Dict]] = None
 	max_workers: int = 3
+	in_batch: bool = False  # H4: set on the per-batch ctx so the per-turn fan-out cap applies
 	subagent: bool = False
 	silent: bool = False
 	sync: bool = True
@@ -411,6 +413,42 @@ _FORBIDDEN_CHILD_OPT_KEYS = frozenset({
 # Cap a spawned subagent's iteration budget so it can't be told to loop unbounded.
 _MAX_CHILD_ITERATIONS = 25
 
+# H4: bound recursive AI-subagent fan-out so injected output can't drive an
+# exponential subagent/token blow-up. Depth caps recursion (child inherits +1 via
+# context); breadth caps how many subagents one parent turn may spawn.
+_MAX_SUBAGENT_DEPTH = 3
+_MAX_SUBAGENTS_PER_TURN = 5
+_SUBAGENT_TURN_LOCK = threading.Lock()
+
+
+def _guard_subagent_fanout(ctx: "ActionContext", context: Dict) -> Optional["Warning"]:
+	"""H4: cap AI-subagent recursion depth + per-turn fan-out.
+
+	Returns a denial ``Warning`` if a cap is hit (caller yields it and skips the
+	spawn); otherwise stamps the child's depth (+1) into ``context`` and bumps the
+	per-turn counter. Breadth is only counted within a batch (one LLM turn); a
+	lone spawn is inherently breadth-1.
+	"""
+	depth = int(ctx.context.get("ai_subagent_depth", 0) or 0)
+	if depth >= _MAX_SUBAGENT_DEPTH:
+		return Warning(
+			message=f"Subagent spawn denied: recursion depth cap ({_MAX_SUBAGENT_DEPTH}) reached",
+			_context=context,
+		)
+	if ctx.in_batch:  # per-turn breadth only bites within a batch
+		with _SUBAGENT_TURN_LOCK:
+			turn = int(ctx.context.get("ai_subagent_turn_count", 0) or 0)
+			over_breadth = turn >= _MAX_SUBAGENTS_PER_TURN
+			if not over_breadth:
+				ctx.context["ai_subagent_turn_count"] = turn + 1
+		if over_breadth:
+			return Warning(
+				message=f"Subagent spawn denied: per-turn fan-out cap ({_MAX_SUBAGENTS_PER_TURN}) reached",
+				_context=context,
+			)
+	context["ai_subagent_depth"] = depth + 1  # child inherits depth+1
+	return None
+
 
 def _sanitize_child_opts(opts: Any) -> Dict:
 	"""Drop LLM-settable control/security keys from sub-runner opts; clamp max_iterations."""
@@ -449,6 +487,11 @@ def _run_runner(action: Dict, ctx: ActionContext, runner_type: str) -> Generator
 
 	# Force subagent flags when spawning an AI task from a parent AI task
 	if runner_type == "task" and name.lower() == "ai":
+		# H4: bound recursive fan-out before constructing/running the child
+		denial = _guard_subagent_fanout(ctx, context)
+		if denial is not None:
+			yield denial
+			return
 		opts["subagent"] = True
 		opts["interactive"] = False
 
@@ -907,8 +950,11 @@ def _run_batch(actions: List[Dict], ctx: ActionContext) -> Generator:
 
 	max_workers = ctx.max_workers or 3
 
+	# H4: fresh per-turn subagent fan-out budget for this batch (one LLM turn)
+	ctx.context["ai_subagent_turn_count"] = 0
+
 	# Silence console output for parallel tasks to avoid interleaved printing
-	batch_ctx = replace(ctx, silent=True)
+	batch_ctx = replace(ctx, silent=True, in_batch=True)
 
 	# Skip Rich progress panel when we are a subagent, or when the batch
 	# contains an AI subagent task (its output conflicts with the Live display)

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -11,7 +11,7 @@ if ADDONS_ENABLED['ai']:
 		ActionContext, dispatch_action, _handle_follow_up, _handle_shell,
 		_handle_query, _handle_add_finding, _run_runner, _decrypt_dict,
 		_build_hooks_from_context, _coerce_finding_fields, _sanitize_child_opts,
-		_MAX_CHILD_ITERATIONS
+		_MAX_CHILD_ITERATIONS, _MAX_SUBAGENT_DEPTH, _MAX_SUBAGENTS_PER_TURN,
 	)
 	from secator.output_types import Ai, Error, Info, Warning, Vulnerability, Url
 
@@ -1001,6 +1001,74 @@ class TestCheckGuardrailsFailClosed(unittest.TestCase):
 		denial, _items = check_guardrails_sync({"action": "shell", "command": "x"}, ctx)
 		self.assertIsNotNone(denial, "exhausted-but-unresolved guardrail must deny, not return None")
 		self.assertIn("unresolved", denial)
+
+
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestSubagentFanoutCap(unittest.TestCase):
+	"""H4: recursion depth + per-turn fan-out caps on AI-subagent spawns."""
+
+	def _mock_task(self, mock_task_cls):
+		runner = MagicMock()
+		runner.id = 'runner123'
+		runner.reports_folder = None
+		runner.__iter__.return_value = iter([])
+		mock_task_cls.return_value = runner
+		return runner
+
+	def test_depth_cap_refuses_spawn(self):
+		"""Spawning an AI subagent at/over _MAX_SUBAGENT_DEPTH is denied."""
+		ctx = ActionContext(
+			targets=['t.com'], model='m',
+			context={'ai_subagent_depth': _MAX_SUBAGENT_DEPTH},
+		)
+		action = {'action': 'task', 'name': 'ai', 'targets': ['t.com']}
+
+		with patch('secator.ai.actions.Task') as mock_task_cls:
+			results = list(_run_runner(action, ctx, 'task'))
+
+		mock_task_cls.assert_not_called()  # denied before constructing the child
+		self.assertEqual(len(results), 1)
+		self.assertIsInstance(results[0], Warning)
+		self.assertIn('depth cap', results[0].message)
+		# no Ai task item emitted (spawn refused)
+		self.assertFalse([r for r in results if isinstance(r, Ai) and r.ai_type == 'task'])
+
+	def test_per_turn_breadth_cap_refuses_spawn(self):
+		"""In a batch, spawning past _MAX_SUBAGENTS_PER_TURN is denied."""
+		ctx = ActionContext(
+			targets=['t.com'], model='m', in_batch=True,
+			context={'ai_subagent_turn_count': _MAX_SUBAGENTS_PER_TURN},
+		)
+		action = {'action': 'task', 'name': 'ai', 'targets': ['t.com']}
+
+		with patch('secator.ai.actions.Task') as mock_task_cls:
+			results = list(_run_runner(action, ctx, 'task'))
+
+		mock_task_cls.assert_not_called()
+		self.assertEqual(len(results), 1)
+		self.assertIsInstance(results[0], Warning)
+		self.assertIn('fan-out cap', results[0].message)
+
+	@patch('secator.ai.actions.TemplateLoader')
+	@patch('secator.ai.actions.Task')
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_normal_depth1_spawn_succeeds(self, mock_build_hooks, mock_task_cls, _mock_tpl):
+		"""A first-level AI subagent (depth 0 -> 1) still spawns; child inherits depth+1."""
+		mock_build_hooks.return_value = {}
+		self._mock_task(mock_task_cls)
+
+		ctx = ActionContext(targets=['t.com'], model='m', context={})  # depth 0, not in a batch
+		action = {'action': 'task', 'name': 'ai', 'targets': ['t.com']}
+
+		results = list(_run_runner(action, ctx, 'task'))
+
+		mock_task_cls.assert_called_once()
+		ai_items = [r for r in results if isinstance(r, Ai) and r.ai_type == 'task']
+		self.assertEqual(len(ai_items), 1)
+		self.assertFalse([r for r in results if isinstance(r, Warning)])
+		# child context carries incremented depth
+		_, kwargs = mock_task_cls.call_args
+		self.assertEqual(kwargs.get('context', {}).get('ai_subagent_depth'), 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Finding — H4: Unbounded recursive subagent fan-out (High / P1)

The AI task spawns child runners in-process (`_run_runner`). An AI child can itself spawn more AI children, with **no recursion depth cap, no per-turn breadth cap, and no cycle guard**. Malicious/injected tool output can therefore drive exponential subagent/token blow-up until the 3h Job deadline, burning tokens.

## Where context flows to the child

`_run_runner` builds `context = _get_result_context(action, ctx)` (`secator/ai/actions.py:486`) — a fresh copy of `ctx.context` — and passes it straight into the child: `runner_cls(tpl, targets, run_opts=run_opts, hooks=hooks, context=context)` (`secator/ai/actions.py:550`). A spawned AI child's `_run_loop` reads that dict back as `ctx.context`, so the recursion state rides through `context`.

## Fix — two caps, reusing the C1 guard region/style

New `_guard_subagent_fanout(ctx, context)` next to the existing `_sanitize_child_opts` / `_MAX_CHILD_ITERATIONS` guards, called only on the AI-subagent spawn path (`runner_type == "task" and name.lower() == "ai"`) so normal multi-tool batches are unaffected:

- **Depth cap** — `_MAX_SUBAGENT_DEPTH = 3`. Read `context['ai_subagent_depth']` (0 if unset); refuse at/over the cap; otherwise stamp the child's copy with `depth + 1` so it inherits the level.
- **Per-turn breadth cap** — `_MAX_SUBAGENTS_PER_TURN = 5`, counted in `context['ai_subagent_turn_count']`, reset to 0 at the top of `_run_batch` (one LLM turn) and only enforced when `ctx.in_batch` (a lone spawn is inherently breadth-1). Increment is guarded by a `threading.Lock` since a batch runs subagents concurrently. New `ActionContext.in_batch` flag set on the per-batch `ctx`.

## Denial shape reused

On a cap hit the guard returns a denial `Warning(message=..., _context=context)`; `_run_runner` yields it and `return`s (no spawn), matching how guardrail denials are surfaced — the `Warning` is collected and fed back to the LLM as that tool call's result. No unhandled exception, so the parent turn never crashes.

## Tests

Baseline `tests/unit/test_ai_actions.py`: **61 passed**. After: **64 passed** (+3). New `TestSubagentFanoutCap`: depth-cap refusal, per-turn breadth-cap refusal, and a normal depth-0→1 spawn still succeeding (child context carries `ai_subagent_depth == 1`).

## Extra findings (not fixed here)

- **Token/quota accounting is not inherited by children.** A spawned AI child gets its own `_run_loop` token counters (`self.context['ai_tokens']` etc.); the parent does not aggregate a child's spend, so caps bound *fan-out* but not total cross-tree token cost.
- **Sibling context aliasing in batches.** Within `_run_batch`, all concurrent `run_single` calls share the same `ctx.context` dict object (via `replace`, shallow copy); `_run_runner` copies it per child, but the shared per-turn counter is mutated concurrently (handled here with a lock — flagging the broader aliasing pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)