### PR TITLE
fix(ai): normalize encoded IPs before SSRF/metadata deny (M8)

### DIFF
--- a/secator/ai/guardrails.py
+++ b/secator/ai/guardrails.py
@@ -1,10 +1,11 @@
 """Permission engine for AI guardrails."""
 import fnmatch
+import ipaddress
 import re
 import socket
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 from secator.ai.encryption import PII_PATTERNS
 
@@ -51,6 +52,59 @@ def parse_rule(rule: str) -> Tuple[str, List[str]]:
 	return rule_type, values
 
 
+_IP_INT_RE = re.compile(r'0[xX][0-9a-fA-F]+|0[oO][0-7]+|\d+')
+_DOTTED_ODD_RE = re.compile(r'(?:0[xX][0-9a-fA-F]+|0[0-7]+|\d+)(?:\.(?:0[xX][0-9a-fA-F]+|0[0-7]+|\d+)){3}')
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
+def _normalize_ip(candidate: str) -> Optional[IPAddress]:
+	"""M8: normalize encoded IPs (decimal/hex/octal int, dotted-hex/octal, IPv6-mapped) to an ip_address.
+
+	Returns None if the candidate is not an IP (e.g. a hostname) so callers fall back to literal matching.
+	Hostnames are NOT resolved here (DNS rebinding is a documented residual).
+	"""
+	s = candidate.strip()
+	if not s:
+		return None
+	if s.startswith('[') and s.endswith(']'):  # [::1] / [::ffff:1.2.3.4]
+		s = s[1:-1]
+	ip = None
+	# Plain dotted-quad / standard IPv6 first (leaves normal targets untouched)
+	try:
+		ip = ipaddress.ip_address(s)
+	except ValueError:
+		# Integer form: decimal (2852039166), hex (0xA9FEA9FE), octal (0o...)
+		if _IP_INT_RE.fullmatch(s):
+			try:
+				ip = ipaddress.ip_address(int(s, 0) if s[:2].lower() in ('0x', '0o') else int(s))
+			except (ValueError, ipaddress.AddressValueError):
+				return None
+		# Dotted octets with hex/octal parts (0xA9.0xFE.0xA9.0xFE, 0251.0376.0251.0376)
+		elif _DOTTED_ODD_RE.fullmatch(s):
+			try:
+				octets = [int(p, 0) if p[:2].lower() == '0x' else int(p, 8) if p.startswith('0') and len(p) > 1 else int(p)
+						  for p in s.split('.')]
+				if all(0 <= o <= 255 for o in octets):
+					ip = ipaddress.ip_address('.'.join(str(o) for o in octets))
+			except (ValueError, ipaddress.AddressValueError):
+				return None
+	if ip is None:
+		return None
+	# Collapse IPv6-mapped/compatible IPv4 (::ffff:169.254.169.254) down to the v4 address
+	if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+		ip = ip.ipv4_mapped
+	return ip
+
+
+def _ip_in_pattern(ip: IPAddress, pattern: str) -> Optional[bool]:
+	"""M8: True/False if `pattern` is an IP/CIDR literal, else None (pattern isn't an address rule)."""
+	try:
+		net = ipaddress.ip_network(pattern, strict=False)
+	except ValueError:
+		return None
+	return ip.version == net.version and ip in net
+
+
 def match_rule(value: str, patterns: List[str]) -> bool:
 	"""Check if a value matches any of the given patterns.
 
@@ -60,6 +114,7 @@ def match_rule(value: str, patterns: List[str]) -> bool:
 	- Glob patterns (fnmatch)
 	- {port} variable (matches :\\d+)
 	- Basename matching for path-like values (e.g. '.env' matches '/home/user/.env')
+	- M8: IP/CIDR patterns are matched by normalized address (encoded IPs are canonicalized first)
 
 	Args:
 		value: The value to check
@@ -68,9 +123,21 @@ def match_rule(value: str, patterns: List[str]) -> bool:
 	Returns:
 		True if value matches any pattern
 	"""
