### PR TITLE
refactor(ai): cheap fast-path for mode detection, LLM only when ambiguous (D4)

### DIFF
--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -29,6 +29,37 @@ from secator.ai.session import save_history, show_session_picker, replay_session
 from secator.ai.utils import call_llm, init_llm, setup_ai, format_llm_status
 
 
+# D4: high-precision cues for the deterministic mode fast-path. Only unambiguous
+# prompts (cues for exactly one of attack/chat, and no exploit-ish cue) are
+# resolved here; everything else defers to the LLM classifier.
+_ATTACK_CUES = (
+	"scan", "pentest", "pen test", "enumerate", "enumeration", "recon",
+	"brute", "bruteforce", "fuzz", "attack", "nmap", "nuclei", "subdomain", "hack",
+)
+_CHAT_CUES = (
+	"summarize", "summary", "explain", "what is", "what are", "what's",
+	"how do", "how does", "tell me", "describe", "list the", "show me", "?",
+)
+_EXPLOIT_CUES = ("exploit", "poc", "proof of concept", "cve-", "vulnerabilit")
+
+
+def fast_detect_mode(prompt):
+	"""D4: cheap deterministic pre-classifier. Returns 'attack'/'chat' for
+	unambiguous prompts, else None to defer to the LLM. Exploit-ish prompts
+	return None so the LLM keeps deciding those (no behavior change there)."""
+	text = (prompt or "").strip().lower()
+	if not text:
+		return "chat"
+	if any(cue in text for cue in _EXPLOIT_CUES):
+		return None
+	has_attack = any(cue in text for cue in _ATTACK_CUES)
+	has_chat = any(cue in text for cue in _CHAT_CUES)
+	if has_attack and not has_chat:
+		return "attack"
+	if has_chat and not has_attack:
+		return "chat"
+	return None
+
 
 @task()
 class ai(PythonRunner):
@@ -717,21 +748,27 @@ class ai(PythonRunner):
 		if not self.prompt:
 			self.mode = "chat"
 			return
-		try:
-			selection_prompt = load_prompt("modes/_selection.txt")
-			messages = [{"role": "user", "content": f"{selection_prompt}\n{self.prompt}"}]
-			with maybe_status("[bold orange3]Detecting intent...[/]", spinner="dots"):
-				result = call_llm(messages, self.intent_model, temperature=0.3, api_base=self.api_base, api_key=self.api_key)
-			self._account_usage(result.get("usage"))
-			mode = result["content"].strip().lower()
-			if mode in ("attack", "chat"):
-				console.print(rf"[bold green]\[INF][/] Detected intent: [bold]{mode}[/]")
-				self.mode = mode
-			else:
-				self.mode = old_mode or "chat"
-		except Exception:
-			console.print(Warning(message='Could not detect mode using LLM. Falling back to "chat" mode.'))
-			self.mode = "chat"
+		# D4: resolve unambiguous prompts deterministically; skip the intent LLM round-trip.
+		fast_mode = fast_detect_mode(self.prompt)
+		if fast_mode:
+			console.print(rf"[bold green]\[INF][/] Detected intent: [bold]{fast_mode}[/] (fast-path)")
+			self.mode = fast_mode
+		else:
+			try:
+				selection_prompt = load_prompt("modes/_selection.txt")
+				messages = [{"role": "user", "content": f"{selection_prompt}\n{self.prompt}"}]
+				with maybe_status("[bold orange3]Detecting intent...[/]", spinner="dots"):
+					result = call_llm(messages, self.intent_model, temperature=0.3, api_base=self.api_base, api_key=self.api_key)  # noqa: E501
+				self._account_usage(result.get("usage"))
+				mode = result["content"].strip().lower()
+				if mode in ("attack", "chat"):
+					console.print(rf"[bold green]\[INF][/] Detected intent: [bold]{mode}[/]")
+					self.mode = mode
+				else:
+					self.mode = old_mode or "chat"
+			except Exception:
+				console.print(Warning(message='Could not detect mode using LLM. Falling back to "chat" mode.'))
+				self.mode = "chat"
 		if not self.mode:
 			self.mode = "chat"
 		mode_max = get_mode_config(self.mode).get("max_iterations", self.max_iterations)

--- a/tests/unit/test_ai_session.py
+++ b/tests/unit/test_ai_session.py
@@ -292,5 +292,82 @@ class TestTurnIdempotency(unittest.TestCase):
 		self.assertEqual(persisted, [])
 
 
