### PR TITLE
feat(ai): bash commands as runners (generic `command` task)

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -1,7 +1,6 @@
 """Action handlers for AI task."""
 import json
 import os
-import subprocess
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -68,7 +67,12 @@ SENSITIVE_ENV_PREFIXES = (
 
 
 def _sanitized_env() -> dict:
-	"""Return a copy of os.environ with sensitive variables removed."""
+	"""Return a copy of os.environ with sensitive variables removed.
+
+	Passed as the `env` run_opt to the AI shell `command` runner so an AI-run
+	`env`/`printenv` can't dump the LLM key + cloud creds into output that flows
+	back to the LLM and is persisted to Mongo.
+	"""
 	return {k: v for k, v in os.environ.items()
 			if not any(k.startswith(p) for p in SENSITIVE_ENV_PREFIXES)
 			and "KEY" not in k and "SECRET" not in k and "TOKEN" not in k and "PASSWORD" not in k}
@@ -476,6 +480,11 @@ _SUBAGENT_TURN_LOCK = threading.Lock()
 # so the model still sees the start AND the final lines (often the result/error).
 _MAX_SHELL_OUTPUT_CHARS = 4000
 
+# Cap on ad-hoc AI shell commands (dispatched as the `command` task). Applied as an
+# instance attribute post-construction (see _handle_shell) since max_timeout is not a
+# run_opts-settable field.
+_SHELL_TIMEOUT = 60
+
 
 def _guard_subagent_fanout(ctx: "ActionContext", context: Dict) -> Optional["Warning"]:
 	"""H4: cap AI-subagent recursion depth + per-turn fan-out.
@@ -742,7 +751,14 @@ def _handle_workflow(action: Dict, ctx: ActionContext) -> Generator:
 
 
 def _handle_shell(action: Dict, ctx: ActionContext) -> Generator:
-	"""Execute a shell command.
+	"""Execute a shell command as a `command` task runner.
+
+	Dispatches the built-in `command` task (a Command subclass that runs an arbitrary
+	shell command line verbatim) through the normal runner lifecycle, instead of a raw
+	`subprocess.run`. This makes the shell invocation persist as a runner doc (via the
+	driver hooks rebuilt from `context['drivers']`) and appear in history, parented
+	under the conversation via `context['session_id']` — exactly like `_run_runner`
+	does for AI-spawned tasks/workflows.
 
 	Args:
 		action: Action dict with command
@@ -758,19 +774,93 @@ def _handle_shell(action: Dict, ctx: ActionContext) -> Generator:
 		yield Info(message=f"[DRY RUN] Would run: {command}", _context=context)
 		return
 
-	yield Ai(content=command, ai_type="shell", _context=context)
-
 	try:
-		result = subprocess.run(
-			command,
-			shell=True,
-			capture_output=True,
-			text=True,
-			timeout=60,
-			env=_sanitized_env()
+		context["task_chunk_id"] = str(uuid.uuid4())
+		if ctx.subagent:
+			context["subagent"] = ctx.context.get("subagent", True)
+
+		# M2: don't silently run a persistence-less child when the parent has drivers
+		# (same guard _run_runner uses for spawned tasks/workflows).
+		hooks, denial = _build_child_hooks_or_denial(context)
+		if denial is not None:
+			yield denial
+			return
+
+		# _build_child_hooks_or_denial returns a CLASS-keyed dict ({Scan:{}, Workflow:{},
+		# Task:{on_init:[...], on_end:[...], ...}}). The generic Task wrapper forwards
+		# self._hooks.get(Task, {}) down to its command signature, but we bypass the
+		# wrapper with direct `command(...)` instantiation, so we must extract the
+		# Task-level (name-keyed) sub-dict ourselves. Without this, register_hooks
+		# resolves hooks via hooks.get(command)/hooks.get('on_init') — neither key exists
+		# in a class-keyed dict — so the mongodb update_runner/on_build hooks never fire
+		# and the runner doc is silently never persisted (command runs SUCCESS, no doc).
+		hooks = hooks.get(Task, {})
+
+		# Run opts mirroring _run_runner's wiring: quiet unless the caller wants
+		# console chatter, reports enabled (findings flow through the normal
+		# pipeline), never dangerous (defense in depth). `env` is the sanitized
+		# process env so an AI-run `env`/`printenv` can't leak the LLM key / cloud
+		# creds into output that reaches the LLM + Mongo (honored via the `env`
+		# run_opt added to Command.yielder).
+		run_opts = {
+			"print_item": not ctx.silent,
+			"print_line": ctx.verbose and not ctx.silent,
+			"print_cmd": False,
+			"print_progress": False,
+			"print_reports_message": False,
+			"enable_reports": True,
+			"exporters": [],
+			"sync": ctx.sync,
+			"dangerous": False,
+			"env": _sanitized_env(),
+		}
+
+		# Instantiate the concrete `command` task directly (NOT the generic Task
+		# wrapper). The wrapper's sync path runs a throwaway inner instance inside
+		# secator.celery.run_command and returns only the structured results, so the
+		# outer wrapper's `.output` stays empty. A direct instance runs the command
+		# in-process and keeps its captured stdout on `.output`, while still firing
+		# the on_init/on_start/on_end driver hooks so the runner doc persists (with
+		# output/status/session_id) parented under the conversation.
+		#
+		# NOTE: `command` (a Command subclass) takes **run_opts, not a `run_opts=`
+		# kwarg — passing `run_opts=` would nest it and silently drop `env` (and every
+		# other opt). Spread it, keeping hooks/context as their own kwargs (both are
+		# popped by Command.__init__).
+		#
+		# Imported locally (not at module top): a top-level `from secator.tasks...`
+		# forces secator.tasks/__init__ to run discover_tasks() while secator.ai.actions
+		# is still being imported, which drops the `ai` task from discovery (circular
+		# import). The function-level import defers it to call time, after all modules
+		# are loaded.
+		from secator.tasks.command import command as CommandTask
+		runner = CommandTask([command], hooks=hooks, context=context, **run_opts)
+
+		# 60s cap on ad-hoc AI shell commands. max_timeout is NOT run_opts-settable
+		# (Command.__init__ resolves it from CONFIG.tasks.overrides); setting the
+		# instance attribute here is honored by get_max_timeout().
+		runner.max_timeout = _SHELL_TIMEOUT
+
+		# Emit the command Ai now that the runner exists: its on_init hook has
+		# stamped the runner id into context, so the UI can link this item to the
+		# persisted runner doc (mirrors _run_runner:688-699).
+		yield Ai(
+			content=command,
+			ai_type="shell",
+			extra_data={
+				"runner_id": context.get("task_id", "") or runner.id,
+				"runner_type": "task",
+			},
+			_context=context,
 		)
-		output = result.stdout or result.stderr or "(no output)"
-		output = _truncate(output, _MAX_SHELL_OUTPUT_CHARS)  # M1: cap so it can't blow up history
+
+		# Run to completion in-process — this fires the persist hooks (on_start/
+		# on_end) exactly like a dispatched task/workflow. Do NOT `yield from
+		# runner`: the command's raw stdout lines are not surfaced as separate
+		# transcript items — the single shell_output below is the contract.
+		runner.run()
+
+		output = _truncate(runner.output or "(no output)", _MAX_SHELL_OUTPUT_CHARS)  # M1: cap so it can't blow up history
 		yield Ai(content=output, ai_type="shell_output", _context=context)
 
 	except Exception as e:

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -287,7 +287,7 @@ class Runner:
 
 	@property
 	def resolved_opts(self):
-		return {k: v for k, v in self.run_opts.items() if v is not None and not k.startswith('print_') and not k.endswith('_')}  # noqa: E501
+		return {k: v for k, v in self.run_opts.items() if v is not None and not k.startswith('print_') and not k.endswith('_') and k != 'env'}  # noqa: E501
 
 	@property
 	def resolved_print_opts(self):

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -538,8 +538,13 @@ class Command(Runner):
 				self.cwd = f'{self.reports_folder}/.outputs/{self.fqn}'
 				os.makedirs(self.cwd, exist_ok=True)
 
-			# Run the command using subprocess
-			env = os.environ
+			# Run the command using subprocess. A caller may pass a sanitized/custom env
+			# via the `env` run_opt (e.g. the AI shell handler strips LLM/cloud secrets so
+			# an AI-run `env`/`printenv` can't dump them). Defaults to the process env when
+			# the opt is absent (existing behavior unchanged). Uses `.get(key, default)`
+			# (not `or`) so an explicit empty `env={}` — a deliberate empty environment —
+			# is honored rather than silently falling back to the full process env.
+			env = self.run_opts.get('env', os.environ)
 			self.process = subprocess.Popen(
 				command,
 				stdin=subprocess.PIPE if sudo_password else None,

--- a/secator/tasks/command.py
+++ b/secator/tasks/command.py
@@ -1,0 +1,30 @@
+from secator.decorators import task
+from secator.definitions import STRING
+from secator.runners import Command
+
+
+@task()
+class command(Command):
+	"""Run an arbitrary shell command verbatim."""
+	cmd = ''
+	shell = True
+	input_flag = None
+	input_types = [STRING]
+	output_types = []
+
+	def _build_cmd(self):
+		"""Set the command to the raw input verbatim (no flag/opt append, no quoting)."""
+		self.cmd = self.inputs[0] if self.inputs else ''
+		self.cmd_options = {}
+		# Command.__init__ runs _build_cmd_input() BEFORE _build_cmd(), and it clobbers
+		# self.shell to (' | ' in self.cmd) — i.e. False for most commands. Restore the
+		# intended shell mode so &&, ;, redirects, $VAR, globbing are interpreted.
+		self.shell = True
+
+	def is_installed(self):
+		"""Arbitrary shell commands have no fixed binary to `which`/auto-install (the base
+		Command.is_installed() derives cmd_name from the class-level `cmd`, which is '' here).
+		Always report installed so the base yielder runs the input verbatim instead of trying
+		(and failing) to auto-install an empty command name.
+		"""
+		return True

--- a/secator/tasks/command.py
+++ b/secator/tasks/command.py
@@ -1,5 +1,8 @@
+from datetime import datetime, timezone
+from time import time
+
 from secator.decorators import task
-from secator.definitions import STRING
+from secator.output_types import Error
 from secator.runners import Command
 
 
@@ -9,7 +12,14 @@ class command(Command):
 	cmd = ''
 	shell = True
 	input_flag = None
-	input_types = [STRING]
+	# NOTE: input_types MUST be empty. A non-empty input_types makes the base
+	# _validate_inputs() (secator/runners/_base.py) run autodetect_type() on each input and
+	# DROP any whose detected type isn't in the list. A command line like "whoami" is
+	# autodetected as 'slug' (not 'str'), so [STRING] would silently strip most bare
+	# single-word commands -> empty inputs -> empty cmd -> FAILURE. An empty input_types
+	# short-circuits the type filter entirely, which is correct: a command line is not a
+	# typed scan target.
+	input_types = []
 	output_types = []
 
 	def _build_cmd(self):
@@ -28,3 +38,67 @@ class command(Command):
 		(and failing) to auto-install an empty command name.
 		"""
 		return True
+
+	@classmethod
+	def from_result(cls, command_line, output, return_code, *, start_time=None, end_time=None, context=None, hooks=None):
+		"""Build a `command` runner from an ALREADY-RUN command's result, without executing it.
+
+		This is the "import" path (as opposed to the "execute" path exercised by
+		`run()`/`yielder()`): it never spawns a subprocess, it just populates the runner's
+		state fields from a result that was captured elsewhere, then fires the same
+		`on_start`/`on_end` hooks a normal run would fire so the imported command persists
+		like any other runner (e.g. via an `update_runner` hook passed in `hooks`). This is
+		the forward-looking seam for importing externally-run commands into Secator Cloud.
+
+		Args:
+			command_line (str): The command line that was run, verbatim. It becomes `self.cmd`
+				via the constructor -> `_build_cmd()`, same as the live-execution path (with
+				`input_types = []`, inputs are never type-filtered, so this holds for every
+				command line, including bare single-word ones like "whoami").
+			output (str): Captured stdout of the already-run command.
+			return_code (int): Process return code of the already-run command. 0 means
+				success; anything else marks the runner FAILURE (an `Error` result is added
+				so `self_errors`, which `status` derives from, is non-empty).
+			start_time (datetime, optional): When the command started (tz-aware). Defaults
+				to now if omitted.
+			end_time (datetime, optional): When the command finished (tz-aware). Defaults to
+				now if omitted.
+			context (dict, optional): Runner context (workspace, etc), same as the live path.
+			hooks (dict, optional): Runner hooks (e.g. `on_end: [update_runner]`), same as the
+				live path -- this is how the imported result gets persisted.
+
+		Returns:
+			command: the populated runner, in SUCCESS or FAILURE status. `yielder()` /
+			`run()` are never called, so no subprocess is ever spawned.
+		"""
+		runner = cls(inputs=[command_line], context=context or {}, hooks=hooks or {})
+
+		# mark_started() fires the on_start hook. It also stamps start_time = now(), so
+		# apply the caller-supplied start_time right after (mark_started() unconditionally
+		# overwrites it, there's no way to seed it beforehand).
+		runner.mark_started()
+		runner.start_time = start_time or datetime.fromtimestamp(time(), timezone.utc)
+
+		# Populate the captured result.
+		runner.output = output
+		runner.return_code = return_code
+		if return_code != 0:
+			# `status` derives FAILURE from `self_errors` being non-empty (see
+			# secator/runners/_base.py). add_result() stamps `_source` to this runner's
+			# unique_name, which is what `_owns_error()` matches on for a task runner.
+			# output=False is REQUIRED: the default (output=True) would do
+			# `self.output += repr(item)` (_base.py), appending this synthetic Error's
+			# ANSI-colored repr onto the caller's captured stdout and corrupting it.
+			runner.add_result(
+				Error(message=f'Command exited with return code {return_code}'),
+				print=False,
+				output=False,
+			)
+
+		# mark_completed() fires the on_end hook (the persistence path). Same caveat as
+		# start_time: it unconditionally stamps end_time = now(), so apply the
+		# caller-supplied end_time right after.
+		runner.mark_completed()
+		runner.end_time = end_time or datetime.fromtimestamp(time(), timezone.utc)
+
+		return runner

--- a/tests/unit/test_ai_actions.py
+++ b/tests/unit/test_ai_actions.py
@@ -15,6 +15,7 @@ if ADDONS_ENABLED['ai']:
 		_MAX_CHILD_ITERATIONS, _MAX_SUBAGENT_DEPTH, _MAX_SUBAGENTS_PER_TURN,
 		_MAX_SHELL_OUTPUT_CHARS, _truncate,
 	)
