### PR TITLE
fix(ai): extensible exec-wrapper peeling closes the C2 laundering class (M11)

### DIFF
--- a/secator/ai/guardrails.py
+++ b/secator/ai/guardrails.py
@@ -37,10 +37,51 @@ OUTPUT_FLAG_COMMANDS = {
 
 # Exec-wrappers run a *different* command passed as args (`timeout 60 rm -rf /`),
 # so we peel the wrapper and check the INNER command, not the allow-listed name (C2).
+# M11: any wrapper NOT peeled reopens the C2 laundering class (`proxychains curl evil`,
+# `firejail rm -rf /`, `flock /tmp/x curl ...`), so the set is broadened + config-extensible.
 EXEC_WRAPPERS = frozenset({
 	"timeout", "xargs", "env", "nice", "ionice", "nohup", "stdbuf",
 	"setsid", "sudo", "doas", "watch", "time", "chroot", "unbuffer",
+	# M11: added laundering-vector wrappers
+	"flock", "runuser", "su", "script", "proxychains", "proxychains4",
+	"firejail", "torsocks", "torify", "unshare", "catchsegv", "chrt", "taskset",
 })
+
+# M11: per-wrapper arg grammar so the REAL command is located, not a lockfile/config/user.
+# (opts_taking_a_value, positional_args_before_cmd, cmd_string_opts) — cmd_string_opts values
+# (e.g. `-c 'curl evil'`) are re-parsed and peeled so the payload is checked, not skipped.
+_EMPTY = frozenset()
+_WRAPPER_ARG_GRAMMAR = {
+	"flock":        (frozenset({"-w", "--timeout", "-E", "--conflict-exit-code"}), 1, frozenset({"-c", "--command"})),
+	"runuser":      (frozenset({"-u", "--user", "-g", "--group", "-G", "--supp-group", "-s", "--shell"}), 0, frozenset({"-c", "--command"})),  # noqa: E501
+	"su":           (frozenset({"-s", "--shell", "-g", "--group", "-G", "--supp-group"}), 1, frozenset({"-c", "--command"})),
+	"script":       (_EMPTY, 0, frozenset({"-c", "--command"})),
+	"proxychains":  (frozenset({"-f"}), 0, _EMPTY),
+	"proxychains4": (frozenset({"-f"}), 0, _EMPTY),
+	"sudo":         (frozenset({"-u", "--user", "-g", "--group", "-U", "-C", "-p", "-r", "-t", "-T"}), 0, _EMPTY),
+}
+
+
+def _exec_wrappers() -> frozenset:
+	"""M11: built-in wrappers plus any ops-configured extras. Config EXTENDS the security baseline."""
+	try:
+		from secator.config import CONFIG
+		extra = getattr(CONFIG.addons.ai, "exec_wrappers", None) or []
+		extra = {str(w).strip() for w in extra if str(w).strip()}
+		if extra:
+			return EXEC_WRAPPERS | extra
+	except Exception:
+		pass
+	return EXEC_WRAPPERS
+
+
+def _split_cmd_string(s: str) -> List[str]:
+	"""Best-effort tokenize a `-c '<cmd>'` payload so the nested command can be re-checked."""
+	import shlex
+	try:
+		return shlex.split(s)
+	except ValueError:
+		return s.split()
 
 
 def parse_rule(rule: str) -> Tuple[str, List[str]]:
@@ -356,18 +397,36 @@ def _peel_wrapper(args: List[str]) -> List[str]:
 
 	Bare `env`/`sudo` (no inner command) is returned as-is so it's still checked by name.
 	"""
+	wrappers = _exec_wrappers()
 	tokens = args
 	for _ in range(len(args)):  # bounded peels (guards against pathological nesting)
 		if not tokens:
 			return tokens
 		name = tokens[0].rsplit('/', 1)[-1]
-		if name not in EXEC_WRAPPERS:
+		if name not in wrappers:
 			return tokens
 		rest = tokens[1:]
+		# M11: peel proxychains/firejail/flock/runuser/... past their OWN args (value-opts,
+		# positional lockfile/config, `-c '<cmd>'`) so the leaf payload is what gets classified.
+		opts_with_val, n_pos, cmd_opts = _WRAPPER_ARG_GRAMMAR.get(name, (_EMPTY, 0, _EMPTY))
 		i = 0
+		pos_seen = 0
 		while i < len(rest):
 			tok = rest[i]
+			if tok == '--':  # end-of-options: the inner command starts next
+				i += 1
+				break
+			if tok in cmd_opts and i + 1 < len(rest):  # `-c '<cmd>'` — re-parse & peel the nested payload
+				nested = _split_cmd_string(rest[i + 1])
+				return _peel_wrapper(nested) if nested else tokens
+			if tok in opts_with_val and i + 1 < len(rest):  # option that consumes its value
+				i += 2
+				continue
 			if tok.startswith('-') or _is_wrapper_operand(tok):
+				i += 1
+				continue
+			if pos_seen < n_pos:  # wrapper's own positional (flock lockfile / su user)
+				pos_seen += 1
 				i += 1
 				continue
 			break

--- a/secator/config.py
+++ b/secator/config.py
@@ -245,6 +245,7 @@ class AiAddon(StrictModel):
 	context_window: int = Field(default=128_000, ge=1)
 	user_response_timeout: int = 600
 	encrypt_pii: bool = True
+	exec_wrappers: List[str] = []  # M11: extra exec-wrappers to peel (extends the built-in security baseline)
 	permissions: Dict = {
 		'allow': [
 			'target({targets})',

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -10,7 +10,7 @@ if ADDONS_ENABLED['ai']:
 	from secator.ai.guardrails import (
 		parse_rule, match_rule, extract_command_targets, detect_paths, detect_paths_with_access,
 		detect_sensitive_env_vars, classify_command, build_target_choices, PermissionEngine,
-		_is_file_path, _normalize_ip
+		_is_file_path, _normalize_ip, _peel_wrapper, _exec_wrappers, EXEC_WRAPPERS
 	)
 	from secator.output_types import Warning, Error
 
@@ -1192,6 +1192,95 @@ class TestOutputFlagWrites(unittest.TestCase):
 		"""Redirect classification is preserved alongside the new flag handling."""
 		paths = self._paths(["echo", "x"], redirects=[("", "/etc/y")])
 		self.assertIn(("/etc/y", "write"), paths)
+
+
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestWrapperPeelingM11(unittest.TestCase):
+	"""M11: broadened + arg-grammar-aware exec-wrapper peeling closes the C2 laundering class.
+
+	The `_peel_wrapper` assertions are PROVEN (they take a token list — no shfmt needed).
+	The `check_action` integration assertions stub `extract_commands` (real shfmt is absent
+	in CI-less envs, which no-ops every parser-dependent test), same pattern as
+	TestOutputFlagWrites."""
+
+	# --- PROVEN: peel locates the leaf command past each wrapper's own arg grammar ---
+
+	def test_proxychains_peels_to_inner(self):
+		self.assertEqual(_peel_wrapper(["proxychains", "curl", "http://evil"]), ["curl", "http://evil"])
+
+	def test_proxychains_config_flag_consumed(self):
+		self.assertEqual(_peel_wrapper(["proxychains", "-f", "/etc/pc.conf", "dd"]), ["dd"])
+
+	def test_firejail_peels_past_long_opts(self):
+		self.assertEqual(_peel_wrapper(["firejail", "--net=none", "rm", "-rf", "/tmp/x"]), ["rm", "-rf", "/tmp/x"])
+
+	def test_flock_lockfile_positional_consumed(self):
+		self.assertEqual(_peel_wrapper(["flock", "/tmp/l", "curl", "http://evil"]), ["curl", "http://evil"])
+
+	def test_flock_value_opt_then_lockfile(self):
+		self.assertEqual(_peel_wrapper(["flock", "-w", "5", "/tmp/l", "dd"]), ["dd"])
+
+	def test_runuser_cmd_string_reparsed(self):
+		self.assertEqual(_peel_wrapper(["runuser", "-c", "curl http://evil"]), ["curl", "http://evil"])
+
+	def test_runuser_user_then_dashdash(self):
+		self.assertEqual(_peel_wrapper(["runuser", "-u", "bob", "--", "curl", "http://evil"]), ["curl", "http://evil"])
+
+	def test_su_user_positional_and_cmd_string(self):
+		self.assertEqual(_peel_wrapper(["su", "root", "-c", "dd if=/dev/zero"]), ["dd", "if=/dev/zero"])
+
+	def test_script_cmd_string_reparsed(self):
+		self.assertEqual(_peel_wrapper(["script", "-c", "curl http://evil", "/tmp/log"]), ["curl", "http://evil"])
+
+	def test_torsocks_peels_to_inner(self):
+		self.assertEqual(_peel_wrapper(["torsocks", "curl", "http://evil"]), ["curl", "http://evil"])
+
+	def test_sudo_user_value_opt_consumed(self):
+		# pre-existing C2 gap: `sudo -u bob` mis-read `bob` as the command; grammar now consumes it
+		self.assertEqual(_peel_wrapper(["sudo", "-u", "bob", "rm", "-rf", "/"]), ["rm", "-rf", "/"])
+
+	# --- PROVEN: C2-covered wrappers + normal commands unchanged ---
+
+	def test_c2_timeout_still_peels(self):
+		self.assertEqual(_peel_wrapper(["timeout", "60", "rm", "-rf", "/"]), ["rm", "-rf", "/"])
+
+	def test_c2_interpreter_gate_preserved(self):
+		# bash is NOT a wrapper — it stays the leaf so its ask-gate still fires
+		self.assertEqual(_peel_wrapper(["timeout", "60", "bash", "-c", "rm -rf /"]), ["bash", "-c", "rm -rf /"])
+
+	def test_normal_command_untouched(self):
+		self.assertEqual(_peel_wrapper(["curl", "http://ok"]), ["curl", "http://ok"])
+
+	def test_bare_wrapper_checked_by_name(self):
+		self.assertEqual(_peel_wrapper(["sudo"]), ["sudo"])
+
+	# --- PROVEN: config EXTENDS the built-in baseline (never shrinks below it) ---
+
+	def test_config_added_wrapper_honored(self):
+		try:
+			CONFIG.addons.ai.exec_wrappers = ["myrunner"]
+			self.assertIn("myrunner", _exec_wrappers())
+			self.assertTrue(EXEC_WRAPPERS <= _exec_wrappers())  # baseline is the floor
+			self.assertEqual(_peel_wrapper(["myrunner", "dd", "if=/dev/zero"]), ["dd", "if=/dev/zero"])
+		finally:
+			CONFIG.addons.ai.exec_wrappers = []
+
+	# --- PROVEN-via-stub: end-to-end deny/ask fires on the peeled leaf, not the wrapper name ---
+
+	def _decide(self, argv):
+		engine = PermissionEngine(dict(CONFIG.addons.ai.permissions), targets=["10.0.0.1"],
+								  workspace="/home/user/.secator/reports/test/tasks/ai_1")
+		with patch('safecmd.bashxtract.extract_commands', return_value=([argv], [], [])):
+			return engine.check_action({"action": "shell", "command": " ".join(argv)}).decision
+
+	def test_proxychains_denied_inner_command(self):
+		self.assertEqual(self._decide(["proxychains", "dd", "if=/dev/zero"]), "deny")  # dd is deny-listed
+
+	def test_flock_launders_denied_command(self):
+		self.assertEqual(self._decide(["flock", "/tmp/l", "dd"]), "deny")
+
+	def test_firejail_scoped_rm_asks(self):
+		self.assertEqual(self._decide(["firejail", "rm", "-rf", "/tmp/x"]), "ask")  # not silent-allowed as firejail
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Finding — M11 (P1 / Security)

C2 made shell guardrail checks wrapper-aware, but `EXEC_WRAPPERS` was a **static, hard-coded set**. Any exec-wrapper not in that set let an attacker launder a denied command — the wrapper was treated as the leaf and its payload never inspected:

`proxychains curl http://evil`, `firejail rm -rf /`, `flock /tmp/x curl ...`, `runuser -c 'curl http://evil'`, `script -c '...'` — same bypass class as C2.

## Root cause

`secator/ai/guardrails.py:354` `_peel_wrapper` only peeled names in the fixed `EXEC_WRAPPERS` frozenset (`guardrails.py:40`); everything else fell through as `inner[0]` = leaf command.

## Fix

- **Broaden `EXEC_WRAPPERS`** with the missing wrappers: `flock`, `runuser`, `su`, `script`, `proxychains`, `proxychains4`, `firejail`, `torsocks`, `torify`, `unshare`, `chrt`, `taskset`, `catchsegv`.
- **`_WRAPPER_ARG_GRAMMAR`** — a compact, data-driven table `(opts_taking_a_value, positional_args_before_cmd, cmd_string_opts)` so each wrapper's OWN args are skipped to reach the real leaf, reusing the existing peel loop (no second parser):
  - value-opts: `proxychains -f cfg`, `flock -w N`, `sudo/runuser/su -u user`
  - positional operands: `flock <lockfile>`, `su <user>`
  - `--` end-of-options boundary
  - `-c '<cmd>'` command strings (`runuser`/`su`/`script`/`flock`) are **re-parsed (shlex) and re-peeled** so the nested payload is checked rather than skipped
- **Config-extensible:** `CONFIG.addons.ai.exec_wrappers` (new field, `secator/config.py`) EXTENDS the built-in set — config is additive over the security baseline, never shrinks it.
- Preserves C2 behavior for already-covered wrappers (`timeout 60 rm` → `rm`), the interpreter ask-gate (`timeout 60 bash -c ...` keeps `bash` as leaf), and normal commands.

## Tests — `TestWrapperPeelingM11` (19, all pass)

- **Proven / shfmt-independent:** all `_peel_wrapper` assertions operate on token lists, and the `_exec_wrappers` config-extension test — no shfmt needed.
- **Proven-via-stub:** 3 `check_action` integration tests stub `extract_commands` (same pattern as the existing `TestOutputFlagWrites`), asserting the peeled leaf's deny/ask fires (`proxychains dd` → deny, `flock /tmp/l dd` → deny, `firejail rm -rf /tmp/x` → ask).
- **shfmt-gated:** the pre-existing `check_action`-based wrapper tests in `TestDefaultPermissions` require real `shfmt`/`safecmd` and fail environmentally on every branch (safecmd swallows the `FileNotFoundError` → empty parse).

Baseline vs after (full `test_ai_guardrails.py`): **57 failed / 94 passed → 57 failed / 113 passed**. Failure set byte-identical (all shfmt-environmental), zero regressions, +19 new passing.

## Residual laundering vectors (flagged, not fixed)

- Compound payload after `-c` (`runuser -c 'curl x && rm -rf /'`) — only the first command of the re-parsed string is classified (`guardrails.py` `_peel_wrapper` cmd-string branch).
- Arbitrary user shell aliases / functions; `$(...)`/backtick command substitution; `eval`; wrapper binaries under nonstandard names or paths not in the set (config extension is the mitigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)