### PR TITLE
fix(core): kill sudo/root subprocess tree on task termination (RC#7)

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -16,7 +16,7 @@ from time import time
 import psutil
 from fp.fp import FreeProxy
 
-from secator.definitions import OPT_NOT_SUPPORTED, OPT_PIPE_INPUT, OPT_SPACE_SEPARATED
+from secator.definitions import IN_WORKER, OPT_NOT_SUPPORTED, OPT_PIPE_INPUT, OPT_SPACE_SEPARATED
 from secator.config import CONFIG
 from secator.output_types import Info, Warning, Error, Stat
 from secator.runners import Runner
@@ -230,6 +230,7 @@ class Command(Runner):
 		self.monitor_stop_event = None
 		self.monitor_queue = None
 		self.process_start_time = None
+		self._prev_sigterm_handler = None
 		# self.retry_count = 0  # TODO: remove this
 
 		# Proxy config (global)
@@ -536,15 +537,21 @@ class Command(Runner):
 				self.cwd = f'{self.reports_folder}/.outputs/{self.fqn}'
 				os.makedirs(self.cwd, exist_ok=True)
 
-			# Run the command using subprocess
+			# Run the command using subprocess.
+			# Spawn the tool in its own session (setsid) so stop_process can kill the whole
+			# process tree in one shot via killpg — this is what lets us reach a `sudo <tool>`
+			# child (RC#7). We keep setsid OFF only for an *interactive* sudo prompt, since
+			# detaching the controlling tty breaks the password prompt (see #722). In a worker
+			# (no tty) or passwordless sudo, setsid is safe and the group kill works.
 			env = os.environ
+			new_session = not self.disable_preexec and not (sudo_required and self.has_tty and sudo_password is not None)  # noqa: E501
 			self.process = subprocess.Popen(
 				command,
 				stdin=subprocess.PIPE if sudo_password else None,
 				stdout=subprocess.PIPE,
 				stderr=subprocess.STDOUT,
 				universal_newlines=True,
-				preexec_fn=os.setsid if not (sudo_required or self.disable_preexec) else None,
+				start_new_session=new_session,
 				shell=self.shell,
 				errors='replace',
 				env=env,
@@ -557,6 +564,11 @@ class Command(Runner):
 			self.monitor_stop_event.clear()
 			self.monitor_thread = threading.Thread(target=self._monitor_process, daemon=True)
 			self.monitor_thread.start()
+
+			# In a worker, catch the SIGTERM from `revoke(terminate=True)` so we kill the tool
+			# subprocess tree instead of dying and orphaning it (RC#7). SIGKILL is uncatchable —
+			# for that path the backstop is deploy-side (see PR notes).
+			self._install_worker_term_handler()
 
 			# If sudo password is provided, send it to stdin
 			if sudo_password:
@@ -585,6 +597,7 @@ class Command(Runner):
 			yield Error.from_exception(e)
 
 		finally:
+			self._restore_worker_term_handler()
 			yield from self._wait_for_end()
 
 	def is_installed(self):
@@ -684,26 +697,85 @@ class Command(Runner):
 		yield error
 
 	def stop_process(self, exit_ok=False, sig=signal.SIGINT):
-		"""Sends signal to running process, if any.
+		"""Send `sig` to the running process tree, if any.
 
-		Uses killpg only when the subprocess has its own process group (preexec_fn=os.setsid).
-		Otherwise (disable_preexec=True or sudo), the subprocess shares the worker's pgid and
-		killpg would also kill the worker.
+		The tool is spawned in its own session (start_new_session) whenever possible, so we can
+		signal the *whole* process group with killpg — that reaches a `sudo <tool>` child too,
+		instead of just the immediate child. When the group is root-owned (the tool runs via
+		sudo), a non-root worker's killpg/kill raises PermissionError; we then escalate the kill
+		through `sudo -n kill` so the root tool actually dies instead of being orphaned and
+		outliving its timeout monitor (RC#7). The sudo escalation is best-effort and requires
+		passwordless `sudo kill` in the worker's sudoers — see the deploy notes in the PR.
 		"""
-		if not self.process:
+		if not self.process or not self.process.pid:
+			if exit_ok:
+				self.exit_ok = True
 			return
-		self.debug(f'Sending signal {signal_to_name(sig)} to process {self.process.pid}.', sub='error')
-		if self.process and self.process.pid:
-			try:
-				pgid = os.getpgid(self.process.pid)
-				if pgid == self.process.pid:
-					os.killpg(pgid, sig)
-				else:
-					os.kill(self.process.pid, sig)
-			except (ProcessLookupError, PermissionError):
-				pass
+		pid = self.process.pid
+		self.debug(f'Sending signal {signal_to_name(sig)} to process {pid}.', sub='error')
+		try:
+			pgid = os.getpgid(pid)
+		except ProcessLookupError:
+			pgid = None
+		use_group = pgid is not None and pgid == pid  # own session => safe to kill the group
+		try:
+			if use_group:
+				os.killpg(pgid, sig)
+			else:
+				os.kill(pid, sig)
+		except ProcessLookupError:
+			pass
+		except PermissionError:
+			# Root-owned target (sudo tool). A non-root worker can't signal it directly, so
+			# escalate through sudo. Kill the whole group when we have one so the tool child dies.
+			self._sudo_kill(pgid if use_group else pid, sig, group=use_group)
 		if exit_ok:
 			self.exit_ok = True
+
+	def _sudo_kill(self, target, sig, group=False):
+		"""Best-effort `sudo -n kill` of a root-owned process (or process group when `group`).
+
+		Needs a passwordless `sudo kill` sudoers entry in the worker container; if that's absent
+		the call fails harmlessly (non-zero exit) and we just log it — the orphan is then a
+		deploy-side problem (activeDeadlineSeconds / drop sudo for capabilities), not a code one.
+		"""
+		spec = f'-{int(target)}' if group else str(int(target))
+		try:
+			ret = subprocess.run(
+				['sudo', '-n', 'kill', f'-{int(sig)}', spec],
+				stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10,
+			).returncode
+			self.debug(f'sudo kill {spec} (sig={int(sig)}) returned {ret}', sub='error')
+		except Exception as e:
+			self.debug(f'sudo kill {spec} failed: {e}', sub='error')
+
+	def _install_worker_term_handler(self):
+		"""Install a SIGTERM handler (worker only) that kills the tool tree on task terminate.
+
+		`app.control.revoke(id, terminate=True)` sends SIGTERM to the pool child running the task.
+		Without a handler the child just dies and the tool subprocess (esp. a root `sudo` one) is
+		orphaned. Signal handlers can only be set from the main thread, so guard for that.
+		"""
+		if not IN_WORKER:
+			return
+		try:
+			if threading.current_thread() is threading.main_thread():
+				self._prev_sigterm_handler = signal.signal(signal.SIGTERM, self._on_worker_term)
+		except (ValueError, OSError):
+			self._prev_sigterm_handler = None
+
+	def _on_worker_term(self, signum, frame):
+		self.debug('Received SIGTERM (task terminate) — killing tool subprocess tree', sub='error')
+		self.killed = True
+		self.stop_process(exit_ok=True, sig=signal.SIGKILL)
+
+	def _restore_worker_term_handler(self):
+		if self._prev_sigterm_handler is not None:
+			try:
+				signal.signal(signal.SIGTERM, self._prev_sigterm_handler)
+			except (ValueError, OSError):
+				pass
+			self._prev_sigterm_handler = None
 
 	def _stop_monitor_thread(self):
 		"""Stop monitor thread."""

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -360,3 +360,71 @@ class TestCommandConfigOverrides(unittest.TestCase):
 				self.assertEqual(cmd_b.input_chunk_size, 100)
 		finally:
 			CONFIG.tasks.overrides = original_overrides
+
+
+class TestStopProcessKillsTree(unittest.TestCase):
+	"""RC#7: stop_process must kill the whole subprocess tree (own session), incl. a sudo/root child."""
+
+	class SleepCmd(Command):
+		input_types = ['slug']
+		cmd = 'sleep'
+		input_flag = None
+		file_flag = None
+
+	def _run_bg(self, cmd):
+		import threading
+		import time
+		t = threading.Thread(target=lambda: list(cmd), daemon=True)
+		t.start()
+		for _ in range(200):  # up to ~10s for the subprocess to spawn
+			if cmd.process and cmd.process.pid and cmd.process.poll() is None:
+				return t
+			time.sleep(0.05)
+		self.fail('subprocess did not start')
+
+	def _assert_group_gone(self, pgid):
+		import os
+		import time
+		for _ in range(200):  # up to ~10s to reap
+			try:
+				os.killpg(pgid, 0)
+			except ProcessLookupError:
+				return  # gone
+			except PermissionError:
+				pass  # still alive, root-owned
+			time.sleep(0.05)
+		self.fail(f'process group {pgid} still alive after kill')
+
+	def test_setsid_group_kill_non_sudo(self):
+		import os
+		import signal
+		cmd = self.SleepCmd(['300'])
+		t = self._run_bg(cmd)
+		pid = cmd.process.pid
+		pgid = os.getpgid(pid)
+		# Core of the fix: the tool is spawned in its own session, so we can killpg the whole tree.
+		self.assertEqual(pgid, pid, 'tool should be its own process-group leader (start_new_session)')
+		cmd.stop_process(sig=signal.SIGKILL)
+		t.join(timeout=15)
+		self.assertFalse(t.is_alive(), 'runner thread should finish after kill')
+		self._assert_group_gone(pgid)
+
+	def test_sudo_group_kill(self):
+		import os
+		import signal
+		import subprocess
+		if subprocess.run(
+			['sudo', '-n', 'true'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+		).returncode != 0:
+			self.skipTest('passwordless sudo not available in this environment')
+
+		class SudoSleep(TestStopProcessKillsTree.SleepCmd):
+			requires_sudo = True
+
+		cmd = SudoSleep(['300'])
+		t = self._run_bg(cmd)
+		pgid = os.getpgid(cmd.process.pid)
+		# sudo makes the group root-owned; killpg raises EPERM and stop_process escalates via sudo kill.
+		cmd.stop_process(sig=signal.SIGKILL)
+		t.join(timeout=15)
+		self._assert_group_gone(pgid)


### PR DESCRIPTION
## Problem (RC#7, prod 2026-07-10)

Celery `app.control.revoke(ids, terminate=True, signal="SIGKILL")` reported
success and `inspect().active()` found all tasks, **but the tasks kept
running**. Tools that run as `sudo <tool>` (e.g. `sudo nmap -sS`) execute as
**root**. The terminate SIGKILL hits the worker's non-root Python child, which
**orphans the root tool** (reparented to PID 1) instead of killing it — and the
orphan then loses secator's timeout-monitor thread, so it runs to natural
completion (up to ~91h for a paranoid all-ports nmap, ignoring even the 10h
cap). `sudo pkill` from inside the container also fails: the container's sudoers
is passwordless for the **tool only**, not `pkill`. Only tearing down the pod
killed them.

Root cause: a non-root worker **cannot signal a root process**
(`os.kill`/`os.killpg` → EPERM), and the tool wasn't in its own process group
so the signal never reached the whole `sudo <tool>` tree.

## Fix (secator-core)

All termination paths route through `Command.stop_process`, so the fix lives
there plus the spawn:

1. **Own session.** The tool is now spawned with `start_new_session=True`
   (setsid) in the worker/passwordless case, so `stop_process` can `killpg` the
   **whole group** — sudo parent *and* tool child — in one shot. setsid is kept
   off only for a genuine **interactive** sudo password prompt (detaching the
   tty breaks it, the regression #722 fixed); the new condition is more precise
   than the old blanket "no setsid for any sudo".
2. **Sudo-aware kill.** When `killpg`/`kill` raises `PermissionError` (root-owned
   group), `stop_process` escalates to `sudo -n kill -<sig> -<pgid>` so the root
   tool actually dies. Best-effort and idempotent — logs and moves on if not
   permitted.
3. **Worker SIGTERM handler.** `revoke(terminate=True)` sends SIGTERM to the
   pool child; without a handler it just dies and orphans the tool. A worker-only,
   main-thread-guarded SIGTERM handler now invokes the cleanup, then restores the
   previous (billiard) handler. This also fixes the timeout-monitor path that let
   the orphaned nmap run unbounded.

## Required deploy follow-ups (NOT changed here — code side only)

Pick one; the code supports all:

- **(recommended) Drop `sudo`, use Linux capabilities.** Give the nmap binary
  `cap_net_raw,cap_net_admin+eip` (`setcap` at image build) and run it without
  sudo. The worker then owns the process and kills it directly — no orphan, no
  sudo-kill. Cleanest.
- **Passwordless `sudo kill`.** Add a sudoers entry allowing the worker user to
  run `kill` passwordless, to enable the escalation in (2).
- **Backstop for SIGKILL-terminate.** SIGKILL is uncatchable in-process; set a
  real Kubernetes Job `activeDeadlineSeconds` (and prefer terminating with
  SIGTERM, not SIGKILL) so any orphan is bounded.

## Tests

`tests/unit/test_command.py::TestStopProcessKillsTree` spawns a real
long-running child, calls `stop_process`, and asserts the whole process group is
gone (and that the tool is its own group leader). A `sudo`-wrapped variant
asserts the escalation path and **skips gracefully** where passwordless sudo is
unavailable (e.g. CI).

```
tests/unit/test_command.py::TestStopProcessKillsTree::test_setsid_group_kill_non_sudo PASSED
tests/unit/test_command.py::TestStopProcessKillsTree::test_sudo_group_kill SKIPPED
55 passed, 1 skipped  (test_command.py + test_runners.py)
```

## Open decisions

- SIGKILL-terminate cannot be cleaned up from inside Python by design — deploy
  backstop required (documented above). The in-process fix targets the catchable
  paths (SIGTERM terminate, timeout/memory monitor, user stop, exceptions).
- The `sudo -n kill` escalation is a no-op without the sudoers entry. If you go
  the capabilities route instead, it's never exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtTyzcUmPYxM5nfp7MnMVd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command termination so stopping a task reliably terminates the complete subprocess tree.
  * Fixed orphaned processes when tasks are terminated from worker environments.
  * Improved handling of commands launched with elevated privileges, including permission-related termination failures.
  * Preserved interactive elevated-command behavior while improving cleanup for non-interactive tasks.

* **Tests**
  * Added coverage verifying process trees are fully terminated for standard and elevated commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->