+	from secator.runners import Task
 	from secator.output_types import Ai, Error, Info, Warning, Vulnerability, Url
 
 
@@ -149,58 +150,130 @@ class TestHandleShell(unittest.TestCase):
 		self.assertIn('DRY RUN', results[0].message)
 		self.assertIn('whoami', results[0].message)
 
-	@patch('secator.ai.actions.subprocess.run')
-	def test_shell_execution(self, mock_run):
-		mock_run.return_value = MagicMock(stdout='root\n', stderr='')
+	def test_shell_execution(self):
+		"""Real integration test: `_handle_shell` dispatches the actual `command` task
+		(no driver -> no persistence, but it still runs) and surfaces its stdout."""
 		ctx = ActionContext(targets=['t.com'], model='m')
 
-		results = list(_handle_shell({'action': 'shell', 'command': 'whoami'}, ctx))
+		results = list(_handle_shell({'action': 'shell', 'command': 'echo hello'}, ctx))
 
 		self.assertEqual(len(results), 2)
 		# First: the command being run
 		self.assertIsInstance(results[0], Ai)
 		self.assertEqual(results[0].ai_type, 'shell')
-		self.assertEqual(results[0].content, 'whoami')
+		self.assertEqual(results[0].content, 'echo hello')
 		# Second: the output
 		self.assertIsInstance(results[1], Ai)
 		self.assertEqual(results[1].ai_type, 'shell_output')