+	# M8: normalize encoded IPs before deny/allow match so alternate encodings can't evade IP rules
+	norm_ip = _normalize_ip(value)
+	canon = str(norm_ip) if norm_ip is not None else None
 	for pattern in patterns:
 		if pattern == "*":
 			return True
+		if norm_ip is not None:
+			in_pat = _ip_in_pattern(norm_ip, pattern)
+			if in_pat is not None:
+				if in_pat:
+					return True
+				continue  # IP/CIDR pattern that doesn't contain this address — no string fallback
+			# Non-address pattern (glob/{port}): also test the canonical dotted form
+			if canon != value and fnmatch.fnmatch(canon, pattern):
+				return True
 		if "{port}" in pattern:
 			regex_pattern = re.escape(pattern).replace(r"\{port\}", r"\d+")
 			if re.fullmatch(regex_pattern, value):

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -10,7 +10,7 @@ if ADDONS_ENABLED['ai']:
 	from secator.ai.guardrails import (
 		parse_rule, match_rule, extract_command_targets, detect_paths, detect_paths_with_access,
 		detect_sensitive_env_vars, classify_command, build_target_choices, PermissionEngine,
-		_is_file_path
+		_is_file_path, _normalize_ip
 	)
 	from secator.output_types import Warning, Error
 
@@ -86,6 +86,53 @@ class TestRuleParser(unittest.TestCase):
 		self.assertTrue(match_rule("/home/user/cert.pem", ["*.pem"]))
 		# Non-path values should not get basename matching
 		self.assertFalse(match_rule("example.com", [".com"]))
+
+
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestEncodedIPDeny(unittest.TestCase):
+	"""M8: alternate IP encodings must not evade an IP/CIDR deny rule."""
+
+	META = "169.254.169.254"
+
+	def test_normalize_ip_encodings(self):
+		import ipaddress
+		expected = ipaddress.ip_address(self.META)
+		for enc in ("2852039166", "0xA9FEA9FE", "0xa9fea9fe",
+					"::ffff:169.254.169.254", "[::ffff:169.254.169.254]",
+					"0xA9.0xFE.0xA9.0xFE", "169.254.169.254"):
+			self.assertEqual(_normalize_ip(enc), expected, enc)
+
+	def test_normalize_ip_non_ip(self):
+		# Hostnames and port-suffixed values are not IPs (no DNS resolution here)
+		self.assertIsNone(_normalize_ip("example.com"))
+		self.assertIsNone(_normalize_ip("10.0.0.1:8080"))
+
+	def test_encoded_forms_denied(self):
+		deny = ["169.254.169.254"]
+		for enc in ("2852039166", "0xA9FEA9FE", "::ffff:169.254.169.254", "169.254.169.254"):
+			self.assertTrue(match_rule(enc, deny), enc)
+
+	def test_public_ip_still_allowed(self):
+		# A normal public IP must not match the metadata deny rule
+		self.assertFalse(match_rule("8.8.8.8", ["169.254.169.254"]))
+		self.assertFalse(match_rule("93.184.216.34", ["169.254.169.254"]))
+
+	def test_cidr_deny_membership(self):
+		# Encoded link-local addresses fall inside a CIDR deny rule
+		self.assertTrue(match_rule("2852039166", ["169.254.0.0/16"]))
+		self.assertFalse(match_rule("8.8.8.8", ["169.254.0.0/16"]))
+
+	def test_check_value_denies_encoded_targets(self):
+		engine = PermissionEngine(config=dict(deny=["target(169.254.169.254)"], allow=["target(*)"]))
+		for enc in ("2852039166", "0xA9FEA9FE", "::ffff:169.254.169.254"):
+			self.assertEqual(engine._check_value("target", enc).decision, "deny", enc)
+		self.assertEqual(engine._check_value("target", "8.8.8.8").decision, "allow")
+
+	def test_encoded_url_target_denied(self):
+		# curl http://<decimal>/ resolves to the metadata IP → deny (via URL host extraction)
+		engine = PermissionEngine(config=dict(deny=["target(169.254.169.254)"], allow=["task(*)", "target(*)"]))
+		result = engine.check_action({"action": "task", "name": "nmap", "targets": ["http://2852039166/latest/meta-data/"]})
+		self.assertEqual(result.decision, "deny")
 
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')


