### PR TITLE
fix(ai): surface/prevent persistence-less subagent spawns (M2)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -119,6 +119,37 @@ def _build_hooks_from_context(context: Dict) -> Dict:
 	return deep_merge_dicts(*hooks_list)
 
 
+def _build_child_hooks_or_denial(context: Dict) -> Tuple[Dict, Optional["Warning"]]:
+	"""M2: rebuild the child's persistence hooks, refusing a persistence-less child.
+
+	``context`` carries the parent's ``drivers`` (copied via ``_get_result_context``),
+	so an empty/failed rebuild while the parent HAS drivers means the child would run
+	to completion and silently persist nothing (lost findings/docs). In that case
+	return a denial ``Warning`` (same shape H4/C1 use) so the caller yields it and
+	skips the spawn. When the parent itself has no drivers (pure local/no-persistence
+	run) an empty-hooks child is expected and allowed.
+
+	Returns ``(hooks, denial)``; if ``denial`` is non-None the caller must not spawn.
+	"""
+	parent_has_drivers = bool(context.get('drivers'))
+	try:
+		hooks = _build_hooks_from_context(context)
+	except Exception as e:  # narrow to the rebuild — surface, don't degrade to hooks={}
+		if parent_has_drivers:
+			return {}, Warning(
+				message=f"Subagent spawn denied: persistence hook rebuild failed — {type(e).__name__}: {e}",
+				_context=context,
+			)
+		return {}, None
+	if parent_has_drivers and not hooks:
+		return {}, Warning(
+			message="Subagent spawn denied: parent has persistence drivers but child hook rebuild "
+					"was empty (would silently drop findings/docs)",
+			_context=context,
+		)
+	return hooks, None
+
+
 def _build_action_display(action: Dict) -> str:
 	"""Build a display string for the action being checked.
 
@@ -550,7 +581,11 @@ def _run_runner(action: Dict, ctx: ActionContext, runner_type: str) -> Generator
 	# _get_result_context), but a sync sub-runner never goes through the pickle
 	# path that re-registers driver hooks — so without this its results would
 	# persist with no workspace scope and never appear in the workspace History.
-	hooks = _build_hooks_from_context(context)
+	# M2: don't silently spawn a persistence-less child when the parent has drivers
+	hooks, denial = _build_child_hooks_or_denial(context)
+	if denial is not None:
+		yield denial
+		return
 	try:
 		runner = runner_cls(tpl, targets, run_opts=run_opts, hooks=hooks, context=context)
 	except TaskNotFoundError as e:

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -11,6 +11,7 @@ if ADDONS_ENABLED['ai']:
 		ActionContext, dispatch_action, _handle_follow_up, _handle_shell,
 		_handle_query, _handle_add_finding, _run_runner, _decrypt_dict,
 		_build_hooks_from_context, _coerce_finding_fields, _sanitize_child_opts,
+		_build_child_hooks_or_denial,
 		_MAX_CHILD_ITERATIONS, _MAX_SUBAGENT_DEPTH, _MAX_SUBAGENTS_PER_TURN,
 	)
 	from secator.output_types import Ai, Error, Info, Warning, Vulnerability, Url
@@ -364,7 +365,8 @@ class TestRunRunner(unittest.TestCase):
 		(the conversation id) so its persisted runner doc is queryable by the
 		conversation. session_id may be derived (not already in ctx.context), so
 		it must be stamped from ctx.session_id."""
-		mock_build_hooks.return_value = {}
+		# non-empty: context has drivers, so empty hooks would trip the M2 guard
+		mock_build_hooks.return_value = {'fake': ['hook']}
 		mock_runner = MagicMock()
 		mock_runner.id = 'runner123'
 		mock_runner.reports_folder = None
@@ -537,6 +539,89 @@ class TestBuildHooksFromContext(unittest.TestCase):
 		hooks = _build_hooks_from_context({'drivers': ['bogus']})
 		self.assertEqual(hooks, {})
 		mock_import.assert_not_called()