-		self.assertIn('root', results[1].content)
+		self.assertIn('hello', results[1].content)
 
-	@patch('secator.ai.actions.subprocess.run')
-	def test_shell_stderr(self, mock_run):
-		mock_run.return_value = MagicMock(stdout='', stderr='error msg')
+	@patch('secator.tasks.command.command')
+	def test_shell_dispatches_command_task_with_parent_context(self, mock_task_cls):
+		"""The shell command must run as a `command` task carrying the parent's context
+		(notably `session_id`), so it persists nested under the conversation."""
+		fake_runner = MagicMock()
+		fake_runner.id = 'task_abc'
+		fake_runner.output = 'hello'
+		mock_task_cls.return_value = fake_runner
+
+		ctx = ActionContext(targets=['t.com'], model='m', session_id='sess-123')
+		results = list(_handle_shell({'action': 'shell', 'command': 'echo hello'}, ctx))
+
+		# CommandTask constructed with the raw command line as its sole input (first
+		# positional arg, since we instantiate the concrete class directly).
+		call_args = mock_task_cls.call_args
+		self.assertEqual(call_args[0][0], ['echo hello'])
+		captured_context = call_args[1]['context']
+		self.assertEqual(captured_context.get('session_id'), 'sess-123')
+
+		fake_runner.run.assert_called_once()
+		self.assertEqual(fake_runner.max_timeout, 60)
+
+		self.assertEqual(results[0].ai_type, 'shell')
+		# The shell Ai must carry the UI-linking extra_data (runner_type + runner_id)
+		# so a future regression in that wiring is caught.
+		self.assertEqual(results[0].extra_data.get('runner_type'), 'task')
+		self.assertTrue(results[0].extra_data.get('runner_id'))
+		self.assertEqual(results[-1].ai_type, 'shell_output')
+		self.assertIn('hello', results[-1].content)
+
+	@patch('secator.tasks.command.command')
+	def test_shell_passes_sanitized_env(self, mock_task_cls):
+		"""SECURITY: the sanitized process env is passed via the `env` run_opt so an
+		AI-run `env`/`printenv` can't dump the LLM key / cloud creds into output that
+		reaches the LLM + Mongo."""
+		import os as _os
+		fake_runner = MagicMock()
+		fake_runner.id = 'task_abc'
+		fake_runner.output = ''
+		mock_task_cls.return_value = fake_runner
+
+		with patch.dict(_os.environ, {'ANTHROPIC_API_KEY': 'sk-secret', 'HOME': '/home/x'}):
+			ctx = ActionContext(targets=['t.com'], model='m')
+			list(_handle_shell({'action': 'shell', 'command': 'env'}, ctx))
+
+		# run_opts are spread as kwargs (command takes **run_opts), so `env` is a
+		# top-level kwarg, not nested under a `run_opts` kwarg.
+		passed_env = mock_task_cls.call_args[1]['env']
+		self.assertNotIn('ANTHROPIC_API_KEY', passed_env)
+		# a benign var still passes through so the command can actually run
+		self.assertEqual(passed_env.get('HOME'), '/home/x')
+
+	@patch('secator.ai.actions._build_child_hooks_or_denial')
+	def test_shell_extracts_task_hooks_and_they_fire(self, mock_hooks):
+		"""REGRESSION GUARD (live-Mongo bug): _build_child_hooks_or_denial returns a
+		CLASS-keyed dict ({Task: {on_end: [...]}, ...}). Direct `command` instantiation
+		bypasses the Task wrapper that would extract the Task sub-dict, so _handle_shell
+		must extract `hooks.get(Task, {})` itself — otherwise register_hooks resolves
+		nothing and the mongodb persistence hooks never fire (command runs SUCCESS but
+		no doc is persisted). This asserts the extraction happened AND the hook actually
+		fired during the real run — a flat-dict mock cannot catch the extraction bug.
+		"""
+		fired = []
+
+		def sentinel(runner):
+			fired.append(runner)
+			return runner  # on_end convention: return the runner
+
+		mock_hooks.return_value = ({Task: {'on_end': [sentinel]}}, None)
+
 		ctx = ActionContext(targets=['t.com'], model='m')
