### PR TITLE
fix: route chunked task sigs via resolve_task_queue (inherit profile + overrides)

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -679,13 +679,6 @@ def break_task(task, task_opts, results=[]):
 		task.enable_hooks = True
 		task.run_hooks('on_build', opts, sub='build')
 		task.enable_hooks = prev_enable_hooks
-		# Route each chunk to the task's RESOLVED queue (profile + operator overrides),
-		# exactly like the parent is routed in Workflow.build_celery_workflow. Without this
-		# the chunk sigs carry no queue and fall back to the task class's default `profile`,
-		# so a chunked task with a non-default profile/override (e.g. nmap ->
-		# SECATOR_TASKS_OVERRIDES_NMAP_PROFILE=small_long) has its chunks misrouted to the
-		# small pool — where they also miss that pool's per-task overrides (e.g. nmap's
-		# longer TASK_MAX_TIMEOUT), so they get soft-killed early.
 		sig = type(task).si(chunk, **opts).set(queue=resolve_task_queue(type(task), opts))
 		task_id = sig.freeze().task_id
 		full_name = f'{task.name}_{ix + 1}'

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -18,7 +18,7 @@ from secator.config import CONFIG
 from secator.output_types import Error, Info, Target as TargetOutput
 from secator.rich import console
 from secator.runners import Scan, Task, Workflow
-from secator.runners._helpers import run_extractors
+from secator.runners._helpers import resolve_task_queue, run_extractors
 from secator.utils import debug, deduplicate, flatten, should_update
 
 
@@ -679,7 +679,14 @@ def break_task(task, task_opts, results=[]):
 		task.enable_hooks = True
 		task.run_hooks('on_build', opts, sub='build')
 		task.enable_hooks = prev_enable_hooks
-		sig = type(task).si(chunk, **opts)
+		# Route each chunk to the task's RESOLVED queue (profile + operator overrides),
+		# exactly like the parent is routed in Workflow.build_celery_workflow. Without this
+		# the chunk sigs carry no queue and fall back to the task class's default `profile`,
+		# so a chunked task with a non-default profile/override (e.g. nmap ->
+		# SECATOR_TASKS_OVERRIDES_NMAP_PROFILE=small_long) has its chunks misrouted to the
+		# small pool — where they also miss that pool's per-task overrides (e.g. nmap's
+		# longer TASK_MAX_TIMEOUT), so they get soft-killed early.
+		sig = type(task).si(chunk, **opts).set(queue=resolve_task_queue(type(task), opts))
 		task_id = sig.freeze().task_id
 		full_name = f'{task.name}_{ix + 1}'
 		task.add_subtask(task_id, task.name, full_name)

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -196,16 +196,6 @@ class TestCelery(unittest.TestCase):
 					self.assertEqual(actual_rate_limit, 1)  # Should be 1 since 2//6 = 0, but max(1, 0) = 1
 
 	def test_chunk_sigs_routed_via_resolve_task_queue(self):
-		"""Chunk sigs must be routed through resolve_task_queue, same as the parent.
-
-		Regression: break_task built chunk sigs without .set(queue=...), so chunks ignored
-		operator profile overrides and fell back to the task's baked class-profile queue.
-		In prod this misrouted chunked nmap (profile 'small' but
-		SECATOR_TASKS_OVERRIDES_NMAP_PROFILE=small_long) from `small_long` down to `small`,
-		where the chunks also missed nmap's longer TASK_MAX_TIMEOUT and were soft-killed at
-		the global 7200s. Here we stub resolve_task_queue to a sentinel and assert every
-		chunk sig carries that resolved queue.
-		"""
 		import secator.celery as celery_mod
 		from secator.celery import break_task
 		from secator.tasks import httpx

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -195,6 +195,39 @@ class TestCelery(unittest.TestCase):
 					self.assertGreaterEqual(actual_rate_limit, 1)
 					self.assertEqual(actual_rate_limit, 1)  # Should be 1 since 2//6 = 0, but max(1, 0) = 1
 
