### PR TITLE
fix(celery): dead-letter OOM-loop tasks by keying worker-loss cap on stable Mongo task id

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -216,8 +216,32 @@ def _expire_worker_loss_key(backend, key):
 		debug(f'worker-loss expire failed for {key}: {e}', sub='celery.state')
 
 
+def worker_loss_key(context, celery_id):
+	"""Stable identity for worker-loss counting across broker redeliveries.
+
+	Prefer the Mongo task id — minted at ``on_build`` (secator.hooks.mongodb) and baked into the
+	child signature's serialized ``context`` — so the counter accumulates on the *logical* task
+	even when the Celery request id rotates between deliveries. The observed OOM zombies redelivered
+	with ``redelivered=true, retries=0`` (pure broker redelivery) each presenting a fresh Celery id,
+	so keying on ``self.request.id`` reset the count to 1 every cycle and the abandon cap never
+	tripped. The Mongo id rides inside the message body, so it is identical on every redelivery.
+
+	Falls back to the Celery id for tasks with no persisted doc (e.g. a bare top-level task that
+	never went through ``on_build``); those keep a stable Celery id under ``reject_on_worker_lost``,
+	so the fallback preserves the original behaviour.
+
+	Args:
+		context (dict): Task context (may carry ``task_chunk_id`` / ``task_id``).
+		celery_id (str): Celery request id, used as a fallback.
+
+	Returns:
+		str: The key to count worker-loss redeliveries against.
+	"""
+	return context.get('task_chunk_id') or context.get('task_id') or celery_id
+
+
 def bump_worker_loss_count(task_id):
-	"""Increment and return the worker-loss delivery count for a Celery task id.
+	"""Increment and return the worker-loss delivery count for a logical task id.
 
 	Stored on the Celery result backend (via its generic key/value interface) so it survives a
 	worker being killed and works with whatever backend is configured — Redis, filesystem, cache,
@@ -226,7 +250,8 @@ def bump_worker_loss_count(task_id):
 	``get``/``set`` (e.g. the database/RPC backends), so the cap simply no-ops there.
 
 	Args:
-		task_id (str): Celery request id (stable across worker-loss redeliveries).
+		task_id (str): Stable logical task id (see ``worker_loss_key``) — the Mongo task id when
+			available, else the Celery request id.
 
 	Returns:
 		int: Number of times this task has been delivered, or 0 if unsupported.
@@ -337,16 +362,19 @@ def run_command(self, results, name, targets, opts={}):
 
 		# Worker-loss redelivery cap. With task_acks_late + task_reject_on_worker_lost, a task
 		# whose worker is killed (cgroup OOMKill of the child, or a node-pressure eviction) is
-		# redelivered with the SAME Celery id. Count redeliveries on the result backend and
-		# abandon after task_max_retries, so a task that OOMs every run can't loop forever and
-		# block the surrounding chord/workflow. reject_on_worker_lost is what actually
-		# re-queues the task on abrupt worker death, so gate on it too (not just late acks).
+		# redelivered and re-run. Count redeliveries on the result backend and abandon after
+		# task_max_retries, so a task that OOMs every run can't loop forever and block the
+		# surrounding chord/workflow. reject_on_worker_lost is what actually re-queues the task on
+		# abrupt worker death, so gate on it too (not just late acks). Key the counter on the stable
+		# Mongo task id (worker_loss_key), not self.request.id: broker redeliveries of a fan-in can
+		# present a fresh Celery id each cycle (redelivered=true, retries=0), which would reset a
+		# per-request-id count to 1 forever and never trip the cap.
 		if (
 			CONFIG.celery.task_max_retries != -1
 			and CONFIG.celery.task_acks_late
 			and CONFIG.celery.task_reject_on_worker_lost
 		):
-			delivery_count = bump_worker_loss_count(self.request.id)
+			delivery_count = bump_worker_loss_count(worker_loss_key(context, self.request.id))
 			if worker_loss_retries_exhausted(delivery_count, CONFIG.celery.task_max_retries):
 				# Attach the request context so the abandoned task doc still carries
 				# celery_id / worker_name / routing_key even when opts had none coming in.

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -405,6 +405,49 @@ class TestWorkerLossRetryCap(unittest.TestCase):
 			with patch.object(app.backend, 'get', side_effect=NotImplementedError, create=True):
 				self.assertEqual(bump_worker_loss_count('task-abc'), 0)
 