### PR DESCRIPTION
## Finding — M8: IP-deny is evadable (SSRF) [P1 Security]

Decimal/hex/octal/IPv6-mapped encodings reach `169.254.169.254` (and other blocked IPs); the deny matched literals only.

## Root cause

`secator/ai/guardrails.py` — `match_rule()` (pre-fix line ~54) compared IP targets against deny/allow patterns as literal strings via `fnmatch`. The default deny rules (`secator/config.py:263` `target(169.254.169.254)`, `:264` `target(127.0.0.1)`) only caught the exact dotted-quad, so alternate encodings of the same address slipped through:
- decimal `2852039166`
- hex `0xA9FEA9FE`
- octal / dotted hex-octet `0xA9.0xFE.0xA9.0xFE`, `0251.0376.0251.0376`
- IPv6-mapped `::ffff:169.254.169.254` / `[::ffff:169.254.169.254]`

## Fix

- New `_normalize_ip(candidate) -> ip_address | None` (stdlib `ipaddress`): canonicalizes integer (dec/hex/oct), dotted hex/octal octets, and IPv6-mapped IPv4 down to a single address; returns `None` for hostnames so literal matching is preserved.
- New `_ip_in_pattern(ip, pattern)`: treats an IP/CIDR deny/allow pattern as an `ip_network` and tests membership.
- `match_rule` normalizes the value once and, for IP/CIDR patterns, matches by network membership (reused uniformly across deny + allow + ask). URL targets already surface their host via `urlparse` in `_check_value`, so `curl http://<encoded>/…` is covered.

**No new policy/config surface** — the same blocked IPs are enforced, just made robust to encodings. CIDR deny rules (e.g. `169.254.0.0/16`) now also work if ever added.

## Now blocked

decimal, hex (`0x…`), octal (`0o…`), dotted hex/octal octets, IPv6-mapped IPv4 — all of `169.254.169.254` / `127.0.0.1` / any IP or CIDR deny rule. Normal public IPs (`8.8.8.8`) and hostnames stay allowed; `{port}`, glob, basename and path matching are unchanged.

## Residuals (not fixed here — by design)

- **DNS rebinding**: a hostname that resolves to a blocked IP is not caught; hostnames are intentionally NOT resolved in `_normalize_ip` (live DNS in the deny path adds TOCTOU + perf issues). Flagged as residual.
- **Bare scheme-less encoded integer as a shell/task target** (e.g. `curl 2852039166` with no `http://`): `_is_network_target` does not classify a bare decimal as a target (deliberately left unchanged — broadening it would misclassify bare port numbers like `8080` as `0.0.31.144`). The URL form is covered.

## Tests

`tests/unit/test_ai_guardrails.py::TestEncodedIPDeny` (7 new): normalization of all encodings, non-IP returns `None`, encoded forms denied, public IP still allowed, CIDR membership, `_check_value` deny, and an encoded-URL task action denied end-to-end.

Baseline (before): 55 failed, 75 passed. After: 55 failed, 82 passed. The 55 failures are pre-existing/environmental (missing `shfmt`/safecmd shell parser) and the failing set is byte-identical before vs after — the only delta is the 7 new passing tests. `ast.parse` on `guardrails.py` OK.

## Adjacent SSRF/target smells (flagged, not fixed)

- `guardrails.py:169` / `:401` — `docker`/`podman` top-level commands skip target detection entirely (`extract_command_targets` returns `[]`); a `docker run … curl http://169.254.169.254` is not target-checked.
- `guardrails.py:406` — interpreter `-c` bodies (`python -c`, `bash -c`) skip path AND target extraction; SSRF inside a `-c` string is unseen.
- No scheme allow/deny: `file://`, `gopher://`, `dict://` etc. are not modeled (only `http`/`https`/`ftp` recognized) — SSRF via `curl gopher://…` or local file read via `file://` bypasses target logic.
- URL-embedded credentials (`http://user:pass@host`) and redirect-following tools (`curl -L`) are not inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)