### PR TITLE
fix(tests): coverage report NoSource failure on main

### DIFF
--- a/tests/unit/test_runner_hooks.py
+++ b/tests/unit/test_runner_hooks.py
@@ -1,8 +1,6 @@
 import pickle
 import sys
-import tempfile
 import unittest
-from pathlib import Path
 
 from secator.config import CONFIG
 from secator.loader import discover_external_drivers
@@ -37,22 +35,25 @@ class TestRunnerHooks(unittest.TestCase):
 
 	@classmethod
 	def setUpClass(cls):
-		cls._tmpdir = tempfile.TemporaryDirectory()
-		tmp = Path(cls._tmpdir.name)
-		(tmp / 'mydriver.py').write_text(CUSTOM_DRIVER)
-		cls._orig_templates = CONFIG.dirs.templates
-		CONFIG.dirs.templates = tmp
-		# discover_external_drivers is @cache'd; clear it so it re-scans our tmp dir
-		# (an earlier test/import may have populated the cache with the real dir)
+		# Drop the driver into the REAL templates dir (not a system tempdir): its
+		# path contains '/templates/', so the coverage report's --omit=*/templates/*
+		# excludes it. A tempdir path is not omitted, so coverage would later fail
+		# with "No source for code" once the tempdir is gone (breaks `coverage report`).
+		cls.template_dir = CONFIG.dirs.templates
+		cls.template_dir.mkdir(parents=True, exist_ok=True)
+		cls.driver_path = cls.template_dir / 'custom_hook_driver.py'
+		cls.driver_path.write_text(CUSTOM_DRIVER)
+		# discover_external_drivers is @cache'd; clear it so it re-scans and picks
+		# up our driver (an earlier test/import may have populated the cache).
 		discover_external_drivers.cache_clear()
 		discover_external_drivers()
 
 	@classmethod
 	def tearDownClass(cls):
-		CONFIG.dirs.templates = cls._orig_templates
-		cls._tmpdir.cleanup()
-		sys.modules.pop('secator.hooks.mydriver', None)
-		# reset the cache so later tests re-discover against the restored dir
+		if cls.driver_path.exists():
+			cls.driver_path.unlink()
+		sys.modules.pop('secator.hooks.custom_hook_driver', None)
+		# reset the cache so later tests re-discover against the cleaned-up dir
 		discover_external_drivers.cache_clear()
 
 	def _build_task(self, **kwargs):
@@ -84,12 +85,12 @@ class TestRunnerHooks(unittest.TestCase):
 
 	def test_driver_hooks_loaded_at_init(self):
 		# context['drivers'] hooks must be present right after construction (no pickle)
-		task = self._build_task(context={'drivers': ['mydriver']})
+		task = self._build_task(context={'drivers': ['custom_hook_driver']})
 		self.assertIn('cd_on_item', self._hook_names(task, 'on_item'))
 		self.assertIn('cd_on_end', self._hook_names(task, 'on_end'))
 
 	def test_custom_driver_hook_survives_pickle_without_reregistration(self):
-		task = self._build_task(context={'drivers': ['mydriver']})
+		task = self._build_task(context={'drivers': ['custom_hook_driver']})
 		# unpickling must NOT call register_hooks (this is what flooded the logs)
 		reg = self._count_register_hooks(lambda: pickle.loads(pickle.dumps(task)))
 		self.assertEqual(reg, 0, 'unpickle must not re-register hooks')
@@ -99,7 +100,7 @@ class TestRunnerHooks(unittest.TestCase):
 		self.assertTrue(callable(back.resolved_hooks['on_item'][0]))
 
 	def test_registration_is_idempotent(self):
-		task = self._build_task(context={'drivers': ['mydriver']})
+		task = self._build_task(context={'drivers': ['custom_hook_driver']})
 		before = len(task.resolved_hooks['on_item'])
 		# re-apply the same context drivers -> no duplicate registration
 		task._apply_context_drivers()


### PR DESCRIPTION
## Problem

The `Tests` workflow is **red on main** — the `coverage` job fails at *Run coverage report* (`coverage combine --keep` succeeds, then `coverage report -m` prints no table and exits 1). Introduced by #1267.

Root cause (reproduced locally):

```
No source for code: '/tmp/tmp8dwgpdlo/mydriver.py'; see .../messages.html#error-no-source
EXIT=1
```

#1267's `tests/unit/test_runner_hooks.py` dropped the fake driver into a system `TemporaryDirectory` and imported it as `secator.hooks.mydriver`. Coverage recorded that `/tmp/...` path. The unit job passed (it only *writes* coverage data), but the separate `coverage` job combines the unit+integration data and runs `coverage report`; by then the tempdir is gone, so coverage raises `NoSource` and exits 1. The path isn't caught by `--omit=*/site-packages/*,*/tests/*,*/templates/*`.

## Fix

Mirror the existing `tests/unit/test_loader.py` convention: write the driver into the **real** `CONFIG.dirs.templates` dir (its path contains `/templates/`, so the report's `--omit=*/templates/*` excludes it) and clean it up in `tearDownClass`. No change to the runtime fix from #1267 — this only relocates where the test's throwaway driver file lives.

## Verification

- `coverage run … test_runner_hooks.py` → 4 passed; then `coverage report --omit=…` → **exit 0, full table, 0 "No source" errors** (was exit 1 before).
- Driver file is removed after the run (no stray file left in `~/.secator/templates/`).
- `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated hook-related test coverage to use a real external driver fixture during initialization.
  * Improved validation for custom hook registration, persistence after serialization, and repeated context application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->