### PR TITLE
fix(ai): model-window-aware history trim budget (M3)

### DIFF
--- a/secator/ai/history.py
+++ b/secator/ai/history.py
@@ -183,17 +183,34 @@ class ChatHistory:
         self.messages.append({"role": "tool", "content": content})
 
     def to_messages(self, max_tokens_total: int = 0) -> List[Dict[str, str]]:
-        """Return a copy of the messages list, trimming if over max_tokens_total.
+        """Return a copy of the messages list, trimming if over the effective budget.
 
         Uses litellm's trim_messages which preserves system messages and recent
         context while removing oldest messages first.
 
         Args:
-            max_tokens_total: Hard token limit. If > 0, trim messages to fit.
+            max_tokens_total: Requested hard token limit (0 = no explicit cap).
         """
-        if max_tokens_total > 0:
-            return self.trim(max_tokens_total)
+        budget = self._trim_budget(max_tokens_total)
+        if budget > 0:
+            return self.trim(budget)
         return self.messages.copy()
+
+    def _trim_budget(self, max_tokens_total: int = 0) -> int:
+        """Effective trim budget, capped to the model's real context window.
+
+        M3: a flat max_tokens_total (e.g. 100k) ignores the model window and
+        fails with context_length_exceeded on smaller-window models. Cap it to
+        get_context_window(model) - OUTPUT_TOKEN_RESERVATION (headroom for the
+        response), and use that window-derived budget even when no explicit cap
+        is set. With no model known, keep the legacy caller-driven behavior.
+        """
+        if not self.model:
+            return max_tokens_total
+        window_budget = max(get_context_window(self.model) - OUTPUT_TOKEN_RESERVATION, 1)
+        if max_tokens_total > 0:
+            return min(max_tokens_total, window_budget)
+        return window_budget
 
     def trim(self, max_tokens: int) -> List[Dict[str, str]]:
         """Trim messages to fit under max_tokens using litellm's trim_messages.

--- a/tests/unit/test_ai_history.py
+++ b/tests/unit/test_ai_history.py
@@ -218,6 +218,76 @@ class TestChatHistory(unittest.TestCase):
         messages = history.to_messages(max_tokens_total=500)
         self.assertEqual(len(messages), 2)
 
+    @patch('secator.ai.history.get_context_window')
+    def test_to_messages_caps_budget_to_small_window(self, mock_get_ctx):
+        """M3: a flat max_tokens_total is capped to a small model's window."""
+        mock_get_ctx.return_value = 8000  # small-window model
+
+        history = ChatHistory()
+        history.model = "small-model"
+        history.add_system("s" * 40)
+        for i in range(40):
+            history.add_user("x" * 4000)  # long history, well over 8k tokens
+
+        original_count = len(history.messages)
+        # Flat 100k cap would NOT trim on a real 8k model without this fix.
+        messages = history.to_messages(max_tokens_total=100000)
+
+        self.assertLess(len(messages), original_count)  # trimmed to fit the window
+        self.assertEqual(messages[0]["role"], "system")
+
+    @patch('secator.ai.history.get_context_window')
+    def test_to_messages_no_explicit_cap_uses_window(self, mock_get_ctx):
+        """M3: with max_tokens_total=0 and a model, trim to the window-derived budget."""
+        mock_get_ctx.return_value = 8000
+
+        history = ChatHistory()
+        history.model = "small-model"
+        history.add_system("s" * 40)
+        for i in range(40):
+            history.add_user("x" * 4000)
+
+        original_count = len(history.messages)
+        messages = history.to_messages()  # no explicit cap
+
+        self.assertLess(len(messages), original_count)
+
+    @patch('secator.ai.history.get_context_window')
+    def test_to_messages_large_window_matches_flat_budget(self, mock_get_ctx):
+        """M3: on a large-window model the flat cap is honored (no over-trim)."""
+        mock_get_ctx.return_value = 200000  # window - reserve (191808) > 100k cap
+
+        history = ChatHistory()
+        history.model = "big-model"
+        history.add_system("short")
+        history.add_user("small message")
+
+        with patch.object(history, 'trim', wraps=history.trim) as spy:
+            history.to_messages(max_tokens_total=100000)
+            # Budget = min(100000, 200000 - 8192) = 100000, unchanged by the window.
+            spy.assert_called_once_with(100000)
+
+    @patch('secator.ai.history.get_context_window')
+    def test_to_messages_window_cap_preserves_tool_pairs(self, mock_get_ctx):
+        """M3 + H2: window-capped trim never leaves a leading orphan tool_result."""
+        mock_get_ctx.return_value = 8000
+
+        history = ChatHistory()
+        history.model = "small-model"
+        history.add_system("s" * 40)
+        for i in range(30):
+            tool_calls = [{"id": f"call_{i}", "type": "function",
+                           "function": {"name": "nmap", "arguments": "{}"}}]
+            history.add_assistant_with_tool_calls("x" * 2000, tool_calls)
+            history.add_tool_result("nmap", f"call_{i}", "y" * 2000)
+
+        messages = history.to_messages(max_tokens_total=100000)
+
+        # First non-system message must not be an orphan tool result.
+        non_system = [m for m in messages if m["role"] != "system"]
+        if non_system:
+            self.assertNotEqual(non_system[0]["role"], "tool")
+
     def test_to_messages_no_truncation_when_zero(self):
         """to_messages without max_tokens_total does not truncate."""
         history = ChatHistory()


