### PR TITLE
perf(runners): route empty-results mark_started to the small pool

### DIFF
--- a/secator/runners/scan.py
+++ b/secator/runners/scan.py
@@ -76,8 +76,15 @@ class Scan(Runner):
 				self.add_result(result, print=False, hooks=False)
 
 		if sigs:
+			# A scan's start marker carries no prior results (empty `[]`), so it
+			# doesn't need the memory-heavy `results` pool (served by the large
+			# worker pool). Route it to `small` so it schedules on existing/warm
+			# capacity — otherwise the large pool triggers a scale-from-zero node
+			# provision just to mark the scan started, which dominates scan-start
+			# latency. `mark_runner_completed` stays on `results` (it aggregates the
+			# full result set and needs the headroom).
 			sig = chain(
-				mark_runner_started.si([], self).set(queue='results'),
+				mark_runner_started.si([], self).set(queue='small'),
 				*sigs,
 				mark_runner_completed.s(self).set(queue='results'),
 			)

--- a/secator/runners/scan.py
+++ b/secator/runners/scan.py
@@ -67,7 +67,15 @@ class Scan(Runner):
 				hooks=self._hooks,
 				context=self.context.copy()
 			)
-			celery_workflow = workflow.build_celery_workflow(chain_previous_results=True)
+			# The scan's first (non-skipped) workflow only ever receives the
+			# scan-start's empty results, so its start marker is light too — route
+			# it to `small` like the scan start. Later workflows accumulate results
+			# and keep `results`/large. `light_start` changes only the queue, not the
+			# `.s(self)` result forwarding.
+			first_workflow = len(sigs) == 0
+			celery_workflow = workflow.build_celery_workflow(
+				chain_previous_results=True, light_start=first_workflow
+			)
 			for task_id, task_info in workflow.celery_ids_map.items():
 				self.add_subtask(task_id, task_info['name'], task_info['descr'])
 			sigs.append(celery_workflow)

--- a/secator/runners/workflow.py
+++ b/secator/runners/workflow.py
@@ -153,8 +153,14 @@ class Workflow(Runner):
 
 		walk_runner_tree(tree, process_task)
 
