### PR TITLE
fix(command): authoritative sudo required

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -502,9 +502,8 @@ class Command(Runner):
 			self.print_command()
 
 			# Check for sudo requirements and prepare the password if needed
-			sudo_required = re.search(r'\bsudo\b', self.cmd)
 			sudo_password = None
-			if CONFIG.security.prompt_sudo_password and sudo_required:
+			if CONFIG.security.prompt_sudo_password and self.sudo_required:
 				self.debug('prompting for sudo password', sub='start')
 				sudo_password, error = self._prompt_sudo(self.cmd)
 				if error:

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -503,7 +503,7 @@ class Command(Runner):
 
 			# Check for sudo requirements and prepare the password if needed
 			sudo_password = None
-			if CONFIG.security.prompt_sudo_password and self.sudo_required:
+			if CONFIG.security.prompt_sudo_password and self.requires_sudo:
 				self.debug('prompting for sudo password', sub='start')
 				sudo_password, error = self._prompt_sudo(self.cmd)
 				if error:
@@ -543,7 +543,7 @@ class Command(Runner):
 				stdout=subprocess.PIPE,
 				stderr=subprocess.STDOUT,
 				universal_newlines=True,
-				preexec_fn=os.setsid if not (self.sudo_required or self.disable_preexec) else None,
+				preexec_fn=os.setsid if not (self.requires_sudo or self.disable_preexec) else None,
 				shell=self.shell,
 				errors='replace',
 				env=env,

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -543,7 +543,7 @@ class Command(Runner):
 				stdout=subprocess.PIPE,
 				stderr=subprocess.STDOUT,
 				universal_newlines=True,
-				preexec_fn=os.setsid if not (sudo_required or self.disable_preexec) else None,
+				preexec_fn=os.setsid if not (self.sudo_required or self.disable_preexec) else None,
 				shell=self.shell,
 				errors='replace',
 				env=env,


### PR DESCRIPTION
Some commands might use sudo in their options set, like for running RCEs with custom pentest tools.

E.g: 
```
zabbix_get -k 'system.run[sudo -l]'
```

Currently, that would mean the system autodetect sudo in the cmd string, and pre-prends 'sudo' to the command, which is not the desired outcome in that case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sudo password prompting so it now follows the command’s actual sudo requirement instead of checking for the word “sudo” in the command text.
  * Reduced unnecessary password prompts when sudo is not required, while keeping prompts enabled when security settings call for them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->