+		results = list(_handle_shell({'action': 'shell', 'command': 'echo hi'}, ctx))
 
-		results = list(_handle_shell({'action': 'shell', 'command': 'bad'}, ctx))
+		# The class-keyed dict was extracted to the Task sub-dict, so the on_end hook
+		# resolved and fired against the real command runner.
+		self.assertTrue(fired, "on_end hook did not fire — Task sub-dict was not extracted")
+		self.assertEqual(results[-1].ai_type, 'shell_output')
+		self.assertIn('hi', results[-1].content)
 
-		self.assertEqual(results[1].content, 'error msg')
-
-	@patch('secator.ai.actions.subprocess.run')
-	def test_shell_no_output(self, mock_run):
-		mock_run.return_value = MagicMock(stdout='', stderr='')
+	def test_shell_no_output(self):
 		ctx = ActionContext(targets=['t.com'], model='m')
 
 		results = list(_handle_shell({'action': 'shell', 'command': 'true'}, ctx))
 
 		self.assertEqual(results[1].content, '(no output)')
 
-	@patch('secator.ai.actions.subprocess.run')
-	def test_shell_exception(self, mock_run):
-		mock_run.side_effect = Exception('Command timed out')
+	@patch('secator.tasks.command.command')
+	def test_shell_exception(self, mock_task_cls):
+		mock_task_cls.side_effect = Exception('Command timed out')
 		ctx = ActionContext(targets=['t.com'], model='m')
 
 		results = list(_handle_shell({'action': 'shell', 'command': 'slow'}, ctx))
 