+	def test_chunk_sigs_routed_via_resolve_task_queue(self):
+		"""Chunk sigs must be routed through resolve_task_queue, same as the parent.
+
+		Regression: break_task built chunk sigs without .set(queue=...), so chunks ignored
+		operator profile overrides and fell back to the task's baked class-profile queue.
+		In prod this misrouted chunked nmap (profile 'small' but
+		SECATOR_TASKS_OVERRIDES_NMAP_PROFILE=small_long) from `small_long` down to `small`,
+		where the chunks also missed nmap's longer TASK_MAX_TIMEOUT and were soft-killed at
+		the global 7200s. Here we stub resolve_task_queue to a sentinel and assert every
+		chunk sig carries that resolved queue.
+		"""
+		import secator.celery as celery_mod
+		from secator.celery import break_task
+		from secator.tasks import httpx
+		if httpx not in TEST_TASKS:
+			return
+
+		HTTP_TARGETS = [f'https://{target}' for target in TARGETS]
+		with mock_command(httpx, fixture=[FIXTURES_TASKS[httpx]] * len(HTTP_TARGETS)):
+			task = httpx(HTTP_TARGETS, sync=False)
+			task.has_children = True
+			orig = celery_mod.resolve_task_queue
+			celery_mod.resolve_task_queue = lambda cls, opts: 'sentinel_queue'
+			try:
+				workflow = break_task(task, {'sync': False}, results=[])
+			finally:
+				celery_mod.resolve_task_queue = orig
+
+			header_tasks = workflow.tasks if hasattr(workflow, 'tasks') else []
+			self.assertTrue(header_tasks, 'expected chunk signatures in the chord header')
+			for sig in header_tasks:
+				self.assertEqual(sig.options.get('queue'), 'sentinel_queue')
+
 	def test_break_task_with_disabled_chunking(self):
 		"""Test that break_task doesn't chunk when input_chunk_size=-1."""
 		from secator.tasks import httpx


### PR DESCRIPTION
## Problem
Investigating a stuck prod scan, `nmap/light` was chunked into 21 sub-tasks; the **parent** was correctly routed to `small_long` (via `SECATOR_TASKS_OVERRIDES_NMAP_PROFILE=small_long`) but **every chunk went to `small`**. On `small` the chunks miss that pool's `SECATOR_TASKS_OVERRIDES_NMAP_MAX_TIMEOUT=36000` (10h) override, so they get soft-killed at the global `TASK_MAX_TIMEOUT=7200` (2h) — `"Task timeout 7200s exceeded: incomplete results saved"` — and fail/abandon mid-scan.

## Root cause
`break_task` (`secator/celery.py`) builds chunk sigs as `type(task).si(chunk, **opts)` with **no `.set(queue=...)`**, so chunks fall back to the task's baked class-profile queue and ignore operator profile overrides. The parent, dispatched in `Workflow.build_celery_workflow`, uses `.set(queue=resolve_task_queue(task, opts))`.

## Fix
Route each chunk through `resolve_task_queue(type(task), opts)` — same as the parent — so chunks land on the parent's pool and inherit its per-task overrides.

## Validation
A/B against the exact prod scenario (nmap, `profile='small'`, override → `small_long`):
- **before:** chunk queues = `['small']` (bug)
- **after:** chunk queues = `['small_long']` ✓

Adds `test_chunk_sigs_routed_via_resolve_task_queue` (stubs `resolve_task_queue`, asserts every chunk sig carries the resolved queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chunked tasks are now routed to the correct queue based on the task’s resolved settings, reducing cases where they could be sent to the wrong destination.
  * Improved handling for tasks run with non-default profiles or operator overrides.
* **Tests**
  * Added coverage to verify chunked task signatures inherit the resolved queue correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->