### PR TITLE
fix(ai): dedupe duplicate tool_results after compaction/batch (non-retryable 400)

### DIFF
--- a/secator/ai/utils.py
+++ b/secator/ai/utils.py
@@ -40,6 +40,39 @@ def _strip_leading_orphan_tools(messages: List[Dict]) -> int:
 	return removed
 
 
+def _dedupe_tool_results(messages: List[Dict]) -> int:
+	"""Drop duplicate tool_result messages sharing a tool_call_id.
+
+	Anthropic (and OpenRouter's providers) fold consecutive 'tool' messages into a
+	single user turn and reject more than one tool_result per tool_use id
+	("each tool_use must have a single result. Found multiple tool_result blocks
+	with id X") — a NON-retryable 400. Duplicates arise when batch results are
+	grouped out of order (itertools.groupby only groups *consecutive* keys), or
+	when history trim/compaction restructures the window. Within each run of
+	consecutive 'tool' messages, keep the first result for each id and drop the
+	rest (in place). Returns the number removed.
+	"""
+	removed = 0
+	i = 0
+	while i < len(messages):
+		if messages[i].get("role") != "tool":
+			i += 1
+			continue
+		seen = set()
+		j = i
+		while j < len(messages) and messages[j].get("role") == "tool":
+			tc_id = messages[j].get("tool_call_id")
+			if tc_id is not None and tc_id in seen:
+				del messages[j]
+				removed += 1
+				continue  # a message shifted into j; re-check without advancing
+			if tc_id is not None:
+				seen.add(tc_id)
+			j += 1
+		i = j
+	return removed
+
+
 def _repair_orphan_tool_uses(messages: List[Dict]) -> int:
 	"""Repair orphan tool_use/tool_result pairing for Anthropic/OpenAI.
 
@@ -58,6 +91,9 @@ def _repair_orphan_tool_uses(messages: List[Dict]) -> int:
 	"""
 	# Leading orphan tool_results have no parent in this window — drop them.
 	repaired = _strip_leading_orphan_tools(messages)
+	# Duplicate tool_results for one id are rejected as a non-retryable 400 — drop
+	# extras so the request is valid (and, when hit as a 400, so the retry repairs it).
+	repaired += _dedupe_tool_results(messages)
 	inserted = 0
 	i = 0
 	while i < len(messages):

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -2,7 +2,6 @@
 """AI-powered penetration testing task."""
 import json
 import uuid
-from itertools import groupby
 from pathlib import Path
 from typing import Generator
 
@@ -1023,11 +1022,18 @@ class ai(PythonRunner):
 			collected.append(result)
 			ctx.results.append(result)
 
-		# Group results by tool_call_id and add to history
+		# Group results by tool_call_id and add to history. Use an order-preserving
+		# dict, NOT itertools.groupby: batch results (_run_batch) interleave by id, and
+		# groupby only groups *consecutive* keys — so an interleaved id yielded several
+		# groups and thus several tool_result messages for one tool_use, which the
+		# provider rejects ("multiple tool_result blocks with id X"). A dict groups all
+		# of an id's results together regardless of arrival order → exactly one result.
 		budget = self.history.get_action_budget(self.model)
 		fallback_path = Path(self.reports_folder) / "report.json" if self.reports_folder else None