-		# shell Ai + Error
-		self.assertEqual(len(results), 2)
-		self.assertIsInstance(results[1], Error)
-		self.assertIn('failed', results[1].message)
+		# Only the Error (the shell Ai is emitted AFTER construction, which never
+		# succeeds here).
+		self.assertEqual(len(results), 1)
+		self.assertIsInstance(results[0], Error)
+		self.assertIn('failed', results[0].message)
 
-	@patch('secator.ai.actions.subprocess.run')
-	def test_shell_output_capped_when_over_limit(self, mock_run):
+	@patch('secator.tasks.command.command')
+	def test_shell_output_capped_when_over_limit(self, mock_task_cls):
 		# M1: huge stdout must be truncated to <= cap + marker and carry the marker.
 		big = "HEAD_LINE\n" + ("x" * (_MAX_SHELL_OUTPUT_CHARS * 3)) + "\nTAIL_LINE"
-		mock_run.return_value = MagicMock(stdout=big, stderr='')
+		fake_runner = MagicMock()
+		fake_runner.id = 'task_abc'
+		fake_runner.output = big
+		mock_task_cls.return_value = fake_runner
 		ctx = ActionContext(targets=['t.com'], model='m')
 
 		results = list(_handle_shell({'action': 'shell', 'command': 'dump'}, ctx))
@@ -214,15 +287,14 @@ class TestHandleShell(unittest.TestCase):
 		self.assertIn('HEAD_LINE', content)
 		self.assertIn('TAIL_LINE', content)
 
-	@patch('secator.ai.actions.subprocess.run')
-	def test_shell_output_short_passes_through_unchanged(self, mock_run):
-		# M1: short output must pass through untouched (no marker).
-		mock_run.return_value = MagicMock(stdout='root\n', stderr='')
+	def test_shell_output_short_passes_through_unchanged(self):
+		# M1: short output must pass through untouched (no marker). The `command`
+		# runner rstrips its captured output, so a trailing newline is not expected.
 		ctx = ActionContext(targets=['t.com'], model='m')
 
-		results = list(_handle_shell({'action': 'shell', 'command': 'whoami'}, ctx))
+		results = list(_handle_shell({'action': 'shell', 'command': 'echo root'}, ctx))
 
-		self.assertEqual(results[1].content, 'root\n')
+		self.assertEqual(results[1].content, 'root')
 		self.assertNotIn('truncated', results[1].content)
 
 	def test_truncate_short_text_unchanged(self):

--- a/tests/unit/test_ai_loop.py
+++ b/tests/unit/test_ai_loop.py
@@ -24,6 +24,21 @@ if HAS_AI:
 	from secator.output_types import Ai
 
 
+def _fake_command_runner(output):
+	"""Build a fake `command` runner instance for patching secator.tasks.command.command.
+
+	The AI shell path now runs commands as the `command` task (not subprocess.run), so
+	these E2E flows patch the class at its source and hand back an instance exposing the
+	fields _handle_shell reads: `.output` (captured stdout), `.id`, `.status`, a callable
+	`.run()`, and a settable `.max_timeout`. Mirrors the fake used in TestHandleShell.
+	"""
+	fake = MagicMock()
+	fake.output = output
+	fake.id = "task_fake"
+	fake.status = "SUCCESS"
+	return fake
+
+
 def _make_tool_call(name, args, tc_id=None):
 	"""Create a mock litellm tool call object."""
 	tc = MagicMock()
@@ -517,8 +532,8 @@ class TestLocalModeFlow(unittest.TestCase):
 		mock_shell_prompt.assert_called_once()
 
 		# Dispatch the approved action
-		with patch('secator.ai.actions.subprocess.run') as mock_run:
-			mock_run.return_value = MagicMock(stdout="exploit output\n", stderr="")
+		with patch('secator.tasks.command.command') as mock_cmd:
+			mock_cmd.return_value = _fake_command_runner("exploit output")
 			results1 = list(dispatch_action(shell_action, ctx))
 
 		# Verify shell output was produced
@@ -598,8 +613,8 @@ class TestRemoteModeFlow(unittest.TestCase):
 		self.assertIsNone(denial, f"Expected approval but got: {denial}")
 
 		# Dispatch the approved action
