### PR TITLE
fix(core): remove command info messages to not pollute self.output

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -501,20 +501,6 @@ class Command(Runner):
 			self.print_description()
 			self.print_command()
 
-			# In remote worker mode, stream description and cmd back to the client
-			if IN_WORKER and self.print_cmd:
-				cmd_str = _s(self.cmd_for_display)
-				if self.chunk and self.chunk_count:
-					cmd_str += f' ({self.chunk}/{self.chunk_count})'
-				if self.description:
-					task_part = f'{self.description} ([bold gold3]{self.unique_name}[/])'
-				else:
-					task_part = f'[bold gold3]{self.unique_name}[/]'
-				yield Info(
-					message=f'Started task {task_part} (cmd=[dim white]{cmd_str}[/])',
-					_source=self.unique_name,
-				)
-
 			# Check for sudo requirements and prepare the password if needed
 			sudo_required = re.search(r'\bsudo\b', self.cmd)
 			sudo_password = None

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -16,7 +16,7 @@ from time import time
 import psutil
 from fp.fp import FreeProxy
 
-from secator.definitions import IN_WORKER, OPT_NOT_SUPPORTED, OPT_PIPE_INPUT, OPT_SPACE_SEPARATED
+from secator.definitions import OPT_NOT_SUPPORTED, OPT_PIPE_INPUT, OPT_SPACE_SEPARATED
 from secator.config import CONFIG
 from secator.output_types import Info, Warning, Error, Stat
 from secator.runners import Runner


### PR DESCRIPTION
The live panel already does that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an intermediate status message shown at task start in remote worker mode, resulting in a cleaner, less noisy client experience.
  * Task execution now moves directly into password and command preparation after the initial task details are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->