### PR TITLE
feat(tasks): add kiterunner task for API endpoint discovery

### DIFF
--- a/secator/tasks/kiterunner.py
+++ b/secator/tasks/kiterunner.py
@@ -1,0 +1,115 @@
+from secator.config import CONFIG
+from secator.decorators import task
+
+# fmt: off
+from secator.definitions import (
+	DATA, DELAY, DEPTH, FILTER_CODES, FILTER_REGEX, FILTER_SIZE, FILTER_WORDS, FOLLOW_REDIRECT, HEADER, MATCH_CODES,
+	MATCH_REGEX, MATCH_SIZE, MATCH_WORDS, METHOD, OPT_NOT_SUPPORTED, PROXY, RATE_LIMIT, REPLAY_PROXY, RETRIES, THREADS,
+	TIMEOUT, URL, USER_AGENT, WORDLIST
+)
+# fmt: on
+from secator.output_types import Url
+from secator.serializers import JSONSerializer
+from secator.tasks._categories import HttpFuzzer
+from secator.utils import process_wordlist
+
+
+@task()
+class kiterunner(HttpFuzzer):
+	"""Contextual content discovery tool for API endpoints.
+
+	Uses Assetnote's compiled route wordlists (`-A`) which embed the expected HTTP method, content-type and body for
+	each route, making it far more accurate than a plain path fuzzer. A custom plaintext or `.kite` wordlist can be
+	passed with `-w`, in which case it overrides the Assetnote wordlist.
+	"""
+	cmd = 'kr scan'
+	input_types = [URL]
+	output_types = [Url]
+	tags = ['url', 'fuzz', 'api']
+	input_flag = None
+	input_chunk_size = 1
+	file_flag = None
+	json_flag = '-o json -q'
+	opt_prefix = '--'  # kiterunner uses cobra: long flags require a double dash
+	item_loaders = [JSONSerializer()]
+	# Override the inherited WORDLIST so it has no default: -w is only passed when the user explicitly provides a
+	# custom wordlist, otherwise the Assetnote wordlist (-A) is used.
+	meta_opts = {
+		**HttpFuzzer.meta_opts,
+		WORDLIST: {'type': str, 'short': 'w', 'process': process_wordlist, 'help': 'Custom plaintext/.kite wordlist (overrides --assetnote-wordlist)'},  # noqa: E501
+	}
+	opts = {
+		'assetnote_wordlist': {'type': str, 'short': 'A', 'default': 'apiroutes-210228:20000', 'help': 'Assetnote route wordlist(s), e.g "apiroutes-210228:20000"'},  # noqa: E501
+		'max_connection_per_host': {'type': int, 'short': 'x', 'default': 3, 'help': 'Max connections to a single host'},
+	}
+	opt_key_map = {
+		HEADER: 'header',
+		DELAY: 'delay',
+		METHOD: 'force-method',
+		THREADS: 'max-parallel-hosts',
+		TIMEOUT: 'timeout',
+		USER_AGENT: 'user-agent',
+		WORDLIST: 'kitebuilder-list',
+		MATCH_CODES: 'success-status-codes',
+		FILTER_CODES: 'fail-status-codes',
+		# kiterunner opts
+		'assetnote_wordlist': 'assetnote-wordlist',
+		'max_connection_per_host': 'max-connection-per-host',
+		# unsupported
+		FOLLOW_REDIRECT: OPT_NOT_SUPPORTED,
+		PROXY: OPT_NOT_SUPPORTED,
+		RATE_LIMIT: OPT_NOT_SUPPORTED,
+		RETRIES: OPT_NOT_SUPPORTED,
+		REPLAY_PROXY: OPT_NOT_SUPPORTED,
+		DATA: OPT_NOT_SUPPORTED,
+		DEPTH: OPT_NOT_SUPPORTED,
+		MATCH_REGEX: OPT_NOT_SUPPORTED,
+		MATCH_SIZE: OPT_NOT_SUPPORTED,
+		MATCH_WORDS: OPT_NOT_SUPPORTED,
+		FILTER_REGEX: OPT_NOT_SUPPORTED,
+		FILTER_SIZE: OPT_NOT_SUPPORTED,
+		FILTER_WORDS: OPT_NOT_SUPPORTED,
+	}
+	encoding = 'ansi'
+	install_version = '1.0.2'
+	install_github_bin = False
+	install_cmd = (
+		'wget -qO /tmp/kiterunner.tar.gz https://github.com/assetnote/kiterunner/releases/download/v[install_version]/kiterunner_[install_version]_linux_amd64.tar.gz '  # noqa: E501
+		f'&& tar -xzf /tmp/kiterunner.tar.gz -C {CONFIG.dirs.bin} kr '
+		f'&& chmod +x {CONFIG.dirs.bin}/kr && rm -f /tmp/kiterunner.tar.gz'
+	)
+	github_handle = 'assetnote/kiterunner'
+	version_flag = OPT_NOT_SUPPORTED
+	proxychains = False
+	proxy_socks5 = False
+	proxy_http = False
+
+	@staticmethod
+	def on_cmd_opts(self, opts):
+		# When a custom wordlist (-w) is provided, drop the Assetnote wordlist (-A) to avoid conflicting sources.
+		if opts.get(WORDLIST, {}).get('value'):
+			opts.pop('assetnote_wordlist', None)
+		return opts
+
+	@staticmethod
+	def validate_item(self, item):
+		if isinstance(item, dict):
+			return 'method' in item and bool(item.get('responses'))
+		return False
+
+	@staticmethod
+	def on_json_loaded(self, item):
+		responses = item.get('responses') or []
+		if not responses:
+			return
+		response = responses[0]
+		url = response.get('uri') or f"{item.get('target', '')}{item.get('path', '')}"
+		yield Url(
+			url=url,
+			status_code=response.get('sc', 0),
+			content_length=response.get('len', 0),
+			method=item.get('method', 'GET'),
+			request_headers=self.get_opt_value('header', preprocess=True),
+			confidence='low',
+			tags=['fuzz', 'api'],
+		)