-		with patch('secator.ai.actions.subprocess.run') as mock_run:
-			mock_run.return_value = MagicMock(stdout="exploit output\n", stderr="")
+		with patch('secator.tasks.command.command') as mock_cmd:
+			mock_cmd.return_value = _fake_command_runner("exploit output")
 			results1 = list(dispatch_action(shell_action, ctx))
 
 		ai_results = [r for r in results1 if isinstance(r, Ai)]
@@ -705,8 +720,8 @@ class TestAutoModeFlow(unittest.TestCase):
 		denial, warnings = check_guardrails(action, ctx)
 		self.assertIsNone(denial)
 
-		with patch('secator.ai.actions.subprocess.run') as mock_run:
-			mock_run.return_value = MagicMock(stdout="response data", stderr="")
+		with patch('secator.tasks.command.command') as mock_cmd:
+			mock_cmd.return_value = _fake_command_runner("response data")
 			results = list(dispatch_action(action, ctx))
 
 		ai_results = [r for r in results if isinstance(r, Ai)]
@@ -839,8 +854,8 @@ class TestMainLoopLocalE2E(unittest.TestCase):
 		self.assertIsNone(denial)
 
 		# Dispatch
-		with patch('secator.ai.actions.subprocess.run') as mock_subprocess:
-			mock_subprocess.return_value = MagicMock(stdout="scan results\n", stderr="")
+		with patch('secator.tasks.command.command') as mock_cmd:
+			mock_cmd.return_value = _fake_command_runner("scan results")
 			results1 = list(dispatch_action(action, ctx))
 		self.assertTrue(any(isinstance(r, Ai) and r.ai_type == "shell_output" for r in results1))
 
@@ -923,8 +938,8 @@ class TestMainLoopRemoteE2E(unittest.TestCase):
 		self.assertIsNone(denial, f"Expected remote approval but got: {denial}")
 
 		# Dispatch (mock subprocess only around dispatch_action)
-		with patch('secator.ai.actions.subprocess.run') as mock_subprocess:
-			mock_subprocess.return_value = MagicMock(stdout="scan results\n", stderr="")
+		with patch('secator.tasks.command.command') as mock_cmd:
+			mock_cmd.return_value = _fake_command_runner("scan results")
 			results1 = list(dispatch_action(action, ctx))
 		self.assertTrue(any(isinstance(r, Ai) and r.ai_type == "shell_output" for r in results1))
 
@@ -994,8 +1009,8 @@ class TestMainLoopAutoE2E(unittest.TestCase):
 		denial2, _ = check_guardrails(action2, ctx)
 		self.assertIsNone(denial2, "Allowed command should pass in auto mode")
 
-		with patch('secator.ai.actions.subprocess.run') as mock_subprocess:
-			mock_subprocess.return_value = MagicMock(stdout="output\n", stderr="")
+		with patch('secator.tasks.command.command') as mock_cmd:
+			mock_cmd.return_value = _fake_command_runner("output")
 			results = list(dispatch_action(action2, ctx))
 		self.assertTrue(any(isinstance(r, Ai) and r.ai_type == "shell_output" for r in results))
 

--- a/tests/unit/test_command_task.py
+++ b/tests/unit/test_command_task.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from secator.runners import Command
 from secator.tasks.command import command
@@ -33,6 +34,19 @@ class TestCommandTask(unittest.TestCase):
 		self.assertNotIn("&&", runner.output)
 		self.assertTrue(runner.shell)
 
+	def test_bare_single_word_command_is_not_stripped(self):
+		"""A bare single-word command (no space) must run, not get type-filtered away.
+
+		`input_types` must be [] — a non-empty input_types makes the base _validate_inputs()
+		run autodetect_type() and DROP inputs whose detected type isn't listed. "true" is
+		autodetected as 'slug', so [STRING] would strip it -> empty inputs -> empty cmd ->
+		FAILURE. This is the exact shape that broke most ordinary commands.
+		"""
+		runner = command(inputs=["true"], run_opts={"sync": True, "print_line": False, "print_item": False})
+		runner.run()
+		self.assertEqual(runner.cmd, "true")
+		self.assertEqual(runner.status, "SUCCESS")
+
 	def test_empty_inputs_does_not_crash(self):
 		"""With no inputs, _build_cmd must not crash (cmd stays empty rather than indexing inputs[0])."""
 		runner = command(inputs=[], run_opts={"sync": True, "print_line": False, "print_item": False})
@@ -42,3 +56,57 @@ class TestCommandTask(unittest.TestCase):
 	def test_is_a_command_subclass(self):
 		"""Sanity check on the inheritance the rest of the PR relies on."""
 		self.assertTrue(issubclass(command, Command))