+
+
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestChildHooksOrDenial(unittest.TestCase):
+	"""M2: refuse to spawn a persistence-less child when the parent has drivers."""
+
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_parent_no_drivers_empty_hooks_allowed(self, mock_build):
+		# pure local/no-persistence run: empty hooks child is expected, no denial
+		mock_build.return_value = {}
+		hooks, denial = _build_child_hooks_or_denial({'workspace_id': 'ws1'})
+		self.assertEqual(hooks, {})
+		self.assertIsNone(denial)
+
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_parent_drivers_present_hooks_pass_through(self, mock_build):
+		# normal spawn: drivers present + non-empty hooks -> pass through unchanged
+		sentinel = {'fake': ['hook']}
+		mock_build.return_value = sentinel
+		hooks, denial = _build_child_hooks_or_denial({'drivers': ['mongodb']})
+		self.assertEqual(hooks, sentinel)
+		self.assertIsNone(denial)
+
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_parent_drivers_but_empty_hooks_denied(self, mock_build):
+		# parent HAS drivers but rebuild produced no hooks -> refuse, surface Warning
+		mock_build.return_value = {}
+		hooks, denial = _build_child_hooks_or_denial({'drivers': ['mongodb']})
+		self.assertEqual(hooks, {})
+		self.assertIsInstance(denial, Warning)
+		self.assertIn('drop findings', denial.message)
+
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_rebuild_raise_with_drivers_denied_not_swallowed(self, mock_build):
+		# a raising rebuild must not degrade to hooks={} silently -> Warning
+		mock_build.side_effect = RuntimeError('boom')
+		hooks, denial = _build_child_hooks_or_denial({'drivers': ['mongodb']})
+		self.assertEqual(hooks, {})
+		self.assertIsInstance(denial, Warning)
+		self.assertIn('rebuild failed', denial.message)
+
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_rebuild_raise_no_drivers_allowed(self, mock_build):
+		# no parent drivers: a rebuild error still yields an allowed empty-hooks child
+		mock_build.side_effect = RuntimeError('boom')
+		hooks, denial = _build_child_hooks_or_denial({'workspace_id': 'ws1'})
+		self.assertEqual(hooks, {})
+		self.assertIsNone(denial)
+
+	@patch('secator.ai.actions.TemplateLoader')
+	@patch('secator.ai.actions.Task')
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_run_runner_refuses_spawn_on_lost_persistence(self, mock_build, mock_task_cls, _tpl):
+		# end-to-end: parent has drivers, rebuild empty -> _run_runner yields a
+		# Warning and never constructs the child runner
+		mock_build.return_value = {}
+		ctx = ActionContext(
+			targets=['t.com'], model='m',
+			context={'workspace_id': 'ws1', 'drivers': ['mongodb']},
+		)
+		action = {'action': 'task', 'name': 'nmap', 'targets': ['10.0.0.1']}
+		results = list(_run_runner(action, ctx, 'task'))
+		mock_task_cls.assert_not_called()
+		warnings = [r for r in results if isinstance(r, Warning)]
+		self.assertEqual(len(warnings), 1)
+		self.assertIn('denied', warnings[0].message)
+
+	@patch('secator.ai.actions.TemplateLoader')
+	@patch('secator.ai.actions.Task')
+	@patch('secator.ai.actions._build_hooks_from_context')
+	def test_run_runner_no_drivers_spawns_normally(self, mock_build, mock_task_cls, _tpl):
+		# parent has NO drivers: empty-hooks child still spawns (no false alarm)
+		mock_build.return_value = {}
+		mock_runner = MagicMock()
+		mock_runner.id = 'runner123'
+		mock_runner.reports_folder = None
+		mock_runner.__iter__.return_value = iter([])
+		mock_task_cls.return_value = mock_runner
+		ctx = ActionContext(targets=['t.com'], model='m', context={'workspace_id': 'ws1'})
+		action = {'action': 'task', 'name': 'nmap', 'targets': ['10.0.0.1']}
+		results = list(_run_runner(action, ctx, 'task'))
+		mock_task_cls.assert_called_once()
+		self.assertFalse([r for r in results if isinstance(r, Warning)])
 
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')


### PR DESCRIPTION
## Finding — M2: Hook rebuild silently drops persistence (P2, Robustness)

When a subagent/child runner is spawned, its persistence hooks (mongodb/api
`update_runner`/`update_finding`, etc.) are reconstructed from
`context['drivers']`. If that rebuild returned empty (drivers missing, none
supported, nothing imported) **or raised**, the child was constructed with
`hooks={}` and ran to completion while silently persisting **nothing** —
findings/docs vanished with no error surfaced.

## Root cause

`secator/ai/actions.py:553` (pre-change): `hooks = _build_hooks_from_context(context)`
fed straight into `runner_cls(..., hooks=hooks, ...)`. `_build_hooks_from_context`
returns `{}` on empty/unsupported drivers and would propagate on an import raise —
either way the child lost persistence with no signal.

## Approach — refuse (not inherit)

`context` already carries the parent's `drivers` (copied via
`_get_result_context`), so `_build_hooks_from_context(context)` is already using
the parent's drivers. If it comes back empty despite the parent having drivers,
re-running the same rebuild (inherit) can't help — the parent's live hook objects
aren't reachable from `ctx`, only the driver names are. So the honest fix is to
**refuse the spawn** and surface a denial `Warning`.

New tiny helper `_build_child_hooks_or_denial(context) -> (hooks, denial)`:
- parent has drivers + rebuild empty  → denial Warning, no spawn
- parent has drivers + rebuild raises → caught narrowly, denial Warning (not `hooks={}`)
- parent has **no** drivers            → empty-hooks child allowed (legit local/no-persistence)

The denial uses the same `Warning(message=..., _context=context)` shape H4/C1 use
(yielded + returned to the LLM). `_run_runner` yields it and returns before
constructing the child. DRY: reuses `_build_hooks_from_context` and the existing
Warning mechanism; +36/-1 in `actions.py`.

## Tests

Baseline: **64 passed**. After: **71 passed** (7 new).
- One existing test (`test_run_runner_propagates_session_id`) stubbed `hooks={}`
  while its context had `drivers` — that was incidental to its session_id purpose;
  its mock now returns a non-empty sentinel so it exercises the normal path.
- New `TestChildHooksOrDenial`: parent-no-drivers empty ok; drivers+hooks pass
  through; drivers+empty denied; rebuild-raise-with-drivers denied (not swallowed);
  rebuild-raise-no-drivers allowed; end-to-end `_run_runner` refuses (Task never
  constructed) with drivers; end-to-end no-drivers spawns normally.

`ast.parse` on `actions.py` passes.

## Extra findings (flagged, not fixed)

- `secator/ai/actions.py:555` — on refusal (and on `TaskNotFoundError`) the child
  runner status is never reconciled; more broadly a child whose parent later fails
  mid-turn has no status-reconciliation path (adjacent to M10's pending-doc work).
- `secator/ai/actions.py:602` (`_get_result_context`) — `ctx.context.copy()` is a
  shallow copy; the child's `context['drivers']` is an **alias** of the parent
  list, so a child mutating `drivers` would mutate the parent's. Not exploited
  here but a latent aliasing smell in the driver-context propagation.