### PR TITLE
fix(ai): warn 'missing shfmt/safecmd' instead of 'Missing ai addon' + ship shfmt via the ai addon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,11 @@ gcs = [
 ]
 ai = [
 	'litellm < 2',
-	'safecmd'
+	'safecmd',
+	# safecmd shells out to the `shfmt` binary (via shutil.which); pin shfmt-py
+	# explicitly so `secator install addons ai` always ships the binary, not just
+	# the safecmd Python package. Without it the guardrail shell parser degrades.
+	'shfmt-py'
 ]
 
 [project.scripts]

--- a/secator/ai/guardrails.py
+++ b/secator/ai/guardrails.py
@@ -349,6 +349,34 @@ def extract_command_targets(command: str) -> List[str]:
 	return targets
 
 
+_SHELL_PARSER_WARNED = False
+
+
+def _warn_shell_parser_unavailable(reason: str) -> None:
+	"""Warn ONCE that the shfmt-based shell parser is unavailable, then let the
+	caller fall back to the non-shfmt path (whole-command approval).
+
+	This is deliberately a Warning, not an Error, and it does NOT claim the ai
+	addon is missing: ``litellm`` (the ai addon) can be installed while the shell
+	parser — ``safecmd`` + the ``shfmt`` binary it shells out to — is not. Without
+	it the guardrail can't split a command into sub-commands, so
+	``_check_action_type`` falls back to asking the user to approve the whole
+	command (safe, just coarser). Warn once so a long agent run isn't spammed on
+	every shell command.
+	"""
+	global _SHELL_PARSER_WARNED
+	if _SHELL_PARSER_WARNED:
+		return
+	_SHELL_PARSER_WARNED = True
+	from secator.rich import console
+	from secator.output_types import Warning
+	console.print(Warning(
+		message=f'{reason}: shell commands cannot be sub-parsed for guardrails — '
+		'falling back to whole-command approval. Run "secator install addons ai" '
+		'to enable precise per-subcommand parsing.'
+	))
+
+
 def _parse_subcommands(command: str) -> List[List[str]]:
 	"""Parse a shell command into sub-command token lists via safecmd's parser.
 
@@ -365,8 +393,8 @@ def _parse_subcommands(command: str) -> List[List[str]]:
 	try:
 		from safecmd.bashxtract import extract_commands
 	except ImportError:
-		from secator.rich import console
-		console.print('[bold red][ERR][/] Missing ai addon: please run "secator install addons ai".')
+		# NOT a missing *ai* addon (litellm can be present without the shell parser).
+		_warn_shell_parser_unavailable('Missing safecmd shell parser')
 		return []
 	try:
 		# Normalize LLM-generated multiline commands: join lines where a pipe/operator
@@ -374,6 +402,10 @@ def _parse_subcommands(command: str) -> List[List[str]]:
 		command = re.sub(r'\s*\n\s*(\||\&\&|\|\|)', r' \1', command)
 		cmds, ops, redirects = extract_commands(command)
 		return [c for c in cmds if c]
+	except FileNotFoundError:
+		# safecmd is installed but the `shfmt` binary it shells out to isn't on PATH.
+		_warn_shell_parser_unavailable('Missing shfmt binary')
+		return []
 	except Exception:
 		return []
 

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -10,7 +10,8 @@ if ADDONS_ENABLED['ai']:
 	from secator.ai.guardrails import (
 		parse_rule, match_rule, extract_command_targets, detect_paths, detect_paths_with_access,
 		detect_sensitive_env_vars, classify_command, build_target_choices, PermissionEngine,
-		_is_file_path, _normalize_ip, _peel_wrapper, _exec_wrappers, EXEC_WRAPPERS
+		_is_file_path, _normalize_ip, _peel_wrapper, _exec_wrappers, EXEC_WRAPPERS,
+		_parse_subcommands,
 	)
 	from secator.output_types import Warning, Error
 
@@ -1281,6 +1282,52 @@ class TestWrapperPeelingM11(unittest.TestCase):
 
 	def test_firejail_scoped_rm_asks(self):
 		self.assertEqual(self._decide(["firejail", "rm", "-rf", "/tmp/x"]), "ask")  # not silent-allowed as firejail
+
+
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestShellParserFallback(unittest.TestCase):
+	"""When the shfmt-based shell parser (safecmd/shfmt) is unavailable, the
+	guardrail must Warn (NOT claim 'Missing ai addon') and fall back to
+	whole-command approval — an empty sub-command list makes the caller `ask`."""
+
+	def setUp(self):
+		import secator.ai.guardrails as g
+		g._SHELL_PARSER_WARNED = False  # reset warn-once flag per test
+
+	def _run_and_capture(self):
+		printed = []
+		with patch('secator.rich.console.print', side_effect=lambda x, *a, **k: printed.append(x)):
+			result = _parse_subcommands('curl -s https://x.com | head -5')
+		return result, printed
+
+	def test_missing_safecmd_warns_not_ai_addon(self):
+		# Simulate safecmd not installed -> ImportError on the in-function import.
+		with patch.dict('sys.modules', {'safecmd.bashxtract': None}):
+			result, printed = self._run_and_capture()
+		self.assertEqual(result, [])  # unparseable -> caller falls back to ask
+		self.assertEqual(len(printed), 1)
+		item = printed[0]
+		self.assertIsInstance(item, Warning)  # a Warning, not an Error
+		self.assertIn('safecmd', item.message)
+		self.assertNotIn('ai addon', item.message.lower())
+
+	def test_missing_shfmt_binary_warns(self):
+		# safecmd imports, but the shfmt binary it shells out to is not on PATH.
+		with patch('safecmd.bashxtract.extract_commands', side_effect=FileNotFoundError('shfmt')):
+			result, printed = self._run_and_capture()
+		self.assertEqual(result, [])
+		self.assertEqual(len(printed), 1)
+		self.assertIsInstance(printed[0], Warning)
+		self.assertIn('shfmt', printed[0].message)
+		self.assertNotIn('ai addon', printed[0].message.lower())
+
+	def test_warns_only_once_across_commands(self):
+		printed = []
+		with patch('safecmd.bashxtract.extract_commands', side_effect=FileNotFoundError):
+			with patch('secator.rich.console.print', side_effect=lambda x, *a, **k: printed.append(x)):
+				_parse_subcommands('a | b')
+				_parse_subcommands('c | d')
+		self.assertEqual(len(printed), 1)  # warn-once, no per-command spam
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem (hit during CLI testing)

In attack mode every shell command the LLM issues hit the guardrail shell parser, which printed:
```
[ERR] Missing ai addon: please run "secator install addons ai".
```
…even though the ai addon **was** installed. `_parse_subcommands` (`guardrails.py`) shells out to `shfmt` via `safecmd`; the misleading message came from its `ImportError` branch. The env had `litellm` (so `ADDONS_ENABLED['ai']=True`) but not `safecmd`/`shfmt` — a partial ai install. Worse, the *other* failure mode (safecmd present, `shfmt` binary not on PATH) was **silent** (`FileNotFoundError` swallowed by `except Exception: return []`).

## Fix
1. **Message** — replace the `Error("Missing ai addon")` with a **one-shot `Warning`** that names the real gap: `"Missing safecmd shell parser"` (ImportError) or `"Missing shfmt binary"` (FileNotFoundError). Both fall back to the **non-shfmt path** — an empty sub-command list, so `_check_action_type` asks the user to approve the whole command (safe, just coarser). Warn once per process (no per-command spam).
2. **Install** — add `shfmt-py` explicitly to the `ai` extra so `secator install addons ai` (`pip install secator[ai]`) always ships the `shfmt` **binary**, not just the `safecmd` Python package (which only pulled it transitively).

## Tests
`TestShellParserFallback`: safecmd-missing → `Warning` naming `safecmd`, never `"ai addon"`; shfmt-binary-missing → `Warning` naming `shfmt`; warn-once across multiple commands. Full AI suite: **no new failures** vs branch baseline.

Found while testing `ai-testing`; targets `ai-resiliency` (#1241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)