+
+
+class TestCommandFromResult(unittest.TestCase):
+	"""`command.from_result` imports an already-run command's result into a runner doc,
+	without executing anything (the forward-looking seam for importing externally-run
+	commands into Secator Cloud).
+	"""
+
+	@mock.patch("subprocess.Popen")
+	def test_from_result_populates_runner_without_executing(self, mock_popen):
+		"""A successful imported result populates output/status and never spawns a subprocess."""
+		runner = command.from_result("nmap -p80 x", "PORT 80 open", 0)
+
+		self.assertEqual(runner.output, "PORT 80 open")
+		self.assertEqual(runner.status, "SUCCESS")
+		mock_popen.assert_not_called()
+
+		data = runner.toDict()
+		self.assertEqual(data["cmd"], "nmap -p80 x")
+		self.assertEqual(data["output"], "PORT 80 open")
+		self.assertEqual(data["status"], "SUCCESS")
+		self.assertEqual(data["return_code"], 0)
+
+	@mock.patch("subprocess.Popen")
+	def test_from_result_bare_command_success(self, mock_popen):
+		"""A bare single-word command imports as SUCCESS with its cmd + output intact.
+
+		Regression for the input-type-stripping bug: before the fix, "whoami" was
+		autodetected as 'slug' and dropped, so cmd came back '' and status FAILURE (the
+		spurious empty-input Error). The passed-in output is a fixed literal so the
+		assertion is deterministic (not machine-dependent).
+		"""
+		runner = command.from_result("whoami", "someoutput", 0)
+
+		self.assertEqual(runner.status, "SUCCESS")
+		self.assertEqual(runner.cmd, "whoami")
+		self.assertEqual(runner.output, "someoutput")
+		mock_popen.assert_not_called()
+
+	@mock.patch("subprocess.Popen")
+	def test_from_result_failure_preserves_output_verbatim(self, mock_popen):
+		"""A non-zero return code yields FAILURE, and the caller's output is preserved verbatim.
+
+		Regression for the output-corruption bug: the synthetic Error added on the FAILURE
+		path must NOT be appended onto self.output (add_result must be called output=False).
+		"""
+		runner = command.from_result("somecmd", "the real stdout", 1)
+
+		self.assertEqual(runner.status, "FAILURE")
+		self.assertEqual(runner.toDict()["status"], "FAILURE")
+		# Exact match — no ANSI Error repr appended.
+		self.assertEqual(runner.output, "the real stdout")
+		self.assertEqual(runner.toDict()["output"], "the real stdout")
+		mock_popen.assert_not_called()

--- a/tests/unit/test_command_task.py
+++ b/tests/unit/test_command_task.py
@@ -1,0 +1,44 @@
+import unittest
+
+from secator.runners import Command
+from secator.tasks.command import command
+
+
+class TestCommandTask(unittest.TestCase):
+	"""The generic `command` task runs an arbitrary command line verbatim in shell mode."""
+
+	def test_runs_verbatim_and_captures_stdout(self):
+		"""A trivial echo runs through the real Command yielder and reaches SUCCESS with stdout captured."""
+		runner = command(inputs=["echo secator-pr3"], run_opts={"sync": True, "print_line": False, "print_item": False})
+		runner.run()
+		self.assertEqual(runner.status, "SUCCESS")
+		self.assertIn("secator-pr3", runner.output)
+		self.assertEqual(runner.return_code, 0)
+
+	def test_shell_metacharacters_are_interpreted(self):
+		"""Shell operators (&&) must be interpreted, not passed as literal echo args.
+
+		Under shell=False the whole string is shlex-split and `&&` becomes a literal echo
+		argument, so only the first echo runs and 'world' never appears. This proves the
+		task actually runs in shell mode end-to-end.
+		"""
+		opts = {"sync": True, "print_line": False, "print_item": False}
+		runner = command(inputs=["echo hello && echo world"], run_opts=opts)
+		runner.run()
+		self.assertEqual(runner.status, "SUCCESS")
+		self.assertIn("hello", runner.output)
+		self.assertIn("world", runner.output)
+		# Under shell=False the whole thing is one echo, so '&&' is echoed literally.
+		# Interpreted correctly, '&&' is an operator and never appears in stdout.
+		self.assertNotIn("&&", runner.output)
+		self.assertTrue(runner.shell)
+
+	def test_empty_inputs_does_not_crash(self):
+		"""With no inputs, _build_cmd must not crash (cmd stays empty rather than indexing inputs[0])."""
+		runner = command(inputs=[], run_opts={"sync": True, "print_line": False, "print_item": False})
+		runner._build_cmd()
+		self.assertEqual(runner.cmd, "")
+
+	def test_is_a_command_subclass(self):
+		"""Sanity check on the inheritance the rest of the PR relies on."""
+		self.assertTrue(issubclass(command, Command))

--- a/tests/unit/test_command_task.py
+++ b/tests/unit/test_command_task.py
@@ -104,6 +104,23 @@ class TestCommandTask(unittest.TestCase):
 		self.assertNotIn('sk-leakme', runner.output)
 		self.assertIn('[]', runner.output)
 
