### PR TITLE
fix(ai): idempotency marker stops Celery redelivery replay (C3)

### DIFF
--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -218,6 +218,7 @@ class ai(PythonRunner):
 
 		# Run loop
 		yield from self._run_loop()
+		self._mark_turn_completed()  # C3: record this turn as done so a redelivery won't replay it
 
 	# -------------------------------------------------------------------------
 	# Remote (web) session restore
@@ -253,6 +254,16 @@ class ai(PythonRunner):
 				'(expected mongodb/api). The web answer channel will not work — check that the '
 				'`mongodb` driver is in the runner context.'
 			)
+
+		# C3: skip replay of an already-completed turn. acks_late can redeliver
+		# this exact message (same celery_id) after a worker crash; without an
+		# idempotency marker the resume path would re-run every tool action and
+		# re-bill tokens. If this turn already completed, short-circuit instead of
+		# replaying _run_loop.
+		turn_uuid = self._turn_uuid()
+		if turn_uuid and self._turn_completed_marker(turn_uuid, query_engine):
+			self.debug(f'C3 idempotency: turn {turn_uuid} already completed; skipping replay', sub='llm')
+			return True
 
 		# Look for prior `_type:"ai"` docs for this session
 		try:
@@ -292,6 +303,7 @@ class ai(PythonRunner):
 
 		yield Info(message=f"Resumed session from DB ({len(self.history.messages)} messages), model: {self.model}, mode: {self.mode}")  # noqa: E501
 		yield from self._run_loop()
+		self._mark_turn_completed()  # C3: record this turn as done so a redelivery won't replay it
 		return True
 
 	def _save_history(self):
@@ -303,6 +315,54 @@ class ai(PythonRunner):
 		if self.interactive == "remote":
 			return
 		save_history(self.history, self.reports_folder, debug_fn=self.debug)
+
+	# -------------------------------------------------------------------------
+	# C3: turn-level idempotency (remote/Celery redelivery)
+	# -------------------------------------------------------------------------
+
+	def _turn_uuid(self):
+		"""Stable id naming THIS delivery's turn for idempotency.
+
+		``celery_id`` (the Celery request id) is stamped on the runner context by
+		the worker entrypoint (``run_command``) and is the SAME across an acks_late
+		worker-loss redelivery, so it uniquely and idempotently names one turn.
+		"""
+		return (self.context or {}).get("celery_id")
+
+	def _turn_completed_marker(self, turn_uuid, query_engine):
+		"""Return the persisted completion marker for ``turn_uuid``, or None."""
+		try:
+			docs = query_engine.search({
+				"_type": "ai",
+				"ai_type": "turn_completed",
+				"_context.session_id": self.session_id,
+				"extra_data.turn_uuid": turn_uuid,
+			}, limit=1)
+		except Exception as e:  # noqa: BLE001 - a marker query must not crash the worker
+			self.debug(f'C3 idempotency: marker query failed: {e}', sub='llm')
+			return None
+		return docs[0] if docs else None
+
+	def _mark_turn_completed(self):
+		"""C3: persist a turn-completion marker once the turn is durably done.
+
+		Remote channel only. Reuses the workspace `_type:"ai"` docs (no new
+		collection); restore_history_from_db skips this ai_type so it never enters
+		the transcript. Called by the caller AFTER `_run_loop` returns, so a crash
+		mid-turn leaves no marker and the partial turn still resumes.
+		"""
+		if self.interactive != "remote":
+			return
+		turn_uuid = self._turn_uuid()
+		if not turn_uuid:
+			return
+		self.add_result(Ai(
+			content="",
+			ai_type="turn_completed",
+			status="completed",
+			session_id=self.session_id,
+			extra_data={"turn_uuid": turn_uuid},
+		), print=False)
 
 	# -------------------------------------------------------------------------
 	# _run_loop: main LLM interaction loop

--- a/tests/unit/test_ai_session.py
+++ b/tests/unit/test_ai_session.py
@@ -184,5 +184,113 @@ class TestRemoteResumeBranch(unittest.TestCase):
 		self.assertTrue(any("remote" in w.message for w in warnings))
 
 