+	def test_worker_loss_key_prefers_mongo_id_over_rotating_celery_id(self):
+		"""The counter key is the stable Mongo task id, not the (rotating) Celery request id."""
+		from secator.celery import worker_loss_key
+		# Chunk id wins, then task id, then falls back to the Celery id.
+		self.assertEqual(worker_loss_key({'task_chunk_id': 'chunk1', 'task_id': 't1'}, 'cel-x'), 'chunk1')
+		self.assertEqual(worker_loss_key({'task_id': 't1'}, 'cel-x'), 't1')
+		self.assertEqual(worker_loss_key({}, 'cel-x'), 'cel-x')
+
+	def test_redeliveries_with_rotating_celery_ids_abandon_after_cap(self):
+		"""Same logical task redelivered with DIFFERENT celery ids each time must still abandon.
+
+		Reproduces the OOM zombie: broker redelivery presents a fresh celery id every cycle. Keyed
+		on the stable Mongo task id the count accumulates and trips the cap; keyed on the celery id
+		it would reset to 1 forever and loop.
+		"""
+		from secator.celery import bump_worker_loss_count, worker_loss_key, worker_loss_retries_exhausted
+		max_retries = 3  # initial + 3 redeliveries allowed -> abandon on the 5th delivery
+		context = {'task_id': f'mongo-{id(self)}'}
+		keys_to_clean = set()
+		try:
+			abandoned_on = None
+			celery_keyed_max = 0
+			for delivery in range(1, 8):
+				celery_id = f'celery-{delivery}'  # rotates every delivery
+				# Stable-id path (the fix)
+				key = worker_loss_key(context, celery_id)
+				keys_to_clean.add(key)
+				count = bump_worker_loss_count(key)
+				if worker_loss_retries_exhausted(count, max_retries) and abandoned_on is None:
+					abandoned_on = delivery
+				# Celery-id path (the old bug) — each rotating id counts to 1, never exhausts
+				ck = worker_loss_key({}, celery_id)
+				keys_to_clean.add(ck)
+				celery_keyed_max = max(celery_keyed_max, bump_worker_loss_count(ck))
+			self.assertEqual(abandoned_on, 5, 'must abandon on the 5th delivery with a rotating celery id')
+			self.assertEqual(celery_keyed_max, 1, 'per-celery-id keying never accumulates (the bug)')
+		finally:
+			for k in keys_to_clean:
+				try:
+					app.backend.delete(k)
+				except Exception:
+					pass
+
 	def test_abandon_task_returns_failure_error(self):
 		"""Abandoning returns results with a self-owned FAILURE Error so the chord proceeds."""
 		from secator.tasks import httpx


### PR DESCRIPTION
## Problem (RC#6 — dead-letter broker-redelivery OOM loops)

A task that OOM-kills its worker (or is node-evicted) has its message requeued by the broker under `task_acks_late` + `task_reject_on_worker_lost`, and re-run. Secator already caps this in `run_command` via `bump_worker_loss_count` + `abandon_task`, gated on `task_max_retries` — **but the counter was keyed on `self.request.id`**, assuming the Celery id is stable across redeliveries.

For the fan-in "zombies" seen in prod (52,337 and 303,499-result fan-ins), that assumption broke: they redelivered via **pure broker redelivery** (`redelivered=true, retries=0`) presenting a **fresh/rotating Celery id each cycle**. So `bump_worker_loss_count(self.request.id)` reset to `1` on every delivery, the cap never tripped, and one worker pod was OOM-killed per cycle **indefinitely — even after the parent scan had FAILED**.

## Fix

Key the counter on the **stable Mongo task id** instead of the rotating Celery id:

- New `worker_loss_key(context, celery_id)` → prefers `context['task_chunk_id']` / `context['task_id']` (minted at `on_build`, baked into the child signature's serialized `context`, so it rides **inside the message body** and is identical on every redelivery). Falls back to the Celery id for bare top-level tasks that never went through `on_build` (those keep a stable Celery id under `reject_on_worker_lost`, so prior behaviour is preserved).
- The count now accumulates on the *logical* task regardless of Celery-id rotation, so `abandon_task` dead-letters it after N deliveries — forwarding results (`forward_results` + `chain_results`) so the surrounding chord/workflow still completes instead of hanging.
- The bump already runs first thing in `run_command`, before `forward_results`/task setup, so it counts even when the OOM happens during setup.

No config or behavioural change when the cap is disabled (`task_max_retries=-1`) or when a task already keeps a stable Celery id.

## Native-Celery note (for the reader)

Celery has **no built-in delivery-count / dead-letter cap** for the Redis broker. `task_reject_on_worker_lost` only *re-queues* on worker loss (it does not count or cap); `Task.retry()` is a different, in-task path (`retries` header) not involved here (`retries=0`); AMQP `x-death` / dead-letter exchanges are RabbitMQ-only and unavailable on the Redis broker + result-backend counting secator uses. So the counting + cap must live in application code — this PR keeps it there and only corrects the key. See the postmortem RC#6 research summary for detail.

## Test

`tests/unit/test_celery.py::TestWorkerLossRetryCap`:
- `test_redeliveries_with_rotating_celery_ids_abandon_after_cap` — same logical task redelivered 7× with a **different Celery id each time** abandons on the 5th delivery (`max_retries=3`), and asserts the old per-Celery-id keying never accumulates past `1`.
- `test_worker_loss_key_prefers_mongo_id_over_rotating_celery_id` — precedence: chunk id → task id → Celery id fallback.

`secator test unit --test test_celery` → 25 passed, 2 skipped. `secator test lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtTyzcUmPYxM5nfp7MnMVd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task redelivery tracking by consistently using a stable task identity.
  * Prevented repeated worker-loss redeliveries from resetting retry counts when delivery identifiers change.
  * Ensured tasks are abandoned at the expected retry limit, improving worker-loss recovery and preventing excessive duplicate processing.

* **Tests**
  * Added coverage for stable task identification and multi-redelivery abandonment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->