### PR TITLE
fix(output_types): strip short content for tags

### DIFF
--- a/secator/output_types/tag.py
+++ b/secator/output_types/tag.py
@@ -45,6 +45,7 @@ class Tag(OutputType):
 		small_content = False
 		if len(content) < 100:
 			small_content = True
+			content = content.strip()
 		# content_xs = trim_string(content, max_length=50).replace('\n', '/')
 		if small_content:
 			s += f' [bold orange4]{_s(content)}[/]'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag display formatting by trimming extra leading and trailing whitespace before rendering, helping content appear more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->