### PR TITLE
fix(ai): coerce query_workspace limit to int (str limit crashed the backend)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -811,7 +811,14 @@ def _handle_query(action: Dict, ctx: ActionContext) -> Generator:
 	"""
 	context = _get_result_context(action, ctx)
 	query_filter = action.get("query", {})
+	# The schema declares `limit` an integer, but some models send it as a string
+	# ("10"); a str limit reaches the backend and raises `'>=' not supported between
+	# int and str`. Coerce to int (bad/None values fall back to the default).
 	limit = action.get("limit", 100)
+	try:
+		limit = int(limit)
+	except (TypeError, ValueError):
+		limit = 100
 
 	# The query_workspace tool schema declares `query` as an object, but some
 	# models/providers serialize it as a JSON *string* (a known tool-calling

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -424,6 +424,27 @@ class TestHandleQuery(unittest.TestCase):
 		uuids = {r.get('_uuid') for r in results if isinstance(r, dict)}
 		self.assertIn('live1', uuids)
 
+	def test_query_stringified_limit_coerced_to_int(self):
+		"""A model-supplied string limit ('10') is coerced to int before the backend
+		(a str limit raises TypeError: '>=' not supported between int and str)."""
+		mock_engine = MagicMock()
+		mock_engine.backend.name = "mongodb"
+		mock_engine.search.return_value = []
+		ctx = ActionContext(targets=['t'], model='m', context={'workspace_id': 'ws1'})
+		with patch.object(ctx, 'get_query_engine', return_value=mock_engine):
+			list(_handle_query({'action': 'query', 'query': {'_type': 'ip'}, 'limit': '10'}, ctx))
+		self.assertEqual(mock_engine.search.call_args.kwargs.get('limit'), 10)
+
+	def test_query_bad_limit_falls_back_to_default(self):
+		"""A non-numeric limit falls back to the default (100), not a crash."""
+		mock_engine = MagicMock()
+		mock_engine.backend.name = "mongodb"
+		mock_engine.search.return_value = []
+		ctx = ActionContext(targets=['t'], model='m', context={'workspace_id': 'ws1'})
+		with patch.object(ctx, 'get_query_engine', return_value=mock_engine):
+			list(_handle_query({'action': 'query', 'query': {}, 'limit': 'notanumber'}, ctx))
+		self.assertEqual(mock_engine.search.call_args.kwargs.get('limit'), 100)
+
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
 class TestRunRunner(unittest.TestCase):


### PR DESCRIPTION
## Bug
```
🟢Query({'_type': 'ip', 'host': 'cachyos.local'}) -> failed results (limit: 10)
[ERR] ai TypeError: '>=' not supported between instances of 'int' and 'str'
  File ".../query/json.py", line 182, in _execute_search
    if limit and len(matched) >= limit:
```
The model sent `query_workspace`'s `limit` as a **string** (`"10"`); it reached the backend and broke the `>=` comparison. Same "model stringifies args" class as #1275, but `coerce_stringified_args` only handles object/array params — not scalar ints like `limit`.

## Fix
Coerce `limit` to `int` in `_handle_query`; bad/None values fall back to the default (100).

## Tests
Stringified `"10"` → `10` reaches the backend; a non-numeric limit falls back to 100. `test_ai_actions.py` 99 passed; the original crash reproduces as resolved.

Targets `ai-resiliency` (#1241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)