### PR TITLE
fix(ai): ai-spawned sub-runners persist their own runner doc, linked by session_id

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -647,19 +647,21 @@ def _run_runner(action: Dict, ctx: ActionContext, runner_type: str) -> Generator
 
 
 def _get_result_context(action, ctx):
-	"""Get result context from action.
+	"""Build the CHILD runner's context.
 
-	Always stamps the ai task's ``session_id`` (the conversation id) onto the
-	derived context. The ai task's ``self.session_id`` may be derived (from
-	``session_name`` / the runner id) and is therefore not guaranteed to already
-	live in ``ctx.context``. Stamping it here means every sub-runner (task /
-	workflow / scan) dispatched by the ai task persists a runner doc whose
-	``context.session_id`` matches the conversation — so the runners spawned by a
-	conversation are queryable by that conversation's session_id.
+	Stamps the conversation ``session_id`` (parenting link — see the runner-parenting
+	design) and marks the child ``has_parent``. Critically, it STRIPS the parent's
+	runner-identity keys (`task_id`/`workflow_id`/`scan_id`): a child that inherited
+	them would make `update_runner`/`runner_id` target the PARENT's doc instead of
+	minting its own. The child keeps drivers/workspace so it persists into the same
+	workspace, linked to the conversation by ``session_id``.
 	"""
 	new_ctx = ctx.context.copy()
+	for identity_key in ("task_id", "workflow_id", "scan_id", "task_chunk_id"):
+		new_ctx.pop(identity_key, None)
 	if ctx.session_id and not new_ctx.get("session_id"):
 		new_ctx["session_id"] = ctx.session_id
+	new_ctx["has_parent"] = True
 	action_context = {}
 	tool_call_id = action.get("tool_call_id")
 	tool_call_name = action.get("tool_call_name")

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -1280,5 +1280,36 @@ class TestSubagentFanoutCap(unittest.TestCase):
 		self.assertEqual(kwargs.get('context', {}).get('ai_subagent_depth'), 1)
 
 
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestChildContextParenting(unittest.TestCase):
+	"""A spawned sub-runner must get a CLEAN identity: it inherits the conversation
+	session_id + drivers but NOT the parent's runner-doc id, so it mints its own doc
+	(linked to the conversation by session_id), instead of clobbering the parent."""
+
+	def test_child_context_strips_parent_identity_keeps_session(self):
+		from secator.ai.actions import _get_result_context, ActionContext
+		ctx = ActionContext(
+			targets=['t.com'], model='m',
+			context={
+				'workspace_id': 'ws1', 'workspace_name': 'w', 'drivers': ['mongodb'],
+				'task_id': 'PARENT_AI_ID',          # the parent ai task's own doc id
+				'session_id': 'conv-1',
+			},
+			session_id='conv-1',
+		)
+		action = {'action': 'task', 'name': 'nmap', 'tool_call_id': 'tc1', 'tool_call_name': 'run_task'}
+		child = _get_result_context(action, ctx)
+		# keeps the conversation link + drivers/workspace
+		self.assertEqual(child['session_id'], 'conv-1')
+		self.assertEqual(child['drivers'], ['mongodb'])
+		self.assertEqual(child['workspace_id'], 'ws1')
+		# marks it a child
+		self.assertTrue(child.get('has_parent'))
+		# does NOT inherit the parent's runner-doc identity (would clobber / suppress its own doc)
+		self.assertNotIn('task_id', child)
+		self.assertNotIn('workflow_id', child)
+		self.assertNotIn('scan_id', child)
+
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
## What / why (PR 2 of the runner-parenting design — core foundation)

AI-task-spawned sub-runners (nmap, httpx, subagents, …) run and their **findings** persist, but the sub-runner itself never created its **own** runner doc — so it never appeared in runner history. Root cause: the child inherited the parent ai task's `context.task_id`, so `update_runner`/`runner_id` targeted the *parent's* doc instead of minting a new one.

## Fix
`_get_result_context` now builds a **clean child context**: strips the parent's runner-identity keys (`task_id`/`workflow_id`/`scan_id`/`task_chunk_id`), keeps `session_id`/`drivers`/`workspace_*`. Each child now takes `update_runner`'s insert branch → mints its own doc, linked to the conversation by `context.session_id`.

## Verified (empirical)
Probe (`secator x ai -p "Run nmap … on scanme.nmap.org" --dangerous -driver mongodb -ws …`):
- **Before:** 0 non-ai task docs under the session.
- **After:** the `nmap` child persists with its own `_id` (≠ parent), `context.task_id` = its own, `context.session_id` = the conversation, `status=SUCCESS`.

## Tests
`TestChildContextParenting` (child context keeps session/drivers/workspace, sets `has_parent`, strips the four identity keys). `test_ai_actions.py` 85/85; no new failures vs branch baseline.

## Not in this PR (design's later phases, go through the user)
- **secator-api:** a `GET /ai/conversations/{session_id}/runners` list resolver (unions tasks/workflows/scans by `context.session_id`).
- **secator-ui:** group a conversation's runners under it.
- **Open decision (API/UI phase):** whether ai children should also carry the *behavioral* top-level `has_parent` (controls whether they show as top-level in the general runner history vs nested). The persisted `has_parent` is currently `false`; parenting-by-`session_id` works regardless.

Part of the AI-task reliability series → `ai-resiliency` (#1241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)