### PR TITLE
fix(query): support {'_id':{'$in':ids}, **filters} fan-in queries (RC#6 prereq)

### DIFF
--- a/docs/design/fanin-query-extractors.md
+++ b/docs/design/fanin-query-extractors.md
@@ -1,0 +1,87 @@
+# Design: query-by-id extractors (fan-in OOM, RC#6/#9)
+
+## Problem
+
+Every runner receives the **full accumulated result set** of the chain as its
+input. A `_base` runner then computes its targets from those results with
+`run_extractors` / `process_extractor` (`secator/runners/_helpers.py`). For very
+large sets this materialises the whole list on the worker Python heap during
+setup and OOMs the worker *before* the tool even runs (so `command.py`'s
+subprocess memory guard is blind to it). Two confirmed live prod zombies:
+`maigret` with 52,337 results and `nmap` with 303,499 results, each in an
+infinite OOM→requeue→OOM loop.
+
+When the MongoDB addon is enabled, results are already shrunk to their Mongo
+`_id` **string** in the chain (`celery.chain_results`) and rehydrated downstream
+by `hooks.mongodb.get_results` — but the runner still calls `get_results` to
+materialise the whole list to reason over it. The fan-in is the id list; the
+heap blow-up is the rehydration + Python-side filtering.
+
+## Goal
+
+Let a `_base` runner **query** previous results to compute its targets instead of
+holding them all — push the work into the `Query` engine
+(`secator/query/`), which filters at the datastore (cheap, especially for
+MongoDB) and returns only the matching rows.
+
+## Prerequisite (this PR): `{'_id': {'$in': ids}, **filters}` per backend
+
+Since results are fanned in by id string, the query layer must support an id +
+filter query. Verified with tests (`tests/unit/test_query.py::TestIdFanInQuery`,
+`TestMongoDBIdConversion`; secator-api `tests/test_query_sanitization.py`):
+
+| backend  | `{'_id':{'$in':ids}, **filters}` | notes |
+|----------|----------------------------------|-------|
+| **api**  | ✅ already works | server-side `api.db.utils.convert_query` converts `_id` `$in`/`$nin` **string** lists → `ObjectId`. Regression test added. The core `ApiBackend` just POSTs the query as JSON; ids stay strings on the wire and are converted server-side. |
+| **mongodb** | ✅ **fixed here** | the core `MongoDBBackend` passed the query straight to pymongo with **no** `ObjectId` conversion, so a raw-string `_id` `$in` matched **nothing**. Added `_convert_id_query` (mirrors `get_results` + the api `convert_query`), applied in `_execute_search` / `_execute_count` / `_execute_update`. |
+| **local (json)** | ✅ mechanism works; ⚠️ n/a by id | `match_query` supports `$in` + sibling filters, but local report.json findings key on `_uuid`, not `_id`. Local runs never fan-in by id (MongoDB addon off) — the full objects are already in memory and the `JsonBackend` filters them via `context['results']`. So the id path is not needed locally; the type/condition filter path is. |
+| sqlite   | `$in` supported; `_id` not a mirrored column | not on the prod fan-in path; out of scope. |
+
+**Base query is safe for id filters:** `_id` is not a `PROTECTED_FIELD`, so
+`_merge_query` ANDs in the enforced `_context.workspace_id` +
+`is_false_positive` without dropping the client `_id` filter (tested).
+
+## Deferred: the extractor refactor itself
+
+Rewire `_base.py::_run_extractors` → `run_extractors`/`process_extractor` to,
+when results are id strings (MongoDB addon on), build a `QueryEngine` query
+`{'_id': {'$in': ids}, '_type': <extractor type>, ...}` and read back only the
+projected field(s) it needs (e.g. `email_address`, host name) — never
+materialising the 300k objects. Fold in #9 (`forward_results` stream/batch
+dedup) since it is the same "don't hold the whole set" problem.
+
+**Why it is not in this PR — the hard part:** extractor `condition`s are
+arbitrary Python `eval` expressions, not Mongo filters. Real examples from the
+shipped configs:
+
+- `item.name == 'net_cidr' and len(targets) == 0`
+- `item._source.startswith("gf")`
+- `not url.verified`
+- `item.stored_response_path != ''`
+
+These reference sibling runner state (`len(targets)`), use Python string methods
+(`.startswith`), and negate/compose freely. There is no general, safe
+translation of this DSL into a Mongo query, and `_run_extractors` is on the hot
+path of **every** runner. A correct refactor needs either:
+
+1. a bounded translator for the common `type.field [op] literal` conditions,
+   with a **fallback** that still fetches-then-filters for expressions it can't
+   translate (so behaviour never changes), **projecting only the extractor
+   field** so even the fallback stops rehydrating full objects; or
+2. pushing just the cheap, always-safe part — the `_type` (+ workspace) filter
+   and field projection — into the query, and keeping the Python `condition`
+   eval on the (now much smaller, projected) candidate set.
+
+Option 2 is the lazy, high-value first step: for `maigret`/`nmap` the `_type`
+filter alone cuts the fan-in by orders of magnitude and the projection removes
+the per-object heap cost, with **zero** change to condition semantics. It should
+be its own reviewable PR on top of this one.
+
+## Rollout
+
+1. **This PR** — backend id-query support + tests (id filters provably work on
+   mongodb/api; local documented). Safe, isolated, no behaviour change to
+   existing queries.
+2. Next — Option 2 extractor refactor (type-filter + projection push-down,
+   Python condition on the reduced set) + a 300k-result memory-bound test.
+3. Later (if needed) — Option 1 condition translator for the common shapes.

