### PR TITLE
chore(ai): remove vestigial code (D3)

### DIFF
--- a/secator/ai/tools.py
+++ b/secator/ai/tools.py
@@ -13,9 +13,6 @@ TOOL_ACTION_MAP = {
 	"stop": "stop",
 }
 
-# Reverse mapping: action type -> tool name
-ACTION_TOOL_MAP = {v: k for k, v in TOOL_ACTION_MAP.items()}
-
 # OpenAI-format tool schemas keyed by tool name
 TOOL_SCHEMAS = {
 	"run_task": {

--- a/secator/ai/utils.py
+++ b/secator/ai/utils.py
@@ -661,8 +661,3 @@ def prompt_user(history, encryptor=None, max_iterations=10, choices=None,
 		return None
 	except (KeyboardInterrupt, EOFError):
 		return None
-
-
-def _maybe_encrypt(text, encryptor):
-	"""Encrypt text if encryptor is available, otherwise return as-is."""
-	return encryptor.encrypt(text) if encryptor else text

--- a/secator/output_types/ai.py
+++ b/secator/output_types/ai.py
@@ -162,11 +162,10 @@ class Ai(OutputType):
 			action_label_str = action_label.capitalize().replace('_', ' ')
 			line = f'{s}[bold blue]{action_label_str}[/]'
 			content = _s(self.content)
-			if self.ai_type in ['task', 'workflow', 'scan']:
+			if self.ai_type in ['task', 'workflow']:
 				colors = {
 					'task': 'bold gold3',
 					'workflow': 'bold dark_orange3',
-					'scan': 'bold red',
 				}
 				color = colors[self.ai_type]
 				content = f'[{color}]{content}[/]'


### PR DESCRIPTION
## D3 — Dead/vestigial code (P4)

Pure deletions, no behavior change. Each removal proven unreferenced via `git grep -nw` across `secator/` and `tests/`.

| Candidate | File:line | Refs (excl. own def) | Action |
|---|---|---|---|
| `ACTION_TOOL_MAP` | `secator/ai/tools.py:17` | 0 | **Removed** |
| `_maybe_encrypt` (orphan dup) | `secator/ai/utils.py:666` | 0 callers | **Removed** |
| `'scan'` render branch | `secator/output_types/ai.py:165,169` | never set as `ai_type`; not in `ACTION_TYPES` → unreachable | **Removed** |
| `maybe_encrypt` (real helper) | `secator/ai/encryption.py:48` | 15+ callers (session, tasks/ai) | **Kept** (live) |
| `Ai` data fields (`choices`, `status`, `session_id`, `_related`, `_uuid`, `_duplicate`, `summary`, `answer`, ...) | `secator/output_types/ai.py` | read in tasks/ai, actions, runners/_base + serialized OutputType schema | **Kept** (live / serialized) |

### Evidence
- `ACTION_TOOL_MAP`: `git grep -nw ACTION_TOOL_MAP` → only its own definition.
- `_maybe_encrypt`: `git grep -nw _maybe_encrypt` → only the definition; the used helper is `maybe_encrypt` (no underscore) in `encryption.py`.
- `'scan'`: only appears inside the render branch; the enclosing `if self.ai_type in ACTION_TYPES:` (`task, workflow, shell, add_finding, query, stopped`) never admits `'scan'`, and `'scan'` is not a configured `AI_TYPES` key.

### Ai fields — kept (conservative)
The `Ai` dataclass fields are part of the persisted/serialized `OutputType` schema and several are read at runtime (`choices`/`status` in `tasks/ai.py`, `session_id` in `actions.py`, `_related`/`_uuid`/`_duplicate` in `runners/_base.py`). Removing any could break UI/DB contracts, so none were touched.

### Verification
- **Tests** (`pytest tests/unit/ -k ai`): baseline **70 failed / 484 passed** → after **70 failed / 484 passed** — failing set byte-identical (pre-existing env failures, unrelated to this change).
- **Import smoke**: `import secator.ai.tools, secator.ai.utils, secator.tasks.ai, secator.ai.actions` → OK.
- **Compile**: `ast.parse` on all three touched files → OK.

### Extra finding (out of lane — not fixed here)
- `secator/ai/prompts.py:264-281` — a fully commented-out `format_user_initial(...)` function (docstring + body). Dead commentary; candidate for a later cleanup in the prompts lane.