-		# Build workflow chain with lifecycle management
-		start_sig = mark_runner_started.si([], self, enable_hooks=True).set(queue='results')
+		# Build workflow chain with lifecycle management.
+		# A parentless / first workflow's start carries no prior results (empty
+		# `[]`), so route it to `small` (fast, warm capacity) rather than the
+		# memory-heavy `results` pool (served by the large worker pool) — this
+		# avoids a scale-from-zero node provision just to mark the workflow started.
+		# When it chains previous results (a workflow inside a scan), its start
+		# receives forwarded results and keeps `results` for the memory headroom.
+		start_sig = mark_runner_started.si([], self, enable_hooks=True).set(queue='small')
 		if chain_previous_results:
 			start_sig = mark_runner_started.s(self, enable_hooks=True).set(queue='results')
 		sig = chain(

--- a/secator/runners/workflow.py
+++ b/secator/runners/workflow.py
@@ -13,7 +13,7 @@ class Workflow(Runner):
 
 	default_exporters = CONFIG.workflows.exporters
 
-	def build_celery_workflow(self, chain_previous_results=False):
+	def build_celery_workflow(self, chain_previous_results=False, light_start=False):
 		"""Build Celery workflow for workflow execution.
 
 		Args:
@@ -154,15 +154,19 @@ class Workflow(Runner):
 		walk_runner_tree(tree, process_task)
 
 		# Build workflow chain with lifecycle management.
-		# A parentless / first workflow's start carries no prior results (empty
-		# `[]`), so route it to `small` (fast, warm capacity) rather than the
-		# memory-heavy `results` pool (served by the large worker pool) — this
-		# avoids a scale-from-zero node provision just to mark the workflow started.
-		# When it chains previous results (a workflow inside a scan), its start
-		# receives forwarded results and keeps `results` for the memory headroom.
-		start_sig = mark_runner_started.si([], self, enable_hooks=True).set(queue='small')
+		# The start marker's pool: a start with no forwarded results — a parentless
+		# workflow (`.si([], ...)`), or a scan's first workflow whose only upstream
+		# is the scan-start's (empty) marker (`light_start`) — is light, so route it
+		# to `small` (fast, warm capacity) instead of the memory-heavy `results`
+		# pool (served by the large worker pool). This avoids a scale-from-zero node
+		# provision just to mark the runner started. A workflow that chains
+		# accumulated results keeps `results` for the memory headroom. `light_start`
+		# only changes the queue — the `.s(self)` form still receives its forwarded
+		# results, so nothing is dropped.
+		start_queue = 'small' if (light_start or not chain_previous_results) else 'results'
+		start_sig = mark_runner_started.si([], self, enable_hooks=True).set(queue=start_queue)
 		if chain_previous_results:
-			start_sig = mark_runner_started.s(self, enable_hooks=True).set(queue='results')
+			start_sig = mark_runner_started.s(self, enable_hooks=True).set(queue=start_queue)
 		sig = chain(
 			start_sig,
 			*sigs,

--- a/tests/unit/test_mark_started_queue.py
+++ b/tests/unit/test_mark_started_queue.py
@@ -1,0 +1,50 @@
+"""Regression: the runner-start marker must not force a large-pool cold start.
+
+`mark_runner_started` used to always dispatch to the `results` queue (served by
+the memory-heavy *large* worker pool) so a workflow deep in a scan could load
+its forwarded results in memory. But a scan's start — and a parentless /
+first-in-scan workflow's start — carries an empty result set (`si([], ...)`), so
+it doesn't need that headroom. Forcing it onto the large pool triggered a
+KEDA scale-from-zero node provision just to *mark the runner started*, which
+dominated scan/workflow start latency.
+
+These tests pin the routing: an empty-results start goes to `small`; a start
+that chains forwarded results (a workflow inside a scan) stays on `results`.
+"""
+import unittest
+
+from secator.runners import Scan, Workflow
+from secator.loader import get_configs_by_type
+
+
+def _first_task_queue(canvas):
+    """Queue of the first step (mark_runner_started) of a built celery chain."""
+    tasks = getattr(canvas, 'tasks', None)
+    assert tasks, f'expected a chain canvas with .tasks, got {canvas!r}'
+    return tasks[0].options.get('queue')
+
+
+class TestMarkStartedQueue(unittest.TestCase):
+    def _workflow(self):
+        workflows = get_configs_by_type('workflow')
+        if not workflows:
+            self.skipTest('No workflows configured')
+        return Workflow(workflows[0], inputs=['example.com'], run_opts={'dry_run': True}, context={})
+
+    def test_parentless_workflow_start_routes_to_small(self):
+        wf = self._workflow()
+        canvas = wf.build_celery_workflow(chain_previous_results=False)
+        self.assertEqual(_first_task_queue(canvas), 'small')
+
+    def test_workflow_chaining_results_stays_on_results(self):
+        wf = self._workflow()
+        canvas = wf.build_celery_workflow(chain_previous_results=True)
+        self.assertEqual(_first_task_queue(canvas), 'results')
+
+    def test_scan_start_routes_to_small(self):
+        scans = get_configs_by_type('scan')
+        if not scans:
+            self.skipTest('No scans configured')
+        scan = Scan(scans[0], inputs=['example.com'], run_opts={'dry_run': True}, context={})
+        canvas = scan.build_celery_workflow()
+        self.assertEqual(_first_task_queue(canvas), 'small')

--- a/tests/unit/test_mark_started_queue.py
+++ b/tests/unit/test_mark_started_queue.py
@@ -41,6 +41,14 @@ class TestMarkStartedQueue(unittest.TestCase):
         canvas = wf.build_celery_workflow(chain_previous_results=True)
         self.assertEqual(_first_task_queue(canvas), 'results')
 
+    def test_workflow_light_start_routes_to_small(self):
+        # A scan's first workflow keeps `.s(self)` (chain_previous_results=True) —
+        # so it still receives the scan-start's forwarded results — but its start is
+        # light (that set is empty), so `light_start` routes just the queue to small.
+        wf = self._workflow()
+        canvas = wf.build_celery_workflow(chain_previous_results=True, light_start=True)
+        self.assertEqual(_first_task_queue(canvas), 'small')
+
     def test_scan_start_routes_to_small(self):
         scans = get_configs_by_type('scan')
         if not scans:


### PR DESCRIPTION
## Problem
`mark_runner_started` is always dispatched to the **`results`** queue — served by the memory-heavy **large** worker pool (`worker-large` serves `large` + `results`) — so a workflow deep in a scan can load its forwarded results in memory.

But the **start of a scan**, and a scan's **first workflow** (whose only upstream is the scan-start's empty marker), and a **parentless workflow**, carry no accumulated results. Putting those on the large pool means a scan flips to `RUNNING` and then **waits for a KEDA scale-from-zero node provision just to mark itself started** before any task schedules — this dominates scan/workflow start latency (observed on GKE Autopilot: scan + workflow `RUNNING`, no tasks, no worker for tens of seconds).

## Fix
Route the light (no accumulated results) starts to **`small`** so they land on existing/warm small-pool capacity:
- `runners/scan.py` — scan start `mark_runner_started.si([], self)` → `queue='small'`.
- `runners/workflow.py` — parentless start (`chain_previous_results=False`, `.si([], ...)`) → `small`; plus a new **`light_start`** flag that routes only the *queue* to `small` while keeping the `.s(self)` form (so forwarded results are still received — nothing dropped).
- `runners/scan.py` — the scan passes `light_start` for its **first** workflow (`len(sigs) == 0`).

Unchanged (still `results`/large, needs the memory headroom): later workflows in a scan (which accumulate results), and `mark_runner_completed` (aggregates the full result set).

Verified on a 5-workflow scan canvas: `scan-start=small, workflow-1 start=small, workflows 2–5 start=results`.

Pairs with a warm-node reservation ("balloon") on `worker-small` for near-instant scan start.

## Tests
`tests/unit/test_mark_started_queue.py`: parentless workflow start → `small`; results-chaining start → `results`; `light_start` → `small`; scan start → `small`. flake8 clean; `test_error_scoping` + new tests green (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)