--- a/secator/query/mongodb.py
+++ b/secator/query/mongodb.py
@@ -9,6 +9,28 @@ from secator.rich import console
 RUNNER_COLLECTIONS = ('tasks', 'workflows', 'scans')
 
 
+def _convert_id_query(query: dict) -> dict:
+	"""Convert `_id` `$in` / `$nin` string lists to ObjectId in-place.
+
+	Findings are fanned in by their `_id` **string** (see celery.chain_results),
+	but Mongo stores `_id` as an ObjectId — a raw string `$in` matches nothing.
+	Mirror the rehydration in hooks.mongodb.get_results and the server-side
+	api.db.utils.convert_query so `{'_id': {'$in': ids}, **filters}` works.
+
+	Only valid 24-char hex ids are converted; anything else is left untouched
+	(it simply won't match a real ObjectId, which is the correct outcome).
+	"""
+	from bson.objectid import ObjectId
+	cond = query.get('_id')
+	if not isinstance(cond, dict):
+		return query
+	for op in ('$in', '$nin'):
+		values = cond.get(op)
+		if isinstance(values, (list, tuple)):
+			cond[op] = [ObjectId(v) if ObjectId.is_valid(v) else v for v in values]
+	return query
+
+
 class MongoDBBackend(QueryBackend):
 	"""Query backend for MongoDB."""
 
@@ -37,6 +59,8 @@ class MongoDBBackend(QueryBackend):
 			client = self._get_client()
 			db = client.main
 
+			query = _convert_id_query(query)
+
 			# Build projection to exclude fields
 			projection = None
 			if exclude_fields:
@@ -59,7 +83,7 @@ class MongoDBBackend(QueryBackend):
 		try:
 			client = self._get_client()
 			db = client.main
-			return db.findings.count_documents(query)
+			return db.findings.count_documents(_convert_id_query(query))
 		except Exception as e:
 			console.print(Warning(message=f'MongoDB count failed: {e}'))
 			return 0
@@ -67,7 +91,7 @@ class MongoDBBackend(QueryBackend):
 	def _execute_update(self, query: dict, update: dict) -> int:
 		"""Update documents matching query in MongoDB."""
 		client = self._get_client()
-		result = client.main.findings.update_one(query, update)
+		result = client.main.findings.update_one(_convert_id_query(query), update)
 		return result.modified_count
 
 	def list_workspaces(self):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -642,3 +642,135 @@ class TestSqliteTranslator(unittest.TestCase):
 		from secator.query.sqlite import _build_where
 		with self.assertRaises(ValueError):
 			_build_where({"x') UNION SELECT 1 --": 'v'})