+class TestTurnIdempotency(unittest.TestCase):
+	"""C3: an acks_late redelivery of an already-completed turn must NOT replay
+	_run_loop (no re-run tool actions, no re-billed tokens); a genuinely
+	incomplete turn must still resume and run."""
+
+	def _make_task(self, marker_docs, prior_docs, celery_id="turn-abc"):
+		from secator.tasks.ai import ai
+
+		task = ai.__new__(ai)
+		task.interactive = "remote"
+		task.session_id = "sess-123"
+		task.session_name = ""
+		task.mode = "chat"
+		task.model = "gpt-4o"
+		task.encryptor = None
+		task.context = {"workspace_id": "ws1", "drivers": ["mongodb"], "celery_id": celery_id}
+		task.context["ai_tokens"] = 0
+		task.run_opts = {"prompt": "continue"}
+		task._reports_folder = tempfile.mkdtemp(prefix="secator-test-")
+		task.backend = MagicMock()
+		task.debug = MagicMock()
+		task.history = MagicMock()
+
+		engine = MagicMock()
+		engine.backend = MagicMock()
+		engine.backend.name = "mongodb"
+
+		def _search(query, limit=0):
+			# The idempotency marker query is the only one keyed by turn_completed.
+			if query.get("ai_type") == "turn_completed":
+				return marker_docs
+			if query.get("_type") == "ai":
+				return prior_docs
+			return []
+		engine.search.side_effect = _search
+		task._get_query_engine = MagicMock(return_value=engine)
+		return task, engine
+
+	def _drive(self, task):
+		gen = task._maybe_resume_remote()
+		restored = None
+		try:
+			while True:
+				next(gen)
+		except StopIteration as e:
+			restored = e.value
+		return restored
+
+	def test_completed_turn_short_circuits_without_replay(self):
+		"""A redelivery whose turn already has a completion marker short-circuits:
+		_run_loop is not called and no tokens are billed."""
+		task, engine = self._make_task(
+			marker_docs=[{"ai_type": "turn_completed", "extra_data": {"turn_uuid": "turn-abc"}}],
+			prior_docs=[{"ai_type": "prompt", "content": "hi"}],
+		)
+		task._run_loop = MagicMock(return_value=iter([]))
+
+		with patch("secator.tasks.ai.restore_history_from_db") as mock_restore:
+			restored = self._drive(task)
+
+		self.assertTrue(restored)                       # turn handled (as a no-op)
+		task._run_loop.assert_not_called()              # no tool actions replayed
+		mock_restore.assert_not_called()                # didn't even rebuild/append
+		self.assertEqual(task.context["ai_tokens"], 0)  # nothing re-billed
+
+	@patch("secator.tasks.ai.restore_history_from_db")
+	@patch("secator.tasks.ai.get_system_prompt", return_value="SYS")
+	def test_incomplete_turn_still_resumes(self, mock_sys, mock_restore):
+		"""No marker (a real mid-turn crash) → the turn resumes and runs _run_loop."""
+		mock_restore.return_value = MagicMock(messages=[{"role": "system", "content": "SYS"}])
+		task, engine = self._make_task(
+			marker_docs=[],
+			prior_docs=[{"ai_type": "prompt", "content": "hi"}],
+		)
+		task._detect_mode = MagicMock()
+		task._run_loop = MagicMock(return_value=iter([]))
+		task._mark_turn_completed = MagicMock()
+
+		restored = self._drive(task)
+
+		self.assertTrue(restored)
+		mock_restore.assert_called_once()
+		task._run_loop.assert_called_once()
+
+	def test_mark_turn_completed_persists_marker(self):
+		"""_mark_turn_completed persists exactly one turn_completed Ai stamped with
+		the celery_id turn_uuid; it is a no-op off the remote channel."""
+		from secator.output_types import Ai
+
+		task, engine = self._make_task(marker_docs=[], prior_docs=[])
+		persisted = []
+		task.add_result = lambda item, **kw: persisted.append(item)
+
+		task._mark_turn_completed()
+		self.assertEqual(len(persisted), 1)
+		marker = persisted[0]
+		self.assertIsInstance(marker, Ai)
+		self.assertEqual(marker.ai_type, "turn_completed")
+		self.assertEqual(marker.extra_data.get("turn_uuid"), "turn-abc")
+		self.assertEqual(marker.session_id, "sess-123")
+
+		# Local channel: no marker persisted (idempotency is a remote concern).
+		persisted.clear()
+		task.interactive = "local"
+		task._mark_turn_completed()
+		self.assertEqual(persisted, [])
+
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Finding — C3 (CRITICAL / P2, Reliability)
The AI Celery task uses `acks_late`, so a worker crash/restart redelivers the same message. On the remote resume path `_maybe_resume_remote` restored history and re-ran `_run_loop` with **no idempotency marker**, so a duplicate delivery replayed the ENTIRE turn: tool actions ran again (side effects), findings were re-emitted, and tokens were re-billed — nothing to dedupe on.

