### PR TITLE
feat(api_discover): hand off discovered OpenAPI specs to nuclei

### DIFF
--- a/secator/configs/workflows/api_discover.yaml
+++ b/secator/configs/workflows/api_discover.yaml
@@ -8,9 +8,9 @@ long_description: |
   brute-forcing of API routes (ffuf, using Assetnote's HTTP Archive apiroutes wordlist — the same real-world
   route dataset kiterunner relied on). Discovered endpoints are probed with httpx to verify they are live and
   fingerprint their technologies. The apiroutes wordlist also covers exposed API specification paths
-  (openapi/swagger), so they surface when fuzzing is enabled. Endpoint discovery only — parameter fuzzing,
-  vulnerability scanning and secrets hunting are handled by the url_params_fuzz and url_vuln workflows (see
-  the `api` scan).
+  (openapi/swagger); when one is found, the --spec option hands it off to nuclei, which parses the spec
+  (input-mode openapi) and DAST-fuzzes every documented endpoint with the correct method and parameters —
+  recovering the contextual testing kiterunner used to provide, using a maintained tool already in secator.
 tags: [http, api, crawl, fuzz]
 input_types:
   - url
@@ -29,6 +29,12 @@ options:
     help: Brute-force API routes with the apiroutes wordlist (ffuf)
     default: False
     short: fuzz
+
+  spec:
+    is_flag: True
+    help: Hand off discovered OpenAPI/Swagger specs to nuclei for endpoint fuzzing (combine with --fuzz to find them)
+    default: False
+    short: spec
 
 tasks:
   katana:
@@ -56,3 +62,13 @@ tasks:
       - type: url
         field: url
         condition: not url.verified
+
+  nuclei:
+    description: Fuzz endpoints from discovered API specs
+    input_mode: openapi
+    dast: True
+    targets_:
+      - type: url
+        field: url
+        condition: "'openapi' in url.url or 'swagger' in url.url or 'api-docs' in url.url"
+    if: opts.spec

--- a/secator/tasks/nuclei.py
+++ b/secator/tasks/nuclei.py
@@ -41,6 +41,7 @@ class nuclei(VulnMulti):
 	opts = {
 		'automatic_scan': {'is_flag': True, 'short': 'as', 'help': 'Automatic web scan using wappalyzer technology detection to tags mapping'},  # noqa: E501
 		'bulk_size': {'type': int, 'short': 'bs', 'help': 'Maximum number of hosts to be analyzed in parallel per template'},  # noqa: E501
+		'dast': {'is_flag': True, 'default': False, 'help': 'Enable DAST fuzzing templates (required to fuzz OpenAPI/Swagger endpoints)'},  # noqa: E501
 		'debug': {'type': str, 'help': 'Debug mode'},
 		'display_templates': {'is_flag': True, 'default': False, 'short': 'dt', 'help': 'Display loaded template names.'},
 		'exclude_severity': {'type': str, 'short': 'es', 'help': 'Exclude severity'},


### PR DESCRIPTION
## Summary

Adds the **OpenAPI-spec handoff** to `api_discover`: when discovery finds an exposed OpenAPI/Swagger spec, hand it off to **nuclei** (already integrated) to parse the spec and DAST-fuzz every documented endpoint.

This recovers the *contextual* API testing that kiterunner used to provide (correct method + parameters per route) — but with a **maintained tool already in secator**, so **no new dependency**.

> Stacked on #1268 (`workflow-api`). Base will be retargeted to `main` once #1268 merges.

## What's included

- **`secator/tasks/nuclei.py`** — new `dast` flag (`-dast`) to enable nuclei's fuzzing templates (required to fuzz OpenAPI endpoints). Defaults to off; no change to existing behavior.
- **`secator/configs/workflows/api_discover.yaml`** — new `--spec` option and a `nuclei` step that targets discovered spec URLs (`openapi` / `swagger` / `api-docs`) with `input_mode=openapi` + `dast`. Gated behind `--spec` (off by default), so pure discovery is unchanged.

## How it works

```
api_discover finds /openapi.json  ──(--spec)──►  nuclei -u <spec-url> -input-mode openapi -dast
(katana / ffuf --fuzz)                            parses the spec, fuzzes every documented endpoint
```

Typical usage: `secator w api_discover <url> --fuzz --spec` (fuzz surfaces the spec, --spec scans it).

## Design notes

- **Why nuclei and not a new tool?** nuclei natively supports OpenAPI/Swagger input (`-input-mode openapi`, its SpecDownloader fetches a remote spec URL) and DAST fuzzing (`-dast`). Adding schemathesis/CATS/apifuzzer would either duplicate this or drag in an unmaintained tool / Java runtime — against secator's design principle #1.
- **Separation of concerns:** the step is optional and flag-gated, consistent with how `url_crawl` gates its optional trufflehog step.

## Testing

- Command generation verified: `nuclei ... -input-mode openapi -dast` emitted correctly.
- `api_discover` loads and builds with `--spec` (tasks: katana, ffuf, wafw00f, httpx, nuclei).
- nuclei unit test passes (no regression from the `dast` flag).
- `flake8 secator/tasks/nuclei.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)