### PR TITLE
fix(ai): cap unbounded shell output into history (M1)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -347,6 +347,17 @@ def dispatch_action(action: Dict, ctx: ActionContext) -> Generator:
 		yield Warning(message=f"Unknown action: {action_type}", _context=context)
 
 
+def _truncate(text: str, max_chars: int) -> str:
+	"""Cap ``text`` to ~``max_chars``, keeping head + tail so both the start and the
+	final lines survive, with a clear marker for the dropped middle. Short text is
+	returned unchanged (no marker)."""
+	if len(text) <= max_chars:
+		return text
+	dropped = len(text) - max_chars
+	half = max_chars // 2
+	return f"{text[:half]}\n…(truncated {dropped} chars)…\n{text[-(max_chars - half):]}"
+
+
 def _format_action_error(e: Exception, max_chars: int = 400) -> str:
 	"""Build a concise, LLM-facing error string for a failed action dispatch.
 
@@ -366,8 +377,7 @@ def _format_action_error(e: Exception, max_chars: int = 400) -> str:
 	tb_tail = "\n".join(tb_lines[-6:]) if tb_lines else ""
 
 	detail = f"{head}\n{tb_tail}" if tb_tail else head
-	if len(detail) > max_chars:
-		detail = detail[:max_chars] + "…(truncated)"
+	detail = _truncate(detail, max_chars)
 	return (
 		f"Action failed with error: {detail}\n"
 		"Fix the issue and try again."
@@ -450,6 +460,12 @@ _MAX_CHILD_ITERATIONS = 25
 _MAX_SUBAGENT_DEPTH = 3
 _MAX_SUBAGENTS_PER_TURN = 5
 _SUBAGENT_TURN_LOCK = threading.Lock()
+
+# M1: cap shell stdout/stderr before it enters AI history so a command emitting
+# megabytes can't blow up the next prompt's token budget / memory. Larger than the
+# 400-char error cap because successful output carries more useful signal; head+tail
+# so the model still sees the start AND the final lines (often the result/error).
+_MAX_SHELL_OUTPUT_CHARS = 4000
 
 
 def _guard_subagent_fanout(ctx: "ActionContext", context: Dict) -> Optional["Warning"]:
@@ -685,6 +701,7 @@ def _handle_shell(action: Dict, ctx: ActionContext) -> Generator:
 			env=_sanitized_env()
 		)
 		output = result.stdout or result.stderr or "(no output)"
+		output = _truncate(output, _MAX_SHELL_OUTPUT_CHARS)  # M1: cap so it can't blow up history
 		yield Ai(content=output, ai_type="shell_output", _context=context)
 
 	except Exception as e:

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -13,6 +13,7 @@ if ADDONS_ENABLED['ai']:
 		_build_hooks_from_context, _coerce_finding_fields, _sanitize_child_opts,
 		_build_child_hooks_or_denial,
 		_MAX_CHILD_ITERATIONS, _MAX_SUBAGENT_DEPTH, _MAX_SUBAGENTS_PER_TURN,
+		_MAX_SHELL_OUTPUT_CHARS, _truncate,
 	)
 	from secator.output_types import Ai, Error, Info, Warning, Vulnerability, Url
 
@@ -186,6 +187,46 @@ class TestHandleShell(unittest.TestCase):
 		self.assertEqual(len(results), 2)
 		self.assertIsInstance(results[1], Error)
 		self.assertIn('failed', results[1].message)
+
+	@patch('secator.ai.actions.subprocess.run')
+	def test_shell_output_capped_when_over_limit(self, mock_run):
+		# M1: huge stdout must be truncated to <= cap + marker and carry the marker.
+		big = "HEAD_LINE\n" + ("x" * (_MAX_SHELL_OUTPUT_CHARS * 3)) + "\nTAIL_LINE"
+		mock_run.return_value = MagicMock(stdout=big, stderr='')
+		ctx = ActionContext(targets=['t.com'], model='m')
+
+		results = list(_handle_shell({'action': 'shell', 'command': 'dump'}, ctx))
+
+		content = results[1].content
+		self.assertLess(len(content), len(big))
+		# body is bounded by the cap (plus the short marker line)
+		self.assertLessEqual(len(content), _MAX_SHELL_OUTPUT_CHARS + 40)
+		self.assertIn('truncated', content)
+		# head + tail preserved so the model sees the start AND the final lines
+		self.assertIn('HEAD_LINE', content)
+		self.assertIn('TAIL_LINE', content)
+
+	@patch('secator.ai.actions.subprocess.run')
+	def test_shell_output_short_passes_through_unchanged(self, mock_run):
+		# M1: short output must pass through untouched (no marker).
+		mock_run.return_value = MagicMock(stdout='root\n', stderr='')
+		ctx = ActionContext(targets=['t.com'], model='m')
+
+		results = list(_handle_shell({'action': 'shell', 'command': 'whoami'}, ctx))
+
+		self.assertEqual(results[1].content, 'root\n')
+		self.assertNotIn('truncated', results[1].content)
+
+	def test_truncate_short_text_unchanged(self):
+		self.assertEqual(_truncate('short', 100), 'short')
+
+	def test_truncate_keeps_head_and_tail(self):
+		text = 'START' + ('m' * 500) + 'END'
+		out = _truncate(text, 100)
+		self.assertLessEqual(len(out), 100 + 40)
+		self.assertTrue(out.startswith('START'))
+		self.assertTrue(out.endswith('END'))
+		self.assertIn('truncated', out)
 
 	def test_shell_decrypts_command(self):
 		encryptor = MagicMock()


### PR DESCRIPTION
## Finding — M1: Unbounded shell output into history (P3, Robustness)

`_handle_shell` in `secator/ai/actions.py` ran the command and yielded its
stdout/stderr straight into AI history with **no length cap**:

```python
output = result.stdout or result.stderr or "(no output)"
yield Ai(content=output, ai_type="shell_output", _context=context)
```

Root cause: `secator/ai/actions.py:687-688` (pre-change). A command emitting
megabytes of stdout dumped it all into history → token blow-up / memory
pressure / API errors on the next LLM call. Note the asymmetry: error text was
already truncated by `_format_action_error(..., max_chars=400)`, but successful
stdout was not.

## Fix

- New module constant `_MAX_SHELL_OUTPUT_CHARS = 4000` — larger than the 400-char
  error cap because successful output carries more useful signal, but still
  bounded.
- Extracted a small shared `_truncate(text, max_chars)` helper (DRY): **head+tail**
  truncation keeping both the start AND the final lines (often where the
  result/error is) with a clear `…(truncated N chars)…` marker in the middle.
  Short text passes through unchanged (no marker).
- `_handle_shell` now truncates `output` before yielding.
- `_format_action_error` refactored to reuse `_truncate` instead of its own inline
  head-truncation (removes duplication; no test pinned the old marker).

Behavior preserved for short output and the `(no output)` fallback.
`_handle_shell` signature and the `Ai(ai_type="shell_output")` shape unchanged.

## Tests

`tests/unit/test_ai_actions.py`:
- large stdout → truncated to <= cap+marker, contains the truncation marker, and
  both first (`HEAD_LINE`) and last (`TAIL_LINE`) lines survive;
- short output passes through unchanged (no marker);
- unit tests on `_truncate` (short unchanged; head+tail preserved).

Counts: **baseline 71 passed → after 75 passed** (+4 new).

## Extra findings (flagged, NOT fixed)

Other unbounded content paths into AI history in the same file:
- `secator/ai/actions.py:940-951` `_handle_add_finding` yields
  `content=f'{str(finding)}'` uncapped.
- `secator/ai/actions.py:740-748` `_handle_query` yields each query result
  finding uncapped (count bounded by `limit`, default 100, but per-finding
  serialized size is not).

(Note: `secator/ai/history.py` has a separate token-level `truncate_to_tokens`
history cap; this M1 fix is the complementary action-level cap.)