### PR TITLE
fix(ai): fix unsubstituted template vars + phantom tool in prompts (D1)

### DIFF
--- a/secator/ai/prompts.py
+++ b/secator/ai/prompts.py
@@ -241,13 +241,14 @@ def get_system_prompt(mode: str, workspace_path: str = "", backend=None) -> str:
 	system_prompt = mode_config["system_prompt"]
 	ws = workspace_path or "<workspace>"
 
-	path_vars = dict(tasks_path=str(TASKS_PATH), workflows_path=str(WORKFLOWS_PATH), profiles_path=str(PROFILES_PATH))
-	if mode == "attack":
-		result = system_prompt.safe_substitute(library_reference=build_library_reference(), **path_vars)
-	elif mode == "exploit":
-		result = system_prompt.safe_substitute(library_reference=build_library_reference(), **path_vars)
-	else:  # chat mode
-		result = system_prompt.safe_substitute(output_types_reference=build_output_types_reference())
+	# The queries.txt constraint (included by every mode) references $query_types and
+	# $output_types_reference, so they must be substituted for all modes — derive both
+	# from FINDING_TYPES so they never drift from the registry.
+	subst = dict(query_types=build_query_types(), output_types_reference=build_output_types_reference())
+	if mode in ("attack", "exploit"):
+		path_vars = dict(tasks_path=str(TASKS_PATH), workflows_path=str(WORKFLOWS_PATH), profiles_path=str(PROFILES_PATH))
+		subst.update(library_reference=build_library_reference(), **path_vars)
+	result = system_prompt.safe_substitute(**subst)
 
 	# Determine interaction rules based on backend
 	# The mode templates already include ${follow_up} for interactive modes.

--- a/secator/ai/prompts/constraints/common.txt
+++ b/secator/ai/prompts/constraints/common.txt
@@ -12,7 +12,7 @@ run_task(name="httpx", targets=["target3.com"], opts={"rate_limit": 30, "proxy":
 run_workflow(name="domain_recon", targets=["example.com"])
 run_shell(command="curl -sk https://10.0.0.1/ | head -50")
 run_task(name="ai", targets=["example.com"], opts={"prompt": "Enumerate subdomains", "mode": "attack", "session_name": "Subdomain enumeration on example.com", "max_iterations": 5})
-run_query(query={'vulnerability': {'severity': {'$in': ['high', 'critical']})
+query_workspace(query={"_type": "vulnerability", "severity": {"$in": ["high", "critical"]}})
 add_finding(name="XSS vuln", matched_at=["http://testphp.vulnweb.com/hpp/?pp=1"], )
 </correct>
 

--- a/tests/unit/test_ai_prompts.py
+++ b/tests/unit/test_ai_prompts.py
@@ -281,6 +281,33 @@ class TestPrompts(unittest.TestCase):
 		self.assertNotIn("NEVER INVENT", COMMON_RULES)
 		self.assertNotIn("ALWAYS provide", COMMON_RULES)
 
+	# === Template-drift regression tests (D1) ===
+
+	def test_rendered_prompts_have_no_unsubstituted_template_vars(self):
+		"""Rendered prompts must not leak $query_types / $output_types_reference (D1)."""
+		for mode in ("attack", "chat", "exploit"):
+			prompt = get_system_prompt(mode)
+			self.assertNotIn("$query_types", prompt, f"$query_types leaked in {mode!r} prompt")
+			self.assertNotIn("$output_types_reference", prompt, f"$output_types_reference leaked in {mode!r} prompt")
+
+	def test_rendered_prompts_substitute_query_types_from_registry(self):
+		"""$query_types renders to the real FINDING_TYPES names, not a placeholder."""
+		from secator.ai.prompts import build_query_types
+		expected = build_query_types()
+		self.assertIn("vulnerability", expected)
+		for mode in ("attack", "chat", "exploit"):
+			self.assertIn(expected, get_system_prompt(mode))
+
+	def test_rendered_prompts_have_no_phantom_run_query_tool(self):
+		"""Examples must call the real query_workspace tool, never a phantom run_query (D1)."""
+		from secator.ai.tools import TOOL_ACTION_MAP
+		self.assertEqual(TOOL_ACTION_MAP["query_workspace"], "query")
+		self.assertNotIn("run_query", TOOL_ACTION_MAP)
+		for mode in ("attack", "chat", "exploit"):
+			prompt = get_system_prompt(mode)
+			self.assertNotIn("run_query", prompt, f"phantom run_query in {mode!r} prompt")
+			self.assertIn("query_workspace", prompt)
+
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Finding **D1 — Prompt template/tool drift** (P4 Pertinence).

## Problem
1. **Unsubstituted template vars.** `constraints/queries.txt` (included by every mode) references `$query_types` and `$output_types_reference`, but `get_system_prompt` only substituted `output_types_reference` in *chat* mode and `query_types` in **no** mode. Result: the rendered system prompt leaked literal `$query_types` (all 3 modes) and `$output_types_reference` (attack + exploit) to the LLM.
2. **Phantom tool.** `constraints/common.txt` `<correct>` example taught `run_query(...)` — a tool that does not exist. The real tool is `query_workspace` (`TOOL_ACTION_MAP["query_workspace"] == "query"`). The example JSON was also malformed (unbalanced braces, wrong `_type` shape).

## Fix
- `secator/ai/prompts.py` `get_system_prompt`: build one substitution dict with `query_types=build_query_types()` and `output_types_reference=build_output_types_reference()` for **all** modes (library_reference/path_vars still only for attack/exploit). Values derive from `FINDING_TYPES`, so no hardcoded list to drift. Uses existing `safe_substitute`.
- `secator/ai/prompts/constraints/common.txt:15`: `run_query({...})` -> `query_workspace(query={"_type": "vulnerability", "severity": {"$in": ["high", "critical"]}})`, matching the `query_workspace` examples already in `queries.txt`.

## Value sources
- `$query_types` <- `build_query_types()` (comma-joined `cls.get_name()` over `FINDING_TYPES`).
- `$output_types_reference` <- `build_output_types_reference()` (same registry).
- Real tool name confirmed against `secator/ai/tools.py` `TOOL_ACTION_MAP` (read-only).

## Tests
`tests/unit/test_ai_prompts.py`: **38 -> 41 passed**. Added 3 regression tests asserting every mode renders with no `$query_types`/`$output_types_reference`, that `query_types` renders to real registry names, and that prompts reference `query_workspace` not `run_query`.

Rendered-prompt check before/after:

| mode | `$query_types` | `$output_types_reference` | `run_query` |
|------|------|------|------|
| before (all) | leaked | leaked (attack/exploit) | present |
| after (all) | gone | gone | gone (query_workspace) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)