### PR TITLE
fix(ai): gate privileged add_finding types at the guardrail (M7)

### DIFF
--- a/secator/ai/guardrails.py
+++ b/secator/ai/guardrails.py
@@ -664,6 +664,17 @@ class PermissionResult:
 	shell_command: str = ""  # full command when prompting for shell approval
 
 
+# M7: finding types downstream auto-trusts. tasks/ai.py _auto_approve_workspace_targets()
+# searches _type:"target" findings and auto-approves them as in-scope, so an injected
+# add_finding of one of these silently widens scope.
+_PRIVILEGED_FINDING_TYPES = frozenset({"target"})
+
+
+def _is_privileged_finding_type(action: Dict) -> bool:
+	"""True if an add_finding action would mint a downstream-trusted (scope-widening) finding."""
+	return str(action.get("_type", "")).strip().lower() in _PRIVILEGED_FINDING_TYPES
+
+
 class PermissionEngine:
 	"""Evaluate AI actions against allow/deny/ask permission rules.
 
@@ -824,6 +835,13 @@ class PermissionEngine:
 			name = action.get("name", "")
 			return self._check_value(action_type, name)
 		elif action_type in ("query", "follow_up", "add_finding"):
+			# M7: don't let injected add_finding mint a trusted target that auto-approve later trusts
+			if action_type == "add_finding" and _is_privileged_finding_type(action):
+				ftype = str(action.get("_type", "")).strip().lower()
+				return PermissionResult(
+					decision="ask",
+					reason=f"add_finding of privileged type '{ftype}' requires approval",
+				)
 			return PermissionResult(decision="allow", reason=f"{action_type} is always allowed")
 		return PermissionResult(decision="deny", reason=f"Unknown action type: {action_type}")
 

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -259,6 +259,23 @@ class TestPermissionEngine(unittest.TestCase):
 		result = engine.check_action({"action": "follow_up", "reason": "test"})
 		self.assertEqual(result.decision, "allow")
 
+	# --- M7: add_finding privileged-type gating ---
+
+	def test_add_finding_benign_allowed(self):
+		engine = self._make_engine()
+		result = engine.check_action({"action": "add_finding", "_type": "vulnerability", "name": "XSS"})
+		self.assertEqual(result.decision, "allow")
+
+	def test_add_finding_target_type_not_allowed(self):
+		engine = self._make_engine()
+		result = engine.check_action({"action": "add_finding", "_type": "target", "name": "evil.com"})
+		self.assertEqual(result.decision, "ask")
+
+	def test_add_finding_target_type_case_insensitive(self):
+		engine = self._make_engine()
+		result = engine.check_action({"action": "add_finding", "_type": " Target ", "name": "evil.com"})
+		self.assertEqual(result.decision, "ask")
+
 	# --- Target checks ---
 
 	def test_target_allowed_via_targets_variable(self):


### PR DESCRIPTION
## M7 (P1, Security): \`add_finding\`/\`query\` unconditionally allowed

**Finding:** Injected/scanned content can drive the AI to write a \`_type:"target"\` finding that auto-approve later trusts, silently widening scope with no prompt.

**Root cause:** \`secator/ai/guardrails.py:826-827\` blanket-allowed \`add_finding\` (alongside \`query\`/\`follow_up\`):
\`\`\`python
elif action_type in ("query", "follow_up", "add_finding"):
    return PermissionResult(decision="allow", reason=f"{action_type} is always allowed")
\`\`\`

**What "privileged/trusted" means downstream:** \`secator/tasks/ai.py:538-556\` \`_auto_approve_workspace_targets()\` runs \`QueryEngine.search({"_type": "target"}, limit=1000)\` and passes every hit to \`permission_engine.add_runtime_allow([...])\`. So any \`target\`-typed finding in the workspace is auto-approved as in-scope on the next turn. An injected \`add_finding\` of that type therefore smuggles a new trusted target and widens scope.

## Fix
Small guardrail-layer defense (defense-in-depth). New module-level predicate:
\`\`\`python
_PRIVILEGED_FINDING_TYPES = frozenset({"target"})

def _is_privileged_finding_type(action: Dict) -> bool:
    return str(action.get("_type", "")).strip().lower() in _PRIVILEGED_FINDING_TYPES
\`\`\`
The decision branch now returns \`ask\` (engine vocabulary, reuses \`PermissionResult\`) when an \`add_finding\` would mint a privileged/trusted type. It reads \`_type\` straight off the action dict the engine already receives — no \`actions.py\` change needed. Benign/info \`add_finding\` stays \`allow\`; read-only \`query\` and engine-internal \`follow_up\` are untouched.

## Tests
- New (proven, no shfmt needed): \`test_add_finding_target_type_not_allowed\` (→ ask), \`test_add_finding_target_type_case_insensitive\` (→ ask), \`test_add_finding_benign_allowed\` (vulnerability → allow); existing \`query\`/\`follow_up\` allow tests still pass.
- Baseline vs after: \`57 failed, 91 passed\` → \`57 failed, 94 passed\`. The 57 failures are pre-existing and **byte-identical** before/after (environmental \`shfmt\`/\`safecmd\`-gated \`TestEdgeCases\` shell-parsing tests) — not regressions. AST parse OK.

## Related trust smell (flagged, not fixed here — cross-lane)
\`secator/tasks/ai.py:538-556\` is the sink that auto-trusts \`_type:"target"\` findings. Note \`_handle_add_finding\` (\`secator/ai/actions.py:466-467\`) strips \`_type\` from \`finding_data\` and \`type_map\` only covers \`FINDING_TYPES\` (no \`Target\`), so today it can't build a literal Target — but this guardrail closes the intent path as defense-in-depth. AI-origin findings also aren't tagged distinctly from tool-discovered ones (\`actions.py:519-524\`), so downstream can't tell them apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)