### PR TITLE
fix(ai): 400s fail fast except orphan-tool repair (M4)

### DIFF
--- a/secator/ai/utils.py
+++ b/secator/ai/utils.py
@@ -297,25 +297,30 @@ def call_llm(
 	# a matching tool_result). Safety net in case the caller bypassed ChatHistory.
 	_repair_orphan_tool_uses(kwargs["messages"])
 
+	# M4: 400s are non-transient (malformed request, context_length_exceeded, ...) —
+	# handled separately below and NOT in this transient-retry tuple.
 	retryable = (
 		litellm.InternalServerError, litellm.RateLimitError,
-		litellm.ServiceUnavailableError, litellm.APIConnectionError, litellm.BadRequestError,
+		litellm.ServiceUnavailableError, litellm.APIConnectionError,
 		litellm.APIError
 	)
 	for attempt in range(1, max_retries + 1):
 		try:
 			response = litellm.completion(**kwargs)
 			break
-		except retryable as e:
-			# Detect the specific "orphan tool_use" error and repair before retry.
+		except litellm.BadRequestError as e:
+			# M4: 400s fail fast, except the orphan tool_use case which we repair
+			# and retry (not counted as an attempt — the repair is the real fix).
 			err_str = str(e)
 			if 'tool_use' in err_str and 'tool_result' in err_str:
 				repaired = _repair_orphan_tool_uses(kwargs["messages"])
 				if repaired:
 					console.print(Warning(
 						message=f"Repaired {repaired} orphan tool_use block(s); retrying LLM call."))
-					# Don't count this as a retry attempt — the repair is the real fix.
 					continue
+			console.print(Error(message=f"LLM call failed with non-retryable 400: {e}"))
+			raise
+		except retryable as e:
 			if attempt < max_retries:
 				wait = 2 ** attempt
 				console.print(Warning(

--- a/tests/unit/test_ai_utils.py
+++ b/tests/unit/test_ai_utils.py
@@ -241,6 +241,87 @@ class TestCallLLM(unittest.TestCase):
         self.assertEqual(tc.function.name, "broken_tool")
         self.assertEqual(tc.function.arguments, "{not valid json")
 
+    @patch('time.sleep')
+    @patch('litellm.completion')
+    def test_call_llm_non_orphan_400_fails_fast(self, mock_completion, mock_sleep):
+        """M4: a plain (non-orphan) 400 is raised immediately, NOT retried 3x."""
+        import litellm
+        from secator.ai.utils import call_llm
+
+        err = litellm.BadRequestError(
+            message="litellm.BadRequestError: context_length_exceeded",
+            model="test-model", llm_provider="anthropic",
+        )
+        mock_completion.side_effect = err
+
+        with self.assertRaises(litellm.BadRequestError):
+            call_llm([{"role": "user", "content": "hi"}], "test-model", max_retries=3)
+
+        self.assertEqual(mock_completion.call_count, 1)  # no 3x spin
+        mock_sleep.assert_not_called()
+
+    @patch('time.sleep')
+    @patch('litellm.completion')
+    def test_call_llm_orphan_400_repairs_and_retries(self, mock_completion, mock_sleep):
+        """M4: the orphan tool_use 400 still triggers repair-and-retry (no fail-fast)."""
+        import litellm
+        from secator.ai.utils import call_llm
+
+        ok_response = MagicMock()
+        ok_response.choices = [MagicMock(message=MagicMock(content="ok", tool_calls=None))]
+        ok_response.usage = None
+
+        err = litellm.BadRequestError(
+            message="AnthropicException - tool_use ids were found without tool_result blocks",
+            model="claude", llm_provider="anthropic",
+        )
+
+        calls = []
+
+        def side_effect(**kwargs):
+            if not calls:  # first call: inject orphan, then raise the orphan 400
+                kwargs["messages"].insert(0, {
+                    "role": "assistant", "content": None,
+                    "tool_calls": [{"id": "toolu_late", "type": "function",
+                                    "function": {"name": "f", "arguments": "{}"}}],
+                })
+                calls.append(1)
+                raise err
+            return ok_response
+
+        mock_completion.side_effect = side_effect
+        result = call_llm([{"role": "user", "content": "hi"}], "claude", max_retries=3)
+
+        self.assertEqual(result["content"], "ok")
+        self.assertEqual(mock_completion.call_count, 2)  # repaired then succeeded
+        mock_sleep.assert_not_called()  # repair skips the backoff
+
+    @patch('time.sleep')
+    @patch('litellm.completion')
+    @patch('litellm.completion_cost')
+    def test_call_llm_transient_error_still_retries(self, mock_cost, mock_completion, mock_sleep):
+        """M4: genuinely-transient errors (429/500) still retry then succeed."""
+        import litellm
+        from secator.ai.utils import call_llm
+
+        ok_response = MagicMock()
+        ok_response.choices = [MagicMock()]
+        ok_response.choices[0].message.content = "ok"
+        ok_response.choices[0].message.tool_calls = None
+        ok_response.usage.total_tokens = 10
+        mock_cost.return_value = 0.0
+
+        err = litellm.RateLimitError(
+            message="rate limited", model="test-model", llm_provider="anthropic",
+        )
+        mock_completion.side_effect = [err, ok_response]
+
+        result = call_llm([{"role": "user", "content": "hi"}], "test-model", max_retries=3)
+
+        self.assertEqual(result["content"], "ok")
+        self.assertEqual(mock_completion.call_count, 2)  # transient retry honored
+        mock_sleep.assert_called_once()
+
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
 class TestPromptUserAllChoices(unittest.TestCase):


### PR DESCRIPTION
## Finding (M4, P3 Robustness)
`litellm.BadRequestError` (HTTP 400) was in the general `retryable` tuple, so non-transient 400s (context_length_exceeded, malformed request, unsupported param) were retried 3x with backoff before the run died anyway — wasting time/tokens. The nearby comment also implied 400s were transient.

## Root cause
`secator/ai/utils.py:302` (pre-fix) — `BadRequestError` listed in `retryable`, and the orphan-tool_use 400 was only caught because of that membership.

## Fix
- Removed `BadRequestError` from `retryable`.
- Added a dedicated `except litellm.BadRequestError` branch **before** the transient tuple:
  - orphan `tool_use`/`tool_result` 400 → `_repair_orphan_tool_uses` + `continue` (not counted as an attempt) — H2's repair path preserved exactly.
  - any other 400 → clear `Error` + immediate `raise` (fail fast, no 3x spin).
- Transient errors (500/429/503/connection/APIError) keep retry + exponential backoff.
- Corrected the misleading comment.

Placing the `BadRequestError` clause first guarantees correct dispatch regardless of the litellm/openai exception hierarchy.

## Tests (baseline 20 → after 23, all pass)
Added to `TestCallLLM`:
- non-orphan 400 raises immediately, `completion.call_count == 1`, no sleep;
- orphan 400 still repairs + retries (`call_count == 2`, no sleep);
- transient `RateLimitError` still retries then succeeds (`call_count == 2`, one sleep).

## Extra findings (not fixed here)
- **M3** flat `max_tokens_total` trim ignores the model context window — `secator/ai/utils.py:17`/`:227` area (token-count helpers) and wherever the trim threshold is applied; a per-model window would be more correct.
- Backoff smell: fixed `2 ** attempt` sleep with **no jitter** (`secator/ai/utils.py:325`) — thundering-herd risk under correlated rate limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)