## Turn id chosen — `celery_id`
`run_command` (`secator/celery.py:316`) stamps `context['celery_id'] = self.request.id` onto the runner context, and that id is **stable across `acks_late` worker-loss redeliveries** (documented at `celery.py:227`) while being unique per turn dispatch. It therefore uniquely and idempotently names THIS delivery's turn. `session_id` names the whole conversation (many turns), so it is not a per-turn id; the incoming user message carries no UI-supplied uuid. Read via `_turn_uuid()`.

## Marker persistence
A `turn_completed` `Ai` doc persisted through the **existing** workspace `_type:"ai"` channel (`add_result`, `print=False`) — no new Mongo collection. `restore_history_from_db` only rebuilds `prompt`/`response` turns, so this ai_type is skipped and never pollutes the transcript. Stamped with `extra_data.turn_uuid = celery_id` + `session_id`, mirroring the proven H7 `extra_data.prompt_uuid` query pattern.

## Short-circuit point
`_maybe_resume_remote` in `secator/tasks/ai.py` (guard added right after the backend-name check, ~line 258): if `_turn_completed_marker(turn_uuid, query_engine)` finds a marker, it `debug`-logs and `return True` (benign no-op) **without** restoring history or running `_run_loop` — no re-run, no re-bill. The marker is set via `_mark_turn_completed()` **after** each remote `_run_loop` returns (the fresh-turn call in `yielder` and the resume call in `_maybe_resume_remote`), so a real mid-turn crash leaves no marker and the incomplete turn still resumes and finishes. Local/non-remote path is unaffected (the helper no-ops off `interactive == "remote"`).

## Tests (baseline vs after)
Same command, `test_ai_interactivity.py + test_ai_loop.py + test_ai_session.py`:
- Baseline: **11 failed, 67 passed**
- After: **11 failed, 70 passed** (identical failing set; +3 new tests)

The 11 pre-existing failures are unrelated: guardrails allow-list not matching in this env, and two stale `TestRemoteResumeBranch`/`TestRestoreHistoryFromDB` tests that still query `session_id` while the branch's H7 code queries `_context.session_id`.

New tests (`TestTurnIdempotency`):
- `test_completed_turn_short_circuits_without_replay` — marker present → `_run_loop` not called, `restore_history_from_db` not called, `ai_tokens` stays 0.
- `test_incomplete_turn_still_resumes` — no marker → restores and runs `_run_loop` once.
- `test_mark_turn_completed_persists_marker` — persists one `turn_completed` Ai stamped with the celery_id turn_uuid + session_id; no-op on the local channel.

## Follow-up
Turn-level guard only. Fully-safe idempotency for a turn that crashes **mid-tool-execution** needs per-tool-action markers (dedupe each dispatched action / billed call) — flagged as a follow-up, out of scope here to keep the change surgical.

## Extra findings (flagged, not fixed)
- **H3** — `RemoteBackend._poll_for_answer` (`secator/ai/interactivity.py:149-190`) blocks a worker slot for up to `timeout` (default 600s) busy-polling for a web answer, pinning a prefork worker for the whole wait.
- Resume double-persist smell — the fresh-turn user prompt is appended + yielded in `_maybe_resume_remote` (`ai.py:289-291`); combined with restore ordering this is a candidate spot for duplicate `prompt` docs on odd redelivery timing (not observed, worth a look alongside per-action idempotency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)