### PR DESCRIPTION
## Finding — M3: Flat \`max_tokens_total\` ignores model window (P3, Robustness)

\`ChatHistory.to_messages()\` trimmed to a fixed token budget (the flat 100k \`CONFIG.addons.ai.max_tokens_total\`) regardless of the model's real context window. On a smaller-window model (e.g. 8k/32k) the 100k budget never triggers trimming, and the next LLM call fails with \`context_length_exceeded\`.

## Root cause

\`secator/ai/history.py:185\` \`to_messages(max_tokens_total)\` → \`if max_tokens_total > 0: return self.trim(max_tokens_total)\`. The caller (\`secator/tasks/ai.py:426\`) passes the flat \`self.max_tokens_total\` (default 100k), which is never clamped to the model window.

## Fix

Made the effective trim budget model-aware **inside** \`history.py\` (caller unchanged):

- New private \`_trim_budget(max_tokens_total)\` computes:
  \`min(max_tokens_total, get_context_window(model) - OUTPUT_TOKEN_RESERVATION)\`.
- **Model threading:** reuses the \`model\` already stored on the \`ChatHistory\` instance (set by the caller at \`tasks/ai.py:170,297\`) — no signature change to the public \`to_messages(max_tokens_total)\`.
- **Reuse (DRY):** uses the existing \`get_context_window()\` helper and the existing \`OUTPUT_TOKEN_RESERVATION\` (8192) constant — no new model lookup, no magic factor. This matches how \`get_available_tokens\`/\`should_compact\` already reserve completion headroom.
- **Safety margin:** subtract the fixed 8192-token \`OUTPUT_TOKEN_RESERVATION\` (headroom for the response), consistent with the rest of the module.
- **No explicit cap (0):** falls back to the window-derived budget instead of "no trim".
- **No model known:** preserves legacy caller-driven behavior.

Trimming mechanism (which messages drop) and H2 tool-pair safety (\`_strip_leading_orphan_tools\`) are untouched — only the budget is now model-aware.

## Tests

Baseline: **44 passed**. After (4 new focused tests): **48 passed**.

New tests (mock \`get_context_window\`):
- small-window (8k) model → long history trimmed even with the flat 100k cap;
- \`max_tokens_total=0\` + model → trims to the window-derived budget;
- large-window (200k) model → flat 100k cap honored, no over-trim (asserts \`trim(100000)\`);
- window-capped trim still never leaves a leading orphan tool_result (H2 preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNjPggRSVZ2xnLb7ZxWP5H