+	def test_env_run_opt_is_not_persisted(self):
+		"""The `env` run_opt must be runtime-only, NOT persisted into the runner doc.
+
+		`resolved_opts` -> `toDict()['run_opts']` is written to Mongo by the mongodb driver
+		and exposed via the runner-list API. Persisting `env` would write the whole (denylist-
+		sanitized) process environment — DB URLs, internal hostnames, etc. that the denylist
+		misses — into every AI-shell runner's history, a broader disclosure than the command's
+		own output. `resolved_opts` excludes `env` so the subprocess still reads it from
+		`run_opts` (command.py) but it never reaches the persisted doc.
+		"""
+		custom_env = {'FOO': 'bar', 'DATABASE_URL': 'postgres://u:pw@host', 'PATH': os.environ.get('PATH', '')}
+		runner = command(['echo hi'], sync=True, print_line=False, print_item=False, env=custom_env)
+		persisted_opts = runner.toDict()['run_opts']
+		self.assertNotIn('env', persisted_opts)
+		# sanity: the runner still holds env at runtime for the subprocess to use
+		self.assertEqual(runner.run_opts.get('env'), custom_env)
+
 
 class TestCommandFromResult(unittest.TestCase):
 	"""`command.from_result` imports an already-run command's result into a runner doc,

--- a/tests/unit/test_command_task.py
+++ b/tests/unit/test_command_task.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest import mock
 
@@ -56,6 +57,52 @@ class TestCommandTask(unittest.TestCase):
 	def test_is_a_command_subclass(self):
 		"""Sanity check on the inheritance the rest of the PR relies on."""
 		self.assertTrue(issubclass(command, Command))
+
+	def test_env_run_opt_is_honored(self):
+		"""A custom `env` run_opt overrides the process env for the subprocess.
+
+		The AI shell handler relies on this to pass a SANITIZED env (LLM key / cloud
+		creds stripped) so an AI-run `env`/`printenv` can't leak them. PATH is included
+		so /bin/sh can still resolve the shell builtin. Opts are spread as kwargs
+		(command takes **run_opts) so `env` actually reaches self.run_opts.
+		"""
+		custom_env = {'FOO': 'bar', 'PATH': os.environ.get('PATH', '')}
+		runner = command(
+			['echo $FOO'],
+			sync=True, print_line=False, print_item=False, env=custom_env,
+		)
+		runner.run()
+		self.assertEqual(runner.status, 'SUCCESS')
+		self.assertIn('bar', runner.output)
+
+	def test_no_env_run_opt_uses_process_env(self):
+		"""Control: with no `env` run_opt, the subprocess inherits the process env
+		(default behavior unchanged)."""
+		with mock.patch.dict(os.environ, {'SECATOR_ENV_PROBE': 'present'}):
+			runner = command(
+				['echo $SECATOR_ENV_PROBE'],
+				sync=True, print_line=False, print_item=False,
+			)
+			runner.run()
+		self.assertEqual(runner.status, 'SUCCESS')
+		self.assertIn('present', runner.output)
+
+	def test_empty_env_run_opt_is_honored(self):
+		"""An explicit empty `env={}` must be honored (deliberate empty environment),
+		NOT silently fall back to the full process env — otherwise a caller asking for a
+		locked-down env would leak every process var. Guards the `.get('env', os.environ)`
+		(vs truthiness `or os.environ`) semantics.
+		"""
+		with mock.patch.dict(os.environ, {'ANTHROPIC_API_KEY': 'sk-leakme'}):
+			runner = command(
+				['echo "[$ANTHROPIC_API_KEY]"'],
+				sync=True, print_line=False, print_item=False, env={},
+			)
+			runner.run()
+		self.assertEqual(runner.status, 'SUCCESS')
+		# With an empty env the var is unset, so the shell expands it to nothing.
+		self.assertNotIn('sk-leakme', runner.output)
+		self.assertIn('[]', runner.output)
 
 
 class TestCommandFromResult(unittest.TestCase):


### PR DESCRIPTION
Shell commands the AI runs become first-class secator runners — persisted as runner docs, visible in history, parented under the conversation via `context.session_id`. Built on `origin/ai-resiliency` (PR 3 of the AI subagent/parenting/bash-runner design).

## What's in it
- **`command` task** (`secator/tasks/command.py`) — a `Command` subclass that runs an arbitrary command line verbatim in shell mode (`input_types=[]` so bare commands like `whoami` aren't type-stripped; `_build_cmd` restores `shell=True`). stdout captured via the base runner's `self.output`.
- **`command.from_result(...)`** — a populate-without-execute import seam (build a runner doc from an already-run command's cmd/output/status/timing without re-running it — the future path for importing externally-run commands into Cloud). Execute vs populate paths cleanly separated.
- **`_handle_shell` rewired** (`secator/ai/actions.py`) — dispatches the `command` task in-process instead of raw `subprocess.run`, so the command persists as a runner doc (mongodb `update_runner` hooks) parented by `session_id`, while preserving the `shell`/`shell_output` transcript contract, the 60s timeout, and the output cap.
- **env sanitization preserved & hardened** — a backward-compatible `env` run-opt on base `Command` (`env = self.run_opts.get('env', os.environ)`) lets `_handle_shell` pass `_sanitized_env()` (strips `ANTHROPIC_`/`AWS_`/`SECRET_`/API-key vars) so an AI-run `env` can't leak creds into output; `env` is kept **runtime-only** (excluded from persisted `resolved_opts`) so it never lands in the runner doc.

## Testing
- Unit: `tests/unit/test_command_task.py` (verbatim exec, shell metachars, bare-command, from_result success/failure/no-exec, env honored/not-persisted), plus rewired `test_ai_actions.py`/`test_ai_loop.py` shell tests. Full `tests/unit`: **1071 passed, 0 regressions** vs baseline.
- E2E: verified against a live Mongo — an AI shell command persists a `command` runner doc with cmd/output/status, parented by `session_id`, and the `shell_output` appears in the transcript.

Built via subagent-driven-development (per-task reviews + a final whole-branch review; the review loop caught a shell-mode clobber, input-type stripping, output corruption, an env-sanitization regression, and — via the live-Mongo E2E — a silent hook-resolution no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)