+
+
+class TestIdFanInQuery(unittest.TestCase):
+	"""Prove the `{'_id': {'$in': <ids>}, **filters}` fan-in query shape works
+	across backends. Findings are fanned in by their `_id` string (see
+	celery.chain_results); the extractor path must be able to query them by id +
+	filter instead of materializing the whole result set (RC#6/#9)."""
+
+	def test_merge_query_preserves_id_filter(self):
+		"""The enforced base query must AND in workspace/false-positive filters
+		without stripping a client `_id` filter (it is not a PROTECTED_FIELD)."""
+		from secator.query._base import QueryBackend
+
+		class _B(QueryBackend):
+			name = 'test'
+
+			def _execute_search(self, q, limit, exclude_fields=None):
+				return []
+
+			def _execute_count(self, q):
+				return 0
+
+			def _execute_update(self, q, u):
+				return 0
+
+		backend = _B(workspace_id='ws123')
+		ids = ['6a4d40157218971a7a32305d', '6a4d40157218971a7a32305e']
+		merged = backend._merge_query({'_id': {'$in': ids}, '_type': 'port'})
+		self.assertEqual(merged['_id'], {'$in': ids})
+		self.assertEqual(merged['_type'], 'port')
+		self.assertEqual(merged['_context.workspace_id'], 'ws123')
+		self.assertEqual(merged['is_false_positive'], {'$ne': True})
+
+	def test_json_backend_id_in_with_filter(self):
+		"""Local/JSON `match_query` supports `{'_id': {'$in': ids}, **filters}` when
+		findings carry an id field — i.e. the query *mechanism* is backend-agnostic.
+
+		NOTE: local report.json findings key on `_uuid`, not `_id`; local runs never
+		fan-in by id (mongodb addon off), so this proves the operator, using `_uuid`
+		as the id field the local backend actually populates."""
+		from secator.query.json import match_query
+
+		items = [
+			{'_uuid': 'a1', '_type': 'port', 'port': 80},
+			{'_uuid': 'a2', '_type': 'port', 'port': 443},
+			{'_uuid': 'a3', '_type': 'url', 'url': 'http://x'},
+		]
+		q = {'_uuid': {'$in': ['a1', 'a3']}, '_type': 'port'}
+		matched = [i for i in items if match_query(i, q)]
+		self.assertEqual([i['_uuid'] for i in matched], ['a1'])
+
+
+class TestMongoDBIdConversion(unittest.TestCase):
+	"""MongoDB query backend must convert `_id` `$in`/`$nin` **string** lists to
+	ObjectId — findings are fanned in by their id *string*, but Mongo stores `_id`
+	as an ObjectId so a raw-string `$in` matches nothing. Mirrors the rehydration
+	in hooks.mongodb.get_results and the server-side api.db.utils.convert_query."""
+
+	def setUp(self):
+		import pytest
+		pytest.importorskip('bson')
+
+	def test_convert_id_query_converts_in_and_nin(self):
+		from bson.objectid import ObjectId
+		from secator.query.mongodb import _convert_id_query
+
+		ids = ['6a4d40157218971a7a32305d', '6a4d40157218971a7a32305e']
+		out = _convert_id_query({'_id': {'$in': list(ids)}, '_type': 'port'})
+		self.assertTrue(all(isinstance(v, ObjectId) for v in out['_id']['$in']))
+		self.assertEqual([str(v) for v in out['_id']['$in']], ids)
+		self.assertEqual(out['_type'], 'port')
+
+		out2 = _convert_id_query({'_id': {'$nin': list(ids)}})
+		self.assertTrue(all(isinstance(v, ObjectId) for v in out2['_id']['$nin']))
+
+	def test_convert_id_query_leaves_invalid_and_plain(self):
+		from bson.objectid import ObjectId
+		from secator.query.mongodb import _convert_id_query
+
+		# Non-ObjectId strings are left untouched (they simply won't match).
+		out = _convert_id_query({'_id': {'$in': ['not-an-oid']}})
+		self.assertEqual(out['_id']['$in'], ['not-an-oid'])
+		# A query with no `_id` is a no-op.
+		self.assertEqual(_convert_id_query({'_type': 'url'}), {'_type': 'url'})
+		# Already-ObjectId values survive.
+		oid = ObjectId()
+		out2 = _convert_id_query({'_id': {'$in': [oid]}})
+		self.assertEqual(out2['_id']['$in'], [oid])
+
+	def test_execute_search_converts_ids_before_query(self):
+		"""Regression: `_execute_search` must convert ids to ObjectId before hitting
+		the driver, else a fan-in by id string returns zero findings."""
+		from unittest.mock import MagicMock, patch
+		from bson.objectid import ObjectId
+		from secator.query.mongodb import MongoDBBackend
+
+		captured = {}
+
+		def _find(query, projection=None):
+			captured['query'] = query
+			cursor = MagicMock()
+			cursor.limit.return_value = iter([])
+			return cursor
+
+		client = MagicMock()
+		client.main.findings.find.side_effect = _find
+
+		ids = ['6a4d40157218971a7a32305d', '6a4d40157218971a7a32305e']
+		backend = MongoDBBackend(workspace_id='ws123')
+		with patch.object(backend, '_get_client', return_value=client):
+			backend.search({'_id': {'$in': list(ids)}, '_type': 'port'})
+
+		sent = captured['query']
+		self.assertTrue(all(isinstance(v, ObjectId) for v in sent['_id']['$in']))
+		self.assertEqual([str(v) for v in sent['_id']['$in']], ids)
+		# base query still enforced alongside the id filter
+		self.assertEqual(sent['_context.workspace_id'], 'ws123')
+		self.assertEqual(sent['is_false_positive'], {'$ne': True})
+
+	def test_execute_count_converts_ids(self):
+		from unittest.mock import MagicMock, patch
+		from bson.objectid import ObjectId
+		from secator.query.mongodb import MongoDBBackend
+
+		captured = {}
+		client = MagicMock()
+		client.main.findings.count_documents.side_effect = lambda q: captured.setdefault('q', q) or 0
+
+		backend = MongoDBBackend(workspace_id='ws123')
+		with patch.object(backend, '_get_client', return_value=client):
+			backend.count({'_id': {'$in': ['6a4d40157218971a7a32305d']}})
+		self.assertTrue(all(isinstance(v, ObjectId) for v in captured['q']['_id']['$in']))


