### PR TITLE
fix(ai): make query_workspace the single source of truth (local-driver union)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -717,6 +717,31 @@ def _handle_shell(action: Dict, ctx: ActionContext) -> Generator:
 		yield Error(message=f"Shell command failed: {e}", _context=context)
 
 
+def _union_live_results(persisted: List[Dict], live_results: List[Dict], query_filter: Dict, limit: int) -> List[Dict]:
+	"""Union backend results with this run's in-memory findings (local driver only).
+
+	The live findings are filtered by the SAME query via an in-memory json backend,
+	then merged into the backend (disk) results and deduped by ``_uuid`` (backend wins),
+	respecting ``limit``. Makes query_workspace the single source of truth under the
+	local driver, whose JSON exporter only writes to disk at end-of-run.
+	"""
+	if not live_results:
+		return persisted
+	from secator.query import QueryEngine
+	# workspace_id "" + a `results` context => an in-memory json backend that filters
+	# the provided results by the query (no disk access).
+	live = QueryEngine("", context={"results": live_results}).search(query_filter, limit=limit or 0)
+	seen = {r.get("_uuid") for r in persisted if r.get("_uuid")}
+	for r in live:
+		u = r.get("_uuid")
+		if u and u in seen:
+			continue
+		persisted.append(r)
+		if u:
+			seen.add(u)
+	return persisted[:limit] if limit else persisted
+
+
 def _handle_query(action: Dict, ctx: ActionContext) -> Generator:
 	"""Query workspace or current results for findings.
 
@@ -755,14 +780,25 @@ def _handle_query(action: Dict, ctx: ActionContext) -> Generator:
 	if ctx.encryptor:
 		query_filter = _decrypt_dict(query_filter, ctx.encryptor)
 
-	if ctx.scope != "current" and not ctx.context.get("workspace_id"):
+	engine = ctx.get_query_engine()
+	is_local = getattr(engine.backend, "name", "") == "json"
+
+	# A non-local backend (mongodb/api) needs a workspace to query. The local (json)
+	# driver can always answer from this run's in-memory findings (unioned below), so
+	# it is exempt from the workspace_id requirement.
+	if not is_local and ctx.scope != "current" and not ctx.context.get("workspace_id"):
 		yield Warning(message="No workspace available for query", _context=context)
 		return
 
 	try:
 		query_str = json.dumps(query_filter, separators=(',', ':'))
-		engine = ctx.get_query_engine()
 		results = engine.search(query_filter, limit=limit)
+		# Local driver: the JSON exporter writes findings to disk only at end-of-run,
+		# so the backend can't see THIS run's live findings mid-run. Union the in-memory
+		# run results so query_workspace is the single source of truth. Other backends
+		# (mongodb/api) persist live via hooks, so they are queried normally (no union).
+		if is_local and ctx.scope != "current":
+			results = _union_live_results(results, ctx.results or [], query_filter, limit)
 		yield Ai(
 			content=query_str,
 			ai_type="query",

--- a/secator/ai/prompts/constraints/common.txt
+++ b/secator/ai/prompts/constraints/common.txt
@@ -73,8 +73,8 @@ When getting denied to run a command many times, you can also try it to run it i
 </guardrails>
 
 <file_io>
-The runner folder is: $workspace_path. This is where we store all inputs / outputs from the current run.
-You can request to read or write files outside the workspace but this require user approval so when possible prefer to read / write to the runner folder.
+Write any files you generate (e.g. a markdown report) to the runner folder's outputs directory: $workspace_path/.outputs/. Prefer this location; reading or writing files elsewhere requires user approval.
+To find existing findings/results, ALWAYS use the query_workspace tool — it is the single source of truth for the workspace and already covers this run's live findings. Do NOT read local report files (e.g. via cat/jq) to look up findings.
 </file_io>
 
 <encrypted_data>

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -252,8 +252,14 @@ class TestHandleQuery(unittest.TestCase):
 	"""Tests for the _handle_query action handler."""
 
 	def test_query_no_workspace(self):
+		"""A NON-local backend (mongodb/api) without a workspace_id yields the
+		'No workspace' guard. The local driver is exempt (it answers from in-memory
+		results — see test_query_local_driver_exempt_from_workspace_guard)."""
+		mock_engine = MagicMock()
+		mock_engine.backend.name = "mongodb"
 		ctx = ActionContext(targets=['t.com'], model='m', context={})
-		results = list(_handle_query({'action': 'query', 'query': {}}, ctx))
+		with patch.object(ctx, 'get_query_engine', return_value=mock_engine):
+			results = list(_handle_query({'action': 'query', 'query': {}}, ctx))
 
 		self.assertEqual(len(results), 1)
 		self.assertIsInstance(results[0], Warning)
@@ -362,6 +368,61 @@ class TestHandleQuery(unittest.TestCase):
 		mock_engine.search.assert_called_once()
 		call_args = mock_engine.search.call_args[0][0]
 		self.assertEqual(call_args['host'], 'example.com')
+
+	def test_union_live_results_dedup_and_filter(self):
+		"""_union_live_results filters live by the query, merges into backend results,
+		and dedupes by _uuid (backend wins)."""
+		from secator.ai.actions import _union_live_results
+		persisted = [{"_uuid": "a", "_type": "port"}]
+		live = [{"_uuid": "a", "_type": "port"},   # dup -> deduped
+				{"_uuid": "b", "_type": "port"},   # new -> included
+				{"_uuid": "c", "_type": "url"}]    # wrong type -> filtered out by the query
+		out = _union_live_results(list(persisted), live, {"_type": "port"}, 100)
+		self.assertEqual(sorted(r["_uuid"] for r in out), ["a", "b"])
+		# no live results -> persisted returned unchanged
+		self.assertEqual(_union_live_results([{"_uuid": "z"}], [], {}, 0), [{"_uuid": "z"}])
+
+	def test_query_local_driver_unions_live_results(self):
+		"""Local (json) driver: query_workspace unions this run's in-memory findings
+		with the backend (JSON exporter only writes to disk at end-of-run)."""
+		mock_engine = MagicMock()
+		mock_engine.backend.name = "json"
+		mock_engine.search.return_value = [{"_uuid": "disk1", "_type": "port", "_context": {}}]
+		ctx = ActionContext(targets=['t'], model='m', context={'workspace_id': 'ws1'},
+							 results=[{"_uuid": "live1", "_type": "port", "_context": {}}])
+		with patch.object(ctx, 'get_query_engine', return_value=mock_engine):
+			results = list(_handle_query({'action': 'query', 'query': {'_type': 'port'}}, ctx))
+		uuids = {r.get('_uuid') for r in results if isinstance(r, dict)}
+		self.assertIn('disk1', uuids)   # backend result
+		self.assertIn('live1', uuids)   # unioned live in-memory result
+
+	def test_query_mongodb_driver_does_not_union(self):
+		"""Non-local backend (mongodb) is queried normally — live self.results are NOT unioned."""
+		mock_engine = MagicMock()
+		mock_engine.backend.name = "mongodb"
+		mock_engine.search.return_value = [{"_uuid": "db1", "_type": "port", "_context": {}}]
+		ctx = ActionContext(targets=['t'], model='m', context={'workspace_id': 'ws1'},
+							 results=[{"_uuid": "live1", "_type": "port", "_context": {}}])
+		with patch.object(ctx, 'get_query_engine', return_value=mock_engine):
+			results = list(_handle_query({'action': 'query', 'query': {'_type': 'port'}}, ctx))
+		uuids = {r.get('_uuid') for r in results if isinstance(r, dict)}
+		self.assertIn('db1', uuids)
+		self.assertNotIn('live1', uuids)   # not unioned for non-local backends
+
+	def test_query_local_driver_exempt_from_workspace_guard(self):
+		"""Local driver with NO workspace_id is not blocked by the 'No workspace' guard —
+		it answers from in-memory results."""
+		mock_engine = MagicMock()
+		mock_engine.backend.name = "json"
+		mock_engine.search.return_value = []
+		ctx = ActionContext(targets=['t'], model='m', context={},   # no workspace_id
+							 results=[{"_uuid": "live1", "_type": "port", "_context": {}}])
+		with patch.object(ctx, 'get_query_engine', return_value=mock_engine):
+			results = list(_handle_query({'action': 'query', 'query': {'_type': 'port'}}, ctx))
+		warnings = [r for r in results if isinstance(r, Warning)]
+		self.assertFalse(any('No workspace' in getattr(w, 'message', '') for w in warnings))
+		uuids = {r.get('_uuid') for r in results if isinstance(r, dict)}
+		self.assertIn('live1', uuids)
 
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')


### PR DESCRIPTION
## Why (diagnosed from a live run)
Asked "What's in my workspace", the model correctly ran `query_workspace` — then `cd`'d into `~/.secator/reports/.../tasks/18/.outputs/` and `cat | jq`'d local JSON to count finding types. Two causes:
1. **Local-driver gap:** the JSON exporter writes findings to disk only at *end-of-run*, so mid-run `query_workspace` (local backend) sees nothing — the prompt compensated by telling the model where the report files live.
2. **Prompt framing:** "the runner folder … is where we store all inputs/outputs" invited the model to *read* those files to find data — a different, possibly stale store than the workspace it queried (outright wrong under `--driver mongodb`/cloud).

## Fix — Query is the single source of truth
- **Local driver only:** `_handle_query` unions the backend results with this run's in-memory findings (`ctx.results`), filtered by the same query and deduped by `_uuid`. **mongodb/api are unchanged** (hooks persist live → no union needed). The local driver is also exempted from the `workspace_id` guard (it can answer from in-memory results).
- **Prompt (`common.txt`):** keep "write generated outputs to `$workspace_path/.outputs/`"; drop the "we store all inputs/outputs here" framing; add "ALWAYS use `query_workspace` — the single source of truth; do NOT read local report files to find findings."

## Tests
`_union_live_results` (filter+merge+dedup), local-driver unions live results, mongodb does NOT union, local exempt from the workspace guard, and the updated `no_workspace` guard test (now scoped to non-local backends). Full AI suite: no new failures.

Targets `ai-resiliency` (#1241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)