+class TestFastDetectMode(unittest.TestCase):
+	"""D4: the deterministic mode fast-path skips the intent LLM round-trip for
+	unambiguous prompts, while ambiguous ones still fall back to the LLM."""
+
+	def test_fast_detect_mode_pure(self):
+		from secator.tasks.ai import fast_detect_mode
+		self.assertEqual(fast_detect_mode("scan the target"), "attack")
+		self.assertEqual(fast_detect_mode("summarize the findings"), "chat")
+		self.assertEqual(fast_detect_mode(""), "chat")
+		# exploit-ish → defer to LLM (no behavior change for those)
+		self.assertIsNone(fast_detect_mode("write an exploit for this CVE-2024-1234"))
+		# conflicting cues → ambiguous → defer to LLM
+		self.assertIsNone(fast_detect_mode("scan and explain the results"))
+		# no cues → ambiguous → defer to LLM
+		self.assertIsNone(fast_detect_mode("please handle the situation"))
+
+	def _make_task(self, prompt, mode=""):
+		from secator.tasks.ai import ai
+		task = ai.__new__(ai)
+		task.mode = mode
+		task.prompt = prompt
+		task.intent_model = "intent-model"
+		task.model = "main-model"
+		task.api_base = None
+		task.api_key = None
+		task.max_iterations = 10
+		task.is_subagent = False
+		task.backend = MagicMock()
+		task._reports_folder = tempfile.mkdtemp(prefix="secator-test-")
+		task._account_usage = MagicMock()
+		return task
+
+	def _patches(self):
+		return (
+			patch("secator.tasks.ai.get_system_prompt", return_value="SYS"),
+			patch("secator.tasks.ai.build_tool_schemas", return_value=[]),
+			patch("secator.tasks.ai.get_mode_config", return_value={"max_iterations": 5}),
+		)
+
+	def test_fast_path_resolves_without_llm(self):
+		"""Unambiguous prompt → mode set deterministically, call_llm untouched."""
+		task = self._make_task("scan the target")
+		p_sys, p_tools, p_cfg = self._patches()
+		with p_sys, p_tools, p_cfg, patch("secator.tasks.ai.call_llm") as mock_llm:
+			task._detect_mode()
+		mock_llm.assert_not_called()
+		self.assertEqual(task.mode, "attack")
+
+	def test_ambiguous_falls_back_to_llm(self):
+		"""Conflicting cues → the LLM classifier still runs and decides."""
+		task = self._make_task("scan and explain the results")
+		p_sys, p_tools, p_cfg = self._patches()
+		with p_sys, p_tools, p_cfg, \
+				patch("secator.tasks.ai.load_prompt", return_value="SELECT"), \
+				patch("secator.tasks.ai.call_llm", return_value={"content": "chat", "usage": {}}) as mock_llm:
+			task._detect_mode()
+		mock_llm.assert_called_once()
+		self.assertEqual(mock_llm.call_args[0][1], "intent-model")  # uses intent_model
+		self.assertEqual(task.mode, "chat")
+
+	def test_force_redetects_over_explicit_mode(self):
+		"""force=True re-detects even when mode was explicitly set (fast-path applies)."""
+		task = self._make_task("scan the target", mode="chat")
+		p_sys, p_tools, p_cfg = self._patches()
+		# Without force, explicit mode short-circuits (no detection, no LLM).
+		with p_sys, p_tools, p_cfg, patch("secator.tasks.ai.call_llm") as mock_llm:
+			task._detect_mode()
+			self.assertEqual(task.mode, "chat")
+			mock_llm.assert_not_called()
+		# With force, detection runs again → fast-path flips to attack.
+		p_sys, p_tools, p_cfg = self._patches()
+		with p_sys, p_tools, p_cfg, patch("secator.tasks.ai.call_llm") as mock_llm:
+			task._detect_mode(force=True)
+			self.assertEqual(task.mode, "attack")
+			mock_llm.assert_not_called()
+
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Finding (D4, P4 Design/Pertinence)
`_detect_mode` (`secator/tasks/ai.py`) made a **separate `call_llm(..., self.intent_model, ...)` round-trip** purely to classify the user's prompt into a mode — an extra LLM call (latency + tokens) for what is essentially a small 2-way (attack/chat) classification.

## What this does
Adds a cheap **deterministic fast-path** (`fast_detect_mode`) run before the LLM:
- **Resolves without any LLM call**: unambiguous prompts that hit high-precision cues for exactly one of `attack`/`chat` (e.g. "scan the target" → attack, "summarize the findings" → chat), and empty prompts → chat.
- **Still hits the LLM** (unchanged behavior): ambiguous prompts (cues for both / no cues) and any **exploit-ish** prompt (`exploit`, `poc`, `cve-`, `vulnerabilit`) defer to the existing `call_llm` classifier. The LLM keeps deciding every case the heuristic isn't confident about, so mode-detection quality is preserved.

The shared tail (max_iterations / system_prompt / tool_schemas) runs for both paths (DRY).

## What I did NOT change
- **`intent_model` opt/config kept** — still referenced by `config.py` and the setup wizard (`ai/utils.py`) and used on the LLM fallback. Removing it would be riskier config-surface churn; out of scope for a conservative P4.
- The explicit-mode short-circuit and **`force=True` re-detection** semantics are unchanged.
- Did **not** touch `prompts.py` / `_selection.txt` or exploit-mode wiring.

## Tests
`tests/unit/test_ai_session.py::TestFastDetectMode` (4 new):
- fast-path resolves attack/chat **without** calling `call_llm` (`assert_not_called`);
- ambiguous input **falls back** to the LLM (`assert_called_once`, still uses `intent_model`);
- `force=True` re-detects over an explicit mode;
- pure `fast_detect_mode` cue/ambiguity/exploit-defer logic.

Baseline vs after (`test_ai_loop.py` + `test_ai_session.py`): baseline **12 failed / 40 passed** → after **12 failed / 44 passed**. The 12 failures are pre-existing and identical (unrelated to intent detection); +4 are the new tests.

## Related smell (NOT fixed here — flagged)
- **D2**: `_detect_mode` (`secator/tasks/ai.py:727`) only accepts `("attack", "chat")` and **discards `exploit`**, even though `modes/_selection.txt` classifies into attack/chat/**exploit** and `MODES` (`ai/prompts.py:70`) defines an `exploit` mode. An exploit-classified prompt falls back to `old_mode or "chat"`. Left for the D2 exploit-wiring lane.