### PR DESCRIPTION
## Why

RC#6 (fan-in Python-heap OOM): a `_base` runner receives the **full accumulated result set** and materializes it to compute its targets via `run_extractors`/`process_extractor`. For huge sets (confirmed live: 52k `maigret`, 303k `nmap`) this OOMs the worker heap during setup, before the tool runs.

The fix direction is to push extractor target-computation into the **Query engine** so it queries results **by id + filter** instead of materializing them. Since results are fanned in by their Mongo `_id` **string** (`celery.chain_results`), the query layer must support `{'_id': {'$in': <ids>}, **filters}`.

This PR is the **verified prerequisite**: id-query support across backends, with tests. The extractor refactor itself is scoped in `docs/design/fanin-query-extractors.md` and deferred (see below).

## Per-backend findings (tested)

| backend | `{'_id':{'$in':ids}, **filters}` | |
|---|---|---|
| **api** | ✅ already works | server-side `convert_query` coerces `_id` `$in`/`$nin` strings → `ObjectId` (regression test added in secator-api#\<pending\>). Core `ApiBackend` just POSTs JSON. |
| **mongodb** | ✅ **fixed here** | backend passed the query straight to pymongo with **no** ObjectId conversion → raw-string `_id` `$in` matched **nothing**. Added `_convert_id_query` (mirrors `hooks.mongodb.get_results` + the api `convert_query`) in `_execute_search`/`_count`/`_update`. |
| **local (json)** | ✅ mechanism works; n/a by id | `match_query` supports `$in`+filters, but local findings key on `_uuid`; local never fans-in by id (addon off) — full objects are already in `context['results']`. |

`_id` is not a `PROTECTED_FIELD`, so `_merge_query` keeps the client `_id` filter while still enforcing `_context.workspace_id` + `is_false_positive` (tested).

## Changes
- `secator/query/mongodb.py`: `_convert_id_query` helper + applied in the three execute methods.
- `tests/unit/test_query.py`: `TestIdFanInQuery` + `TestMongoDBIdConversion` (mongodb ObjectId conversion incl. a regression that fails if ids reach the driver as strings; base-query merge preserves `_id`; local `$in`+filter mechanism). Mongo tests `importorskip('bson')` so CI without the mongodb extra skips cleanly.

## Deferred (design doc included)
`docs/design/fanin-query-extractors.md` scopes the extractor refactor. The hard part: extractor `condition`s are arbitrary Python `eval` (`item._source.startswith("gf")`, `len(targets)==0`, `not url.verified`) with no general Mongo translation, on the hot path of every runner. Recommended next step = push only the always-safe `_type`(+workspace) filter and field **projection** into the query, keep the Python condition on the reduced/projected set (folds in #9). Its own PR.

## Tests
`secator test unit --test test_query` → 148 passed, 8 skipped. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtTyzcUmPYxM5nfp7MnMVd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MongoDB queries using lists of document IDs, including support for converting valid string IDs to the correct database format.
  * Ensured ID-based searches, counts, and updates preserve workspace and false-positive filtering.
  * Added support for ID fan-in queries across local JSON and MongoDB backends.

* **Documentation**
  * Added design documentation outlining improvements to reduce memory usage in fan-in query workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->