-		for tc_id, group in groupby(collected, key=lambda r: r["_context"]['tool_call_id']):
-			group_results = list(group)
+		grouped = {}
+		for r in collected:
+			grouped.setdefault(r["_context"]['tool_call_id'], []).append(r)
+		for tc_id, group_results in grouped.items():
 			tc_name = group_results[0]["_context"]['tool_call_name']
 			has_errors = any(r["_type"] == "error" for r in group_results)
 			serialized = [

--- a/tests/unit/test_ai_utils.py
+++ b/tests/unit/test_ai_utils.py
@@ -298,6 +298,45 @@ class TestCallLLM(unittest.TestCase):
 
     @patch('time.sleep')
     @patch('litellm.completion')
+    def test_call_llm_duplicate_tool_result_400_repairs_and_retries(self, mock_completion, mock_sleep):
+        """A 'multiple tool_result blocks with id' 400 is now deduped and retried,
+        instead of failing fast as non-retryable."""
+        import litellm
+        from secator.ai.utils import call_llm
+
+        ok_response = MagicMock()
+        ok_response.choices = [MagicMock(message=MagicMock(content="ok", tool_calls=None))]
+        ok_response.usage = None
+
+        err = litellm.BadRequestError(
+            message=("messages.24.content.3: each tool_use must have a single result. "
+                     "Found multiple tool_result blocks with id: toolu_dup"),
+            model="claude", llm_provider="anthropic",
+        )
+        calls = []
+
+        def side_effect(**kwargs):
+            if not calls:  # first call: inject an assistant + duplicate tool_results, then raise
+                kwargs["messages"][:0] = [
+                    {"role": "assistant", "content": None,
+                     "tool_calls": [{"id": "toolu_dup", "type": "function",
+                                     "function": {"name": "f", "arguments": "{}"}}]},
+                    {"role": "tool", "tool_call_id": "toolu_dup", "name": "f", "content": "r1"},
+                    {"role": "tool", "tool_call_id": "toolu_dup", "name": "f", "content": "r2"},
+                ]
+                calls.append(1)
+                raise err
+            return ok_response
+
+        mock_completion.side_effect = side_effect
+        result = call_llm([{"role": "user", "content": "hi"}], "claude", max_retries=3)
+
+        self.assertEqual(result["content"], "ok")
+        self.assertEqual(mock_completion.call_count, 2)  # deduped then succeeded
+        mock_sleep.assert_not_called()
+
+    @patch('time.sleep')
+    @patch('litellm.completion')
     @patch('litellm.completion_cost')
     def test_call_llm_transient_error_still_retries(self, mock_cost, mock_completion, mock_sleep):
         """M4: genuinely-transient errors (429/500) still retry then succeed."""
@@ -558,6 +597,64 @@ class TestRepairOrphanToolUses(unittest.TestCase):
 
         self.assertEqual(result["content"], "ok")
         mock_sleep.assert_not_called()  # repair branch should skip the backoff sleep
+
+
+class TestDedupeToolResults(unittest.TestCase):
+    """Providers reject >1 tool_result per tool_use id ('multiple tool_result blocks
+    with id X') — a non-retryable 400. Duplicates arise from batch results grouped
+    out of order or history trim/compaction; drop the extras, keep the first."""
+
+    def test_drops_consecutive_duplicate_same_id(self):
+        from secator.ai.utils import _dedupe_tool_results
+        messages = [
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "x", "type": "function", "function": {"name": "f", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "x", "name": "f", "content": "first"},
+            {"role": "tool", "tool_call_id": "y", "name": "f", "content": "other"},
+            {"role": "tool", "tool_call_id": "x", "name": "f", "content": "DUP"},
+            {"role": "user", "content": "next"},
+        ]
+        removed = _dedupe_tool_results(messages)
+        self.assertEqual(removed, 1)
+        tool_ids = [m["tool_call_id"] for m in messages if m.get("role") == "tool"]
+        self.assertEqual(tool_ids, ["x", "y"])  # first x kept, dup dropped, y intact
+        # the kept x is the FIRST result
+        self.assertEqual(next(m for m in messages if m.get("tool_call_id") == "x")["content"], "first")
+
+    def test_no_op_when_unique(self):
+        from secator.ai.utils import _dedupe_tool_results
+        messages = [
+            {"role": "tool", "tool_call_id": "a", "content": "1"},
+            {"role": "tool", "tool_call_id": "b", "content": "2"},
+        ]
+        before = [dict(m) for m in messages]
+        self.assertEqual(_dedupe_tool_results(messages), 0)
+        self.assertEqual(messages, before)
+
+    def test_dedupe_scoped_per_consecutive_run(self):
+        """The same id in two SEPARATE tool runs (own assistant each) is not a dup."""
+        from secator.ai.utils import _dedupe_tool_results
+        messages = [
+            {"role": "tool", "tool_call_id": "x", "content": "r1"},
+            {"role": "assistant", "content": "thinking"},
+            {"role": "tool", "tool_call_id": "x", "content": "r2"},
+        ]
+        self.assertEqual(_dedupe_tool_results(messages), 0)  # separated by a non-tool msg
+
+    def test_repair_dedupes_duplicate_tool_results(self):
+        """_repair_orphan_tool_uses now removes duplicates as part of its pass."""
+        from secator.ai.utils import _repair_orphan_tool_uses
+        messages = [
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "x", "type": "function", "function": {"name": "f", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "x", "name": "f", "content": "first"},
+            {"role": "tool", "tool_call_id": "x", "name": "f", "content": "DUP"},
+            {"role": "user", "content": "next"},
+        ]
+        changed = _repair_orphan_tool_uses(messages)
+        self.assertGreaterEqual(changed, 1)
+        tool_ids = [m["tool_call_id"] for m in messages if m.get("role") == "tool"]
+        self.assertEqual(tool_ids, ["x"])  # exactly one result for x
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Bug (hit during CLI testing, after compaction)

```
[WRN] Chat history trimmed: dropped 10 messages to fit under 100000 tokens.
[ERR] LLM call failed with non-retryable 400: ... each tool_use must have a single result.
      Found multiple `tool_result` blocks with id: toolu_bdrk_01Bi8...
```

Providers fold consecutive `tool` messages into a single user turn and reject more than one `tool_result` per `tool_use` id — a **non-retryable** 400 that aborts the whole run.

## Root cause
`_dispatch_and_collect` grouped batch results with `itertools.groupby`, which groups only **consecutive** equal keys. In batch mode (`_run_batch`) results **interleave** by `tool_call_id` (e.g. `[X, Y, X]`), so `groupby` produced *several* groups for one id → `add_tool_result` fired more than once for it → duplicate consecutive `tool` messages → litellm folds them into one user turn with duplicate `tool_result` blocks → 400. History trim/compaction restructures the window the same way (hence the correlation with compaction).

## Fix (source + safety net)
1. **Order-preserving grouping** — group `collected` by an ordered `dict` instead of `groupby`, so each `tool_call_id` yields exactly one result regardless of arrival order (also fixes token accounting for interleaved batches).
2. **`_dedupe_tool_results`** in `_repair_orphan_tool_uses` — within each run of consecutive `tool` messages, keep the first result per id, drop the rest. Runs **proactively** before every LLM call *and* on the **400-repair-retry** path, so the "multiple tool_result blocks" 400 is now repaired + retried instead of failing fast.

## Tests
`TestDedupeToolResults` (drop consecutive dup, no-op when unique, per-run scoping, repair integration) + `call_llm` duplicate-400 → repaired-and-retried. Full AI suite: **no new failures** vs branch baseline.

Targets `ai-resiliency` (#1241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)