### PR TITLE
fix(gitleaks): set input_chunk_size to 1

### DIFF
--- a/secator/tasks/gitleaks.py
+++ b/secator/tasks/gitleaks.py
@@ -25,6 +25,7 @@ class gitleaks(Command):
 	"""Tool for detecting secrets like passwords, API keys, and tokens in git repos, files, and stdin."""
 	cmd = 'gitleaks'
 	tags = ['secret', 'scan']
+	input_chunk_size = 1
 	input_types = [PATH]
 	input_flag = None
 	json_flag = '-f json'


### PR DESCRIPTION
Gitleaks was breaking on multiple inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved how the Gitleaks task processes input by handling items in smaller chunks, which can help with more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->