### PR TITLE
fix(ai): cover plain-chat & max-iter remote turns with pending docs (H5)

### DIFF
--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -461,6 +461,14 @@ class ai(PythonRunner):
 					# only happen once). Nothing to re-yield here — the frontend reads the
 					# persisted doc.
 
+					# H5: remote max-iter after tool work is a terminal turn (no further
+					# user input expected) — don't block-poll on prompt_uuid=None with no
+					# answerable pending doc; end cleanly via the loop tail (save + Info).
+					if (isinstance(self.backend, RemoteBackend)
+							and iteration == self.max_iterations
+							and follow_up_choices is None and tool_calls):
+						break
+
 					result = self._prompt_and_redetect(follow_up_choices or [], prompt_uuid=follow_up_prompt_uuid)
 					if result is None:
 						self._save_history()
@@ -1026,6 +1034,19 @@ class ai(PythonRunner):
 
 		Returns list of items to yield, or None to exit.
 		"""
+		# H5: plain-chat remote turns reach here with no pre-persisted pending doc
+		# (unlike the guardrail/follow-up path). Persist one now with a real
+		# prompt_uuid so the frontend can render/answer it and the poll matches only
+		# this prompt — never poll on prompt_uuid=None.
+		if isinstance(self.backend, RemoteBackend) and not prompt_uuid:
+			prompt_uuid = str(uuid.uuid4())
+			self.add_result(self.backend.build_pending_prompt(
+				question="What's next?",
+				choices=choices,
+				session_id=self.session_id,
+				prompt_type="follow_up",
+				prompt_uuid=prompt_uuid,
+			))
 		response = self.backend.ask_user(
 			question="What's next?",
 			choices=choices,

--- a/tests/unit/test_ai_interactivity.py
+++ b/tests/unit/test_ai_interactivity.py
@@ -2,6 +2,9 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from secator.definitions import ADDONS_ENABLED
+HAS_AI = ADDONS_ENABLED.get('ai', False)
+
 
 class TestInteractivityBackendBase(unittest.TestCase):
 	"""Verify base class interface."""
@@ -307,6 +310,169 @@ class TestCreateBackend(unittest.TestCase):
 		from secator.ai.interactivity import create_backend, AutoBackend
 		backend = create_backend("unknown")
 		self.assertIsInstance(backend, AutoBackend)
+
+
+@unittest.skipUnless(HAS_AI, "ai addon required")
+class TestRemoteTurnPendingDocCoverage(unittest.TestCase):
+	"""H5: common remote turns (plain-chat reply, max-iter exit) must not poll on
+	prompt_uuid=None. Plain-chat must persist a proper pending doc and poll on its
+	real uuid; the max-iter terminal path must not strand a dangling pending doc."""
+
+	class _FakeHistory:
+		def add_user(self, *a, **k):
+			pass
+
+		def count_tokens_by_role(self, model=None):
+			return {"total": 0}
+
+		def to_messages(self, *a, **k):
+			return []
+
+	def test_plain_chat_remote_persists_pending_doc_and_polls_on_uuid(self):
+		"""A plain-chat remote turn persists a pending follow_up doc with a
+		non-None prompt_uuid and polls scoped to THAT uuid (never None)."""
+		from secator.tasks.ai import ai as AiTask
+		from secator.ai.interactivity import RemoteBackend
+		from secator.output_types import Ai
+
+		mock_engine = MagicMock()
+		mock_engine.search.return_value = [{"answer": "keep going", "_timestamp": 1.0}]
+		backend = RemoteBackend(timeout=60, query_engine=mock_engine, poll_interval=0.01)
+
+		persisted = []
+		fake_self = MagicMock()
+		fake_self.backend = backend
+		fake_self.session_id = "sess-chat"
+		fake_self.model = "gpt-4o"
+		fake_self.mode = "chat"
+		fake_self.encryptor = None
+		fake_self.max_iterations = 10
+		fake_self.history = self._FakeHistory()
+		fake_self.add_result = lambda item, **kw: persisted.append(item)
+
+		# plain-chat turn: no prompt_uuid passed in (this is the H5 path)
+		items = AiTask._prompt_and_redetect(fake_self, [])
+
+		pend = [p for p in persisted if isinstance(p, Ai) and p.status == "pending"]
+		self.assertEqual(len(pend), 1, "exactly one pending doc must be persisted")
+		uuid_stamped = (pend[0].extra_data or {}).get("prompt_uuid")
+		self.assertTrue(uuid_stamped, "pending doc must carry a real (non-None) prompt_uuid")
+		self.assertEqual(pend[0].ai_type, "follow_up")
+
+		# the poll must be scoped to THAT prompt's uuid — never None
+		search_query = mock_engine.search.call_args[0][0]
+		self.assertEqual(search_query.get("extra_data.prompt_uuid"), uuid_stamped)
+		# the answer resolved, so the loop continues (non-None items) rather than exiting
+		self.assertIsNotNone(items)
+
+	def test_local_plain_chat_does_not_persist_pending_doc(self):
+		"""Local (CLI) plain-chat must NOT create a pending doc — that is a
+		remote-channel concern only."""
+		from secator.tasks.ai import ai as AiTask
+		from secator.ai.interactivity import CLIBackend
+		from secator.output_types import Ai
+
+		backend = MagicMock(spec=CLIBackend)
+		backend.ask_user.return_value = {"answer": "do x"}
+
+		persisted = []
+		fake_self = MagicMock()
+		fake_self.backend = backend
+		fake_self.session_id = "sess-local"
+		fake_self.model = "gpt-4o"
+		fake_self.mode = "chat"
+		fake_self.encryptor = None
+		fake_self.max_iterations = 10
+		fake_self.history = self._FakeHistory()
+		fake_self.add_result = lambda item, **kw: persisted.append(item)
+
+		AiTask._prompt_and_redetect(fake_self, [])
+
+		pend = [p for p in persisted if isinstance(p, Ai) and p.status == "pending"]
+		self.assertEqual(pend, [], "local backend must not persist a pending doc")
+
+	@patch("secator.query.QueryEngine")
+	@patch("secator.tasks.ai.init_llm")
+	@patch("secator.tasks.ai.call_llm")
+	def test_remote_max_iter_does_not_strand_pending_doc(self, mock_call_llm, mock_init, mock_qe_cls):
+		"""At remote max-iter after tool work, the loop ends cleanly: it does not
+		enter the follow-up poll and does not persist a dangling pending doc."""
+		from secator.tasks.ai import ai as AiTask
+		from secator.ai.interactivity import RemoteBackend
+		from secator.output_types import Ai, Info
+
+		mock_call_llm.return_value = {
+			"content": "working", "tool_calls": [object()], "usage": {"tokens": 100, "cost": 0.001},
+		}
+
+		persisted = []
+		prompt_calls = []
+		backend = RemoteBackend(timeout=60, query_engine=MagicMock(), poll_interval=0.01)
+
+		fake_self = MagicMock()
+		fake_self.backend = backend
+		fake_self.session_id = "sess-max"
+		fake_self.model = "gpt-4o"
+		fake_self.mode = "chat"
+		fake_self.max_iterations = 1
+		fake_self.interactive = "remote"
+		fake_self.is_subagent = False
+		fake_self.inputs = []
+		fake_self.context = {}
+		fake_self.scope = "workspace"
+		fake_self.results = []
+		fake_self.max_workers = 3
+		fake_self.encryptor = None
+		fake_self.dry_run = False
+		fake_self.verbose = False
+		fake_self._sync = False
+		fake_self.temp = 0.7
+		fake_self.api_base = ""
+		fake_self.api_key = ""
+		fake_self.tool_schemas = []
+		fake_self.max_tokens_total = 100000
+		fake_self.permission_engine = MagicMock()
+		fake_self.history = self._FakeHistory()
+		fake_self.add_result = lambda item, **kw: persisted.append(item)
+
+		def _empty_gen(*a, **k):
+			return
+			yield  # pragma: no cover - make it a generator
+
+		fake_self._summarize_auto = _empty_gen
+		fake_self._summarize_user = _empty_gen
+		fake_self._drain_history_usage = lambda: None
+		fake_self._account_usage = lambda u: None
+		fake_self._add_assistant_to_history = lambda c, t: None
+		fake_self._save_history = lambda: None
+
+		def _fake_process(tool_calls, ctx):
+			return [{"action": "shell", "tool_call_id": "t", "tool_call_name": "run_shell"}]
+			yield  # pragma: no cover
+
+		fake_self._process_tool_calls = _fake_process
+
+		def _fake_dispatch(actions, ctx):
+			return {"follow_up_choices": None, "stop_reason": None, "follow_up_prompt_uuid": None}
+			yield  # pragma: no cover
+
+		fake_self._dispatch_and_collect = _fake_dispatch
+
+		def _track_prompt(choices, prompt_uuid=None):
+			prompt_calls.append((choices, prompt_uuid))
+			return []
+
+		fake_self._prompt_and_redetect = _track_prompt
+
+		items = list(AiTask._run_loop(fake_self))
+
+		self.assertEqual(prompt_calls, [], "remote max-iter must not enter the follow-up poll")
+		pend = [p for p in persisted if isinstance(p, Ai) and getattr(p, "status", None) == "pending"]
+		self.assertEqual(pend, [], "remote max-iter must not persist a dangling pending doc")
+		self.assertTrue(
+			any(isinstance(it, Info) and "max iterations" in it.message.lower() for it in items),
+			"loop must end via the terminal 'reached max iterations' tail",
+		)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Finding — H5 (High / P2, Reliability)

Common remote turns that are NOT a guardrail/follow-up question — an ordinary chat reply, or the max-iterations exit — entered the poll/wait with `prompt_uuid=None` and persisted **no** `pending` Ai doc. Consequences: the frontend had nothing to render/answer, and with no (or a `None`-keyed) pending doc the resume/redelivery path could strand the user or trigger a stale re-run.

## The `None`-prompt_uuid paths (before)

- `secator/tasks/ai.py:464` — `_prompt_and_redetect(follow_up_choices or [], prompt_uuid=follow_up_prompt_uuid)`: for a plain-chat reply (`not tool_calls`) and for `iteration == self.max_iterations`, `follow_up_prompt_uuid` is `None` and no pending doc was persisted.
- `secator/tasks/ai.py:1029` — `_prompt_and_redetect` → `self.backend.ask_user(..., prompt_type="follow_up", prompt_uuid=None)` → `RemoteBackend._poll_for_answer(session_id, "follow_up", prompt_uuid=None)` (`secator/ai/interactivity.py:133/149`): unscoped poll, no doc for the UI to answer.

The guardrail/follow-up path already persists a `pending` doc + real `prompt_uuid` in `_dispatch_and_collect` (`ai.py:867-879`) and is left unchanged.

## Fix (per path)

- **Plain-chat remote turn** (`_prompt_and_redetect`): when the backend is remote and no `prompt_uuid` was passed, generate one and persist a `pending` `follow_up` doc via `RemoteBackend.build_pending_prompt` (DRY — same helper the permission path uses), then poll scoped to that uuid. Never polls on `None`. Local (CLI) backend is untouched — pending docs stay a remote-driver concern.
- **Max-iter terminal path** (`_run_loop`): remote + `iteration == max_iterations` + no follow-up + tool work now `break`s out to the terminal tail (save + "reached max iterations") instead of block-polling on an unanswerable doc, so no dangling `pending` doc is stranded.

M10 (timeout/GC/answered-search) and H7 (prompt_uuid correlation) helpers are reused, not reimplemented. No new status strings.

## Tests

`tests/unit/test_ai_interactivity.py`: **26 → 29 passed** (3 new).
- plain-chat remote turn persists exactly one `pending` doc with a non-None `prompt_uuid` and polls scoped to it;
- local plain-chat persists no pending doc;
- remote max-iter neither prompts/polls nor strands a pending doc, and ends via the terminal tail.

Broader `tests/unit/test_ai_loop.py` shows 9 pre-existing failures (safecmd/shfmt parser missing in this env) — identical with the branch stashed, not regressions from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)