### PR TITLE
fix(ai): give allow_all real session-wide scope vs one-shot allow (M12)

### DIFF
--- a/secator/ai/interactivity.py
+++ b/secator/ai/interactivity.py
@@ -136,10 +136,13 @@ class RemoteBackend(InteractivityBackend):
 
 		if prompt_type == "permission":
 			engine = context.get("engine")
-			if answer in ("allow", "allow_all") and engine:
-				ptype = context.get("permission_type")
-				value = context.get("value", "")
-				self._add_permission_rules(engine, ptype, value)
+			if answer in ("allow", "allow_all"):
+				# M12: allow_all persists a session-scoped allow rule; single allow is
+				# a true one-shot that adds NO rule (H9) — next match re-prompts.
+				if answer == "allow_all" and engine:
+					ptype = context.get("permission_type")
+					value = context.get("value", "")
+					self._add_permission_rules(engine, ptype, value)
 				return {"answer": "allow"}
 			return {"answer": "deny"}
 

--- a/tests/unit/test_ai_interactivity.py
+++ b/tests/unit/test_ai_interactivity.py
@@ -287,6 +287,77 @@ class TestRemoteBackend(unittest.TestCase):
 		backend = RemoteBackend(timeout=60, query_engine=None)
 		backend._expire_stale_pending("session1")  # must not raise
 
+	def _permission_backend(self, answer):
+		"""RemoteBackend whose poll resolves to `answer` for a shell prompt."""
+		from secator.ai.interactivity import RemoteBackend
+		mock_engine = MagicMock()
+		mock_engine.search.return_value = [{"answer": answer, "_timestamp": 1.0}]
+		return RemoteBackend(timeout=60, query_engine=mock_engine, poll_interval=0.01)
+
+	@staticmethod
+	def _shell_name_allowed(engine, cmd_name):
+		"""True if the engine auto-allows this shell command NAME (no re-prompt).
+
+		Asserted at the command-name layer (``_check_value``) rather than via
+		check_action() so the test does not depend on the safecmd/shfmt parser,
+		which is not present in every env. This is the exact layer a persisted
+		``shell(<cmd>)`` session rule matches on.
+		"""
+		return engine._check_value("shell", cmd_name).decision == "allow"
+
+	def test_allow_all_persists_session_rule_second_action_auto_allowed(self):
+		"""M12: allow_all adds a session-scoped rule; a 2nd matching action needs no prompt."""
+		from secator.ai.guardrails import PermissionEngine
+		engine = PermissionEngine(config={})  # no static rules: unknown cmd -> no auto-allow
+		backend = self._permission_backend("allow_all")
+
+		# Pre-condition: with no rule, the command name is not pre-allowed.
+		self.assertFalse(self._shell_name_allowed(engine, "nmap"))
+
+		result = backend.ask_user(
+			"Shell `nmap -sV` requires approval", ["deny", "allow", "allow_all"],
+			"session1", prompt_type="permission", engine=engine,
+			permission_type="shell", value="nmap -sV", prompt_uuid="u1",
+		)
+		self.assertEqual(result["answer"], "allow")
+		# A session-scoped shell(nmap) pattern rule must now be present.
+		self.assertTrue(
+			any(rt == "shell" and "nmap" in patterns for rt, patterns in engine.runtime_allow),
+			"allow_all must persist a session-scoped shell(nmap) rule",
+		)
+		# A SECOND, DIFFERENT nmap invocation is auto-allowed without a new prompt.
+		self.assertTrue(self._shell_name_allowed(engine, "nmap"))
+
+	def test_single_allow_does_not_persist_rule_second_action_reprompts(self):
+		"""M12/H9: single allow is one-shot — no rule added, a 2nd match re-prompts."""
+		from secator.ai.guardrails import PermissionEngine
+		engine = PermissionEngine(config={})
+		backend = self._permission_backend("allow")
+
+		result = backend.ask_user(
+			"Shell `nmap -sV` requires approval", ["deny", "allow", "allow_all"],
+			"session1", prompt_type="permission", engine=engine,
+			permission_type="shell", value="nmap -sV", prompt_uuid="u1",
+		)
+		self.assertEqual(result["answer"], "allow")
+		# No session rule was persisted -> a second matching action is not pre-allowed.
+		self.assertEqual(engine.runtime_allow, [])
+		self.assertFalse(self._shell_name_allowed(engine, "nmap"))
+
+	def test_deny_unchanged_no_rule(self):
+		"""deny returns deny and never touches runtime_allow."""
+		from secator.ai.guardrails import PermissionEngine
+		engine = PermissionEngine(config={})
+		backend = self._permission_backend("deny")
+
+		result = backend.ask_user(
+			"Shell `nmap` requires approval", ["deny", "allow", "allow_all"],
+			"session1", prompt_type="permission", engine=engine,
+			permission_type="shell", value="nmap", prompt_uuid="u1",
+		)
+		self.assertEqual(result["answer"], "deny")
+		self.assertEqual(engine.runtime_allow, [])
+
 
 class TestCreateBackend(unittest.TestCase):
 	"""Verify create_backend factory."""


### PR DESCRIPTION
## Finding — M12: \`allow_all\` == \`allow\` semantics (P2, Low)

\`RemoteBackend\` treated the two remote permission answers identically:
choosing "allow all" granted no broader scope than a single-invocation allow.

## Root cause

\`secator/ai/interactivity.py:139-144\` — \`RemoteBackend.ask_user\` called
\`_add_permission_rules\` for **both** \`allow\` and \`allow_all\`. Meanwhile H9
(\`guardrails.py:1014-1018\`) already defines the intended split for the CLI:
option 0 "Allow this command" adds **no** rule (one-shot), option 1 "Allow all"
adds a session rule. The remote path collapsed both into the same rule-adding
branch, so \`allow_all\` was no broader than \`allow\`.

## Fix

Gate rule persistence on \`allow_all\` only:

- \`allow\` (single) → returns allow for this invocation, adds **no** session
  rule (true one-shot, per H9 — the next matching action re-prompts).
- \`allow_all\` → persists the existing session-scoped **\`shell(<cmd>)\`** pattern
  rule via the unchanged \`_add_permission_rules\` → \`engine.add_runtime_allow\`.
  Subsequent matching commands are then auto-allowed at the command-name layer
  (\`_check_value("shell", ...)\`) without a new prompt.
- \`deny\` unchanged.

Reuses the existing rule-construction mechanism and the engine's existing
\`shell(<cmd>)\` / \`target(...)\` / \`read|write(...)\` shapes — no new rule grammar,
no cross-lane edit (guardrails.py untouched).

## Tests

Added to \`TestRemoteBackend\`:
- \`allow_all\` persists a session-scoped \`shell(nmap)\` rule → a 2nd, different
  nmap invocation is auto-allowed (asserted at \`_check_value\`, the name layer,
  to avoid the safecmd/shfmt parser dep absent in some envs).
- single \`allow\` persists **no** rule → 2nd match not pre-allowed (re-prompts;
  H9 one-shot preserved).
- \`deny\` unchanged, never touches \`runtime_allow\`.

Baseline: **29 passed**. After: **32 passed** (`tests/unit/test_ai_interactivity.py`).
\`ast.parse\` on \`interactivity.py\` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)