--- a/tests/fixtures/kiterunner_output.json
+++ b/tests/fixtures/kiterunner_output.json
@@ -1,0 +1,30 @@
+[
+  {
+    "level": "info",
+    "method": "GET",
+    "target": "http://localhost:3000",
+    "path": "/api/Products",
+    "responses": [
+      {
+        "uri": "http://localhost:3000/api/Products",
+        "sc": 200,
+        "len": 1234
+      }
+    ],
+    "message": ""
+  },
+  {
+    "level": "info",
+    "method": "GET",
+    "target": "http://localhost:3000",
+    "path": "/rest/products/search",
+    "responses": [
+      {
+        "uri": "http://localhost:3000/rest/products/search",
+        "sc": 200,
+        "len": 567
+      }
+    ],
+    "message": ""
+  }
+]

--- a/tests/integration/inputs.py
+++ b/tests/integration/inputs.py
@@ -21,6 +21,7 @@ INPUTS_TASKS = {
 	'httpx': 'http://localhost:3000/',
 	'h8mail': 'test@test.com',
 	'jswhois': 'wikipedia.org',
+	'kiterunner': 'http://localhost:3000/',
 	'nuclei': 'http://localhost:3000/',
 	'searchsploit': 'apache 2.4.5',
 	'subfinder': 'github.com',

--- a/tests/integration/outputs.py
+++ b/tests/integration/outputs.py
@@ -102,6 +102,10 @@ OUTPUTS_TASKS = {
 	'katana': [
 		Url(url='http://localhost:3000/scripts.js', host='localhost:3000', status_code=200, method='GET', _source='katana'),
 	],
+	'kiterunner': [
+		Url(url='http://localhost:3000/api/Products', status_code=200, content_length=1234, method='GET', _source='kiterunner'),
+		Url(url='http://localhost:3000/rest/products/search', status_code=200, content_length=567, method='GET', _source='kiterunner'),
+	],
 	'maigret': [
 		UserAccount(site_name='GitHubGist', username='ocervell', url='https://gist.github.com/ocervell', _source='maigret'),
 	],


### PR DESCRIPTION
## Summary

Adds **kiterunner** ([assetnote/kiterunner](https://github.com/assetnote/kiterunner)) as a secator task — a contextual content discovery tool specialized for **API endpoint discovery**.

Unlike a plain path fuzzer, kiterunner brute-forces API routes using Assetnote's compiled route wordlists (`-A apiroutes-*`), which embed the expected **HTTP method, content-type and body** for each route. This makes it significantly more accurate at finding unlinked API endpoints (POST/PUT/PATCH routes) than `ffuf`/`feroxbuster`.

## What's included

- `secator/tasks/kiterunner.py` — `kiterunner(HttpFuzzer)`:
  - Defaults to the Assetnote wordlist `apiroutes-210228:20000` (`-A`); a custom plaintext/`.kite` wordlist can be passed with `-w`, which overrides `-A`.
  - Parses `-o json -q` output into `Url` output types.
  - Installs the release binary `kr` from GitHub (binary name differs from repo, so `install_github_bin` is disabled in favor of an explicit `install_cmd`).
  - Uses `opt_prefix = '--'` (cobra-style long flags); unsupported options (proxy, rate-limit, retries, follow-redirect, body/regex/size filters) are mapped to `OPT_NOT_SUPPORTED`.
- `tests/fixtures/kiterunner_output.json` + entries in `tests/integration/inputs.py` and `outputs.py`.

## Notes / caveats

- **kiterunner is effectively unmaintained** (last release `v1.0.2`, 2021). It's included specifically for its unique value: the compiled `.kite`/`-A` contextual route wordlists. Fed a plain wordlist it would just duplicate `ffuf`.
- The release only ships a `linux_amd64` binary in the current `install_cmd`; other platforms would need a source build.

## Testing

- `secator test unit --task kiterunner --test test_tasks` → passes (Url output types parsed from fixture).
- `flake8 secator/tasks/kiterunner.py` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering API endpoints from a target URL and returning the results as structured URL output.
  * Improved handling of scan options, including custom wordlists and request headers.

* **Tests**
  * Added fixture data and integration coverage for the new endpoint discovery workflow.
  * Included expected output validation for discovered paths, status codes, and response sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->