### PR TITLE
feat: add live JSON driver (per-runner report.json, concurrency-safe)

### DIFF
--- a/secator/definitions.py
+++ b/secator/definitions.py
@@ -55,7 +55,7 @@ LLM_SPINNER_MESSAGES = [
 ]
 
 # Available drivers and exporters
-AVAILABLE_DRIVERS = ['mongodb', 'gcs', 'api', 'discord', 'sqlite']
+AVAILABLE_DRIVERS = ['mongodb', 'gcs', 'api', 'discord', 'sqlite', 'json']
 AVAILABLE_EXPORTERS = ['csv', 'gdrive', 'json', 'jsonl', 'markdown', 'table', 'txt']
 
 # Canonical execution priority for drivers whose hooks share a lifecycle event.
@@ -67,7 +67,7 @@ AVAILABLE_EXPORTERS = ['csv', 'gdrive', 'json', 'jsonl', 'markdown', 'table', 't
 #      directly to the store the API reads.
 # Drivers not listed here (e.g. discord notifications, external drivers) are not
 # ranked and keep their relative order after the ranked ones.
-DRIVER_PRIORITY = ['gcs', 'mongodb', 'sqlite', 'api']
+DRIVER_PRIORITY = ['gcs', 'mongodb', 'sqlite', 'json', 'api']
 
 # Vocab
 ALIVE = 'alive'

--- a/secator/hooks/json.py
+++ b/secator/hooks/json.py
@@ -18,116 +18,25 @@
 #   Sharding does most of the work: each runner owns its own report.json, so two
 #   *different* runners never touch the same file. The remaining hazard is two
 #   writers hitting the SAME file (a redelivered task, or update_finding racing
-#   update_runner). We make every write a locked read-modify-write with an
-#   atomic swap, correct under both pools:
-#     1. per-path in-process lock (``threading.Lock``) — gevent monkey-patches
-#        threading, so this is greenlet-cooperative under the gevent pool and a
-#        real mutex under prefork threads. It serializes same-process writers
-#        BEFORE they touch the OS lock, so the blocking flock below is only ever
-#        contended across processes (rare), never stalling the gevent hub.
-#     2. ``fcntl.flock(LOCK_EX)`` on a stable sidecar ``.lock`` file — mutual
-#        exclusion across prefork processes. The lock is a *separate* file (never
-#        replaced), so os.replace() below can't pull the locked inode out from
-#        under a holder.
-#     3. tempfile + ``os.replace`` — atomic on POSIX, so a concurrent reader
-#        (e.g. the query backend mid-run) always sees a whole old-or-new file,
-#        never a torn write.
-#   The lock serializes RMW, so no update is lost; the atomic swap means no
-#   reader ever sees corruption.
+#   update_runner). Every write goes through ``atomic_json`` (secator.utils): a
+#   locked read-modify-write with an atomic swap, correct under both pools. See
+#   that function's docstring for the layered-lock details.
 #
 # ponytail: no `on_build` PENDING placeholder (mongodb/sqlite mint one so the UI
 # tree shows not-yet-run children). Locally the query backend discovers runners
 # by walking report dirs, so a child simply appears once it starts. Add on_build
 # if a live "pending children" view is needed.
 
-import fcntl
-import json
-import os
-import tempfile
-import threading
 import uuid
 from pathlib import Path
 
 from secator.output_types import OUTPUT_TYPES
 from secator.runners import Scan, Task, Workflow
-from secator.utils import debug
-
-# One lock object per report.json path, so same-process writers (greenlets under
-# gevent, threads under prefork) serialize before the cross-process flock.
-_path_locks = {}
-_path_locks_guard = threading.Lock()
+from secator.utils import atomic_json, debug
 
 
-def _get_path_lock(path):
-	key = str(path)
-	lock = _path_locks.get(key)
-	if lock is None:
-		with _path_locks_guard:
-			lock = _path_locks.get(key)
-			if lock is None:
-				lock = threading.Lock()
-				_path_locks[key] = lock
-	return lock
-
-
-def _read_json(path):
-	"""Read a report.json, tolerating absence / partial writes.
-
-	os.replace makes torn reads impossible in the normal path; the JSONDecodeError
-	guard is belt-and-suspenders for an externally-truncated file.
-	"""
-	try:
-		with open(path, 'r') as f:
-			return json.load(f)
-	except (FileNotFoundError, json.JSONDecodeError):
-		return {'info': {}, 'results': {}}
-
-
-def _atomic_write(path, data):
-	"""Write JSON to a temp file in the same dir, then os.replace() over the target."""
-	path = Path(path)
-	fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix='.report-', suffix='.json.tmp')
-	try:
-		with os.fdopen(fd, 'w') as f:
-			json.dump(data, f, indent=2, default=str)
-			f.flush()
-			os.fsync(f.fileno())
-		os.replace(tmp, path)
-	except BaseException:
-		try:
-			os.unlink(tmp)
-		except OSError:
-			pass
-		raise
-
-
-def atomic_json_update(path, mutate):
-	"""Concurrency-safe read-modify-write of a report.json.
-
-	Args:
-		path (str | Path): report.json path.
-		mutate (callable): takes the loaded dict, mutates it in place.
-
-	Safe under both Celery pools (prefork processes + gevent greenlets): see the
-	module docstring. Returns the mutated dict.
-	"""
-	path = Path(path)
-	path.parent.mkdir(parents=True, exist_ok=True)
-	lock_path = str(path) + '.lock'
-	with _get_path_lock(path):                        # (1) in-process (greenlet/thread)
-		with open(lock_path, 'w') as lock_fd:
-			fcntl.flock(lock_fd, fcntl.LOCK_EX)       # (2) cross-process (prefork)
-			try:
-				data = _read_json(path)
-				if 'results' not in data:
-					data['results'] = {}
-				if 'info' not in data:
-					data['info'] = {}
-				mutate(data)
-				_atomic_write(path, data)             # (3) atomic swap
-				return data
-			finally:
-				fcntl.flock(lock_fd, fcntl.LOCK_UN)
+def _empty_report():
+	return {'info': {}, 'results': {}}
 
 
 def _report_path(runner):
@@ -137,12 +46,9 @@ def _report_path(runner):
 def update_runner(self):
 	"""Persist the runner's own info block into its report.json (live)."""
 	info = self.toDict()
-
-	def mutate(data):
-		data['info'] = info
-
 	path = _report_path(self)
-	atomic_json_update(path, mutate)
+	with atomic_json(path, default=_empty_report) as data:
+		data['info'] = info
 	debug(f'wrote runner info to {path}', sub='hooks.json', verbose=True)
 
 
@@ -156,15 +62,14 @@ def update_finding(self, item):
 	record['_uuid'] = item._uuid
 	_type = item._type
 
-	def mutate(data):
-		bucket = data['results'].setdefault(_type, [])
+	with atomic_json(_report_path(self), default=_empty_report) as data:
+		bucket = data.setdefault('results', {}).setdefault(_type, [])
 		for i, existing in enumerate(bucket):
 			if existing.get('_uuid') == item._uuid:
 				bucket[i] = record
-				return
-		bucket.append(record)
-
-	atomic_json_update(_report_path(self), mutate)
+				break
+		else:
+			bucket.append(record)
 	return item
 
 

--- a/secator/hooks/json.py
+++ b/secator/hooks/json.py
@@ -1,0 +1,194 @@
+# secator/hooks/json.py
+#
+# Live JSON *driver* (not the end-of-run JSON exporter).
+#
+# It mirrors the mongodb/sqlite drivers but persists to the local filesystem:
+# every runner writes/updates its OWN ``report.json`` inside its
+# ``runner.reports_folder`` AS results are produced (on_item) and as its status
+# changes (on_init/on_start/on_interval/on_end). The file format
+# (``{"info": {...}, "results": {type: [items]}}``) is byte-compatible with what
+# the JSON exporter emits and with what the ``local`` query backend
+# (``secator/query/json.py``) already reads — so a run driven with
+# ``--driver json`` is queryable *mid-run*, not just at the end.
+#
+# Concurrency (the crux):
+#   Results are produced by many workers writing the report tree at once.
+#     - prefork pool  -> separate OS processes (separate memory)
+#     - gevent pool   -> greenlets in one process (cooperative)
+#   Sharding does most of the work: each runner owns its own report.json, so two
+#   *different* runners never touch the same file. The remaining hazard is two
+#   writers hitting the SAME file (a redelivered task, or update_finding racing
+#   update_runner). We make every write a locked read-modify-write with an
+#   atomic swap, correct under both pools:
+#     1. per-path in-process lock (``threading.Lock``) — gevent monkey-patches
+#        threading, so this is greenlet-cooperative under the gevent pool and a
+#        real mutex under prefork threads. It serializes same-process writers
+#        BEFORE they touch the OS lock, so the blocking flock below is only ever
+#        contended across processes (rare), never stalling the gevent hub.
+#     2. ``fcntl.flock(LOCK_EX)`` on a stable sidecar ``.lock`` file — mutual
+#        exclusion across prefork processes. The lock is a *separate* file (never
+#        replaced), so os.replace() below can't pull the locked inode out from
+#        under a holder.
+#     3. tempfile + ``os.replace`` — atomic on POSIX, so a concurrent reader
+#        (e.g. the query backend mid-run) always sees a whole old-or-new file,
+#        never a torn write.
+#   The lock serializes RMW, so no update is lost; the atomic swap means no
+#   reader ever sees corruption.
+#
+# ponytail: no `on_build` PENDING placeholder (mongodb/sqlite mint one so the UI
+# tree shows not-yet-run children). Locally the query backend discovers runners
+# by walking report dirs, so a child simply appears once it starts. Add on_build
+# if a live "pending children" view is needed.
+
+import fcntl
+import json
+import os
+import tempfile
+import threading
+import uuid
+from pathlib import Path
+
+from secator.output_types import OUTPUT_TYPES
+from secator.runners import Scan, Task, Workflow
+from secator.utils import debug
+
+# One lock object per report.json path, so same-process writers (greenlets under
+# gevent, threads under prefork) serialize before the cross-process flock.
+_path_locks = {}
+_path_locks_guard = threading.Lock()
+
+
+def _get_path_lock(path):
+	key = str(path)
+	lock = _path_locks.get(key)
+	if lock is None:
+		with _path_locks_guard:
+			lock = _path_locks.get(key)
+			if lock is None:
+				lock = threading.Lock()
+				_path_locks[key] = lock
+	return lock
+
+
+def _read_json(path):
+	"""Read a report.json, tolerating absence / partial writes.
+
+	os.replace makes torn reads impossible in the normal path; the JSONDecodeError
+	guard is belt-and-suspenders for an externally-truncated file.
+	"""
+	try:
+		with open(path, 'r') as f:
+			return json.load(f)
+	except (FileNotFoundError, json.JSONDecodeError):
+		return {'info': {}, 'results': {}}
+
+
+def _atomic_write(path, data):
+	"""Write JSON to a temp file in the same dir, then os.replace() over the target."""
+	path = Path(path)
+	fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix='.report-', suffix='.json.tmp')
+	try:
+		with os.fdopen(fd, 'w') as f:
+			json.dump(data, f, indent=2, default=str)
+			f.flush()
+			os.fsync(f.fileno())
+		os.replace(tmp, path)
+	except BaseException:
+		try:
+			os.unlink(tmp)
+		except OSError:
+			pass
+		raise
+
+
+def atomic_json_update(path, mutate):
+	"""Concurrency-safe read-modify-write of a report.json.
+
+	Args:
+		path (str | Path): report.json path.
+		mutate (callable): takes the loaded dict, mutates it in place.
+
+	Safe under both Celery pools (prefork processes + gevent greenlets): see the
+	module docstring. Returns the mutated dict.
+	"""
+	path = Path(path)
+	path.parent.mkdir(parents=True, exist_ok=True)
+	lock_path = str(path) + '.lock'
+	with _get_path_lock(path):                        # (1) in-process (greenlet/thread)
+		with open(lock_path, 'w') as lock_fd:
+			fcntl.flock(lock_fd, fcntl.LOCK_EX)       # (2) cross-process (prefork)
+			try:
+				data = _read_json(path)
+				if 'results' not in data:
+					data['results'] = {}
+				if 'info' not in data:
+					data['info'] = {}
+				mutate(data)
+				_atomic_write(path, data)             # (3) atomic swap
+				return data
+			finally:
+				fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+
+def _report_path(runner):
+	return Path(runner.reports_folder) / 'report.json'
+
+
+def update_runner(self):
+	"""Persist the runner's own info block into its report.json (live)."""
+	info = self.toDict()
+
+	def mutate(data):
+		data['info'] = info
+
+	path = _report_path(self)
+	atomic_json_update(path, mutate)
+	debug(f'wrote runner info to {path}', sub='hooks.json', verbose=True)
+
+
+def update_finding(self, item):
+	"""Upsert a single finding into this runner's report.json results (live)."""
+	if type(item) not in OUTPUT_TYPES:
+		return item
+	if not item._uuid:
+		item._uuid = str(uuid.uuid4())
+	record = item.toDict()
+	record['_uuid'] = item._uuid
+	_type = item._type
+
+	def mutate(data):
+		bucket = data['results'].setdefault(_type, [])
+		for i, existing in enumerate(bucket):
+			if existing.get('_uuid') == item._uuid:
+				bucket[i] = record
+				return
+		bucket.append(record)
+
+	atomic_json_update(_report_path(self), mutate)
+	return item
+
+
+HOOKS = {
+	Scan: {
+		'on_init': [update_runner],
+		'on_start': [update_runner],
+		'on_interval': [update_runner],
+		'on_duplicate': [update_finding],
+		'on_end': [update_runner],
+	},
+	Workflow: {
+		'on_init': [update_runner],
+		'on_start': [update_runner],
+		'on_interval': [update_runner],
+		'on_duplicate': [update_finding],
+		'on_end': [update_runner],
+	},
+	Task: {
+		'on_init': [update_runner],
+		'on_start': [update_runner],
+		'on_item': [update_finding],
+		'on_duplicate': [update_finding],
+		'on_interval': [update_runner],
+		'on_end': [update_runner],
+	},
+}

--- a/secator/utils.py
+++ b/secator/utils.py
@@ -1471,16 +1471,18 @@ def _get_path_lock(path):
 
 
 def _read_json(path, default):
-	"""Read a JSON file, tolerating absence / partial writes.
+	"""Read a JSON file. Absent -> default(); corrupt -> raise.
 
-	os.replace makes torn reads impossible in the normal path; the JSONDecodeError
-	guard is belt-and-suspenders for an externally-truncated file. ``default`` is a
-	callable factory (e.g. ``dict``) returning the fallback on absence/corruption.
+	Absence is normal (first write), so it returns ``default()`` (a callable
+	factory, e.g. ``dict``). Corruption is NOT normal — os.replace makes torn
+	writes impossible, so a JSONDecodeError means a real anomaly. We let it
+	propagate rather than reset to empty, so a read-modify-write never clobbers a
+	corrupt-but-present file (and its accumulated data) with a blank one.
 	"""
 	try:
 		with open(path, 'r') as f:
 			return json.load(f)
-	except (FileNotFoundError, json.JSONDecodeError):
+	except FileNotFoundError:
 		return default()
 
 
@@ -1506,8 +1508,10 @@ def _atomic_write(path, data):
 def atomic_json(path, default=dict):
 	"""Locked read-modify-write of a JSON file, as a context manager.
 
-	Yields the parsed data (default() if the file is absent/corrupt); the caller
-	mutates it in place. On clean block exit the data is written back atomically
+	Yields the parsed data (default() if the file is absent; a present-but-corrupt
+	file raises rather than being reset to empty, so a read-modify-write never
+	clobbers accumulated data); the caller mutates it in place. On clean block exit
+	the data is written back atomically
 	(tempfile + fsync + os.replace). On exception, nothing is written — the file
 	is left unchanged. The layered lock is always released in ``finally``.
 
@@ -1516,7 +1520,7 @@ def atomic_json(path, default=dict):
 	Args:
 		path (str | Path): JSON file path (parent dirs are created).
 		default (callable): factory for the fallback value when the file is
-			absent/corrupt, e.g. ``dict``, ``list``, ``lambda: {'info': {}, 'results': {}}``.
+			absent, e.g. ``dict``, ``list``, ``lambda: {'info': {}, 'results': {}}``.
 
 	Notes:
 		- The block runs while the lock is HELD — keep it to the read-modify-write,
@@ -1544,6 +1548,7 @@ def read_json(path, default=dict):
 
 	Safe without a lock because writers use os.replace(), so a reader always sees a
 	complete old-or-new file, never a torn write. Returns ``default()`` (a callable
-	factory) if the file is absent or corrupt.
+	factory) if the file is absent; a present-but-corrupt file raises
+	JSONDecodeError (a real anomaly, not silently masked).
 	"""
 	return _read_json(path, default)

--- a/secator/utils.py
+++ b/secator/utils.py
@@ -1,3 +1,4 @@
+import fcntl
 import importlib
 import ipaddress
 import itertools
@@ -9,11 +10,14 @@ import re
 import select
 import signal
 import sys
+import tempfile
+import threading
 import tldextract
 import traceback
 import validators
 import warnings
 
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from functools import reduce
 from pathlib import Path
@@ -1429,3 +1433,117 @@ def remove_duplicates(items):
 		if key not in seen:
 			seen[key] = item
 	return list(seen.values())
+
+
+# --- Atomic JSON: concurrency-safe read-modify-write of a JSON file ----------
+#
+# A layered lock makes a JSON file safe to update from many writers at once,
+# correct under both Celery pools (prefork processes + gevent greenlets):
+#   1. per-path in-process lock (``threading.Lock``) — gevent monkey-patches
+#      threading, so this is greenlet-cooperative under the gevent pool and a
+#      real mutex under prefork threads. It serializes same-process writers
+#      BEFORE they touch the OS lock, so the blocking flock is only ever
+#      contended across processes (rare), never stalling the gevent hub.
+#   2. ``fcntl.flock(LOCK_EX)`` on a stable sidecar ``.lock`` file — mutual
+#      exclusion across prefork processes. It is a *separate* file (never
+#      replaced/unlinked), so os.replace() can't pull the locked inode out from
+#      under a holder.
+#   3. tempfile + ``os.replace`` — atomic on POSIX, so a concurrent reader
+#      always sees a whole old-or-new file, never a torn write. That is why
+#      read_json() below can snapshot lock-free.
+
+# One lock object per path, so same-process writers (greenlets under gevent,
+# threads under prefork) serialize before the cross-process flock.
+_path_locks = {}
+_path_locks_guard = threading.Lock()
+
+
+def _get_path_lock(path):
+	key = str(path)
+	lock = _path_locks.get(key)
+	if lock is None:
+		with _path_locks_guard:
+			lock = _path_locks.get(key)
+			if lock is None:
+				lock = threading.Lock()
+				_path_locks[key] = lock
+	return lock
+
+
+def _read_json(path, default):
+	"""Read a JSON file, tolerating absence / partial writes.
+
+	os.replace makes torn reads impossible in the normal path; the JSONDecodeError
+	guard is belt-and-suspenders for an externally-truncated file. ``default`` is a
+	callable factory (e.g. ``dict``) returning the fallback on absence/corruption.
+	"""
+	try:
+		with open(path, 'r') as f:
+			return json.load(f)
+	except (FileNotFoundError, json.JSONDecodeError):
+		return default()
+
+
+def _atomic_write(path, data):
+	"""Write JSON to a temp file in the same dir, then os.replace() over the target."""
+	path = Path(path)
+	fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix='.report-', suffix='.json.tmp')
+	try:
+		with os.fdopen(fd, 'w') as f:
+			json.dump(data, f, indent=2, default=str)
+			f.flush()
+			os.fsync(f.fileno())
+		os.replace(tmp, path)
+	except BaseException:
+		try:
+			os.unlink(tmp)
+		except OSError:
+			pass
+		raise
+
+
+@contextmanager
+def atomic_json(path, default=dict):
+	"""Locked read-modify-write of a JSON file, as a context manager.
+
+	Yields the parsed data (default() if the file is absent/corrupt); the caller
+	mutates it in place. On clean block exit the data is written back atomically
+	(tempfile + fsync + os.replace). On exception, nothing is written — the file
+	is left unchanged. The layered lock is always released in ``finally``.
+
+	Wholesale replace is just ``data.clear(); data.update(new)`` inside the block.
+
+	Args:
+		path (str | Path): JSON file path (parent dirs are created).
+		default (callable): factory for the fallback value when the file is
+			absent/corrupt, e.g. ``dict``, ``list``, ``lambda: {'info': {}, 'results': {}}``.
+
+	Notes:
+		- The block runs while the lock is HELD — keep it to the read-modify-write,
+		  no slow I/O / subprocess inside, or you serialize every other writer.
+		- The ``.lock`` sidecar file persists (never unlinked — unlinking races
+		  holders); this is harmless.
+		- Safe under both Celery pools (prefork processes + gevent greenlets).
+	"""
+	path = Path(path)
+	path.parent.mkdir(parents=True, exist_ok=True)
+	lock_path = str(path) + '.lock'
+	with _get_path_lock(path):                        # (1) in-process (greenlet/thread)
+		with open(lock_path, 'w') as lock_fd:
+			fcntl.flock(lock_fd, fcntl.LOCK_EX)       # (2) cross-process (prefork)
+			try:
+				data = _read_json(path, default)
+				yield data
+				_atomic_write(path, data)             # (3) atomic swap (clean exit only)
+			finally:
+				fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+
+def read_json(path, default=dict):
+	"""Lock-free snapshot read of a JSON file written by ``atomic_json``.
+
+	Safe without a lock because writers use os.replace(), so a reader always sees a
+	complete old-or-new file, never a torn write. Returns ``default()`` (a callable
+	factory) if the file is absent or corrupt.
+	"""
+	return _read_json(path, default)

--- a/tests/unit/test_atomic_json.py
+++ b/tests/unit/test_atomic_json.py
@@ -10,6 +10,8 @@ import shutil
 import unittest
 from pathlib import Path
 
+import pytest
+
 
 # --- module-level workers (must be importable/picklable for multiprocessing) ---
 
@@ -48,6 +50,15 @@ class AtomicJsonTestBase(unittest.TestCase):
 	def _items(self):
 		data = json.loads(Path(self.path).read_text())  # must be valid JSON (no torn write)
 		return data['items']
+
+	def _join(self, procs, timeout=60):
+		"""Join workers; terminate any that time out so a regression can't hang the suite."""
+		for p in procs:
+			p.join(timeout)
+			if p.is_alive():
+				p.terminate()
+				p.join(5)
+			self.assertEqual(p.exitcode, 0, f'worker {p.pid} did not exit cleanly (exitcode={p.exitcode})')
 
 
 class TestAtomicJson(AtomicJsonTestBase):
@@ -91,26 +102,25 @@ class TestAtomicJson(AtomicJsonTestBase):
 		]
 		for p in procs:
 			p.start()
-		for p in procs:
-			p.join(60)
-			self.assertEqual(p.exitcode, 0)
+		self._join(procs)
 		items = self._items()
 		self.assertEqual(len(items), self.N_WORKERS * self.PER_WORKER)
 		self.assertEqual(len(set(items)), self.N_WORKERS * self.PER_WORKER)
 
 	def test_concurrent_gevent_greenlets(self):
 		"""N greenlets in one (isolated, monkey-patched) process append to one file."""
+		pytest.importorskip('gevent')
 		ctx = mp.get_context('spawn')
 		p = ctx.Process(target=_gevent_child, args=(self.path, self.N_WORKERS, self.PER_WORKER))
 		p.start()
-		p.join(60)
-		self.assertEqual(p.exitcode, 0)
+		self._join([p])
 		items = self._items()
 		self.assertEqual(len(items), self.N_WORKERS * self.PER_WORKER)
 		self.assertEqual(len(set(items)), self.N_WORKERS * self.PER_WORKER)
 
 	def test_concurrent_mixed_processes_and_greenlets(self):
 		"""prefork processes AND a gevent-greenlet process share one file."""
+		pytest.importorskip('gevent')
 		fork = mp.get_context('fork')
 		spawn = mp.get_context('spawn')
 		procs = [
@@ -121,9 +131,7 @@ class TestAtomicJson(AtomicJsonTestBase):
 		for p in procs:
 			p.start()
 		gproc.start()
-		for p in procs + [gproc]:
-			p.join(60)
-			self.assertEqual(p.exitcode, 0)
+		self._join(procs + [gproc])
 		items = self._items()
 		self.assertEqual(len(items), 2 * self.N_WORKERS * self.PER_WORKER)
 		self.assertEqual(len(set(items)), 2 * self.N_WORKERS * self.PER_WORKER)
@@ -135,10 +143,18 @@ class TestReadJson(AtomicJsonTestBase):
 		self.assertEqual(read_json(self.path, default=dict), {})
 		self.assertEqual(read_json(self.path, default=lambda: {'items': []}), {'items': []})
 
-	def test_corrupt_returns_default(self):
-		from secator.utils import read_json
+	def test_corrupt_raises_not_masked(self):
+		# A present-but-corrupt file is a real anomaly, not a normal partial write:
+		# read_json (and atomic_json) must raise, never silently reset to default and
+		# clobber accumulated data.
+		from secator.utils import atomic_json, read_json
 		Path(self.path).write_text('{ not valid json')
-		self.assertEqual(read_json(self.path, default=lambda: {'items': []}), {'items': []})
+		with self.assertRaises(json.JSONDecodeError):
+			read_json(self.path, default=lambda: {'items': []})
+		with self.assertRaises(json.JSONDecodeError):
+			with atomic_json(self.path, default=lambda: {'items': []}):
+				pass
+		self.assertEqual(Path(self.path).read_text(), '{ not valid json')  # unchanged
 
 	def test_present_returns_data(self):
 		from secator.utils import atomic_json, read_json
@@ -157,9 +173,7 @@ class TestReadJson(AtomicJsonTestBase):
 		for _ in range(200):
 			snap = read_json(self.path, default=lambda: {'items': []})
 			self.assertIsInstance(snap['items'], list)
-		for p in procs:
-			p.join(60)
-			self.assertEqual(p.exitcode, 0)
+		self._join(procs)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_atomic_json.py
+++ b/tests/unit/test_atomic_json.py
@@ -1,0 +1,166 @@
+# tests/unit/test_atomic_json.py
+#
+# Direct tests for the atomic_json / read_json primitives in secator.utils
+# (mongomock-free — no driver, no output types).
+
+import json
+import multiprocessing as mp
+import tempfile
+import shutil
+import unittest
+from pathlib import Path
+
+
+# --- module-level workers (must be importable/picklable for multiprocessing) ---
+
+def _proc_worker(path, worker_id, count):
+	"""Append `count` uniquely-keyed entries to a shared list key via atomic_json (one process)."""
+	from secator.utils import atomic_json
+	for i in range(count):
+		with atomic_json(path, default=lambda: {'items': []}) as data:
+			data['items'].append(f'{worker_id}-{i}')
+
+
+def _gevent_child(path, n_greenlets, count):
+	"""Separate process: monkey-patch gevent, then hammer one file from N greenlets via atomic_json."""
+	import gevent.monkey
+	gevent.monkey.patch_all()
+	import gevent
+	from secator.utils import atomic_json
+
+	def work(worker_id):
+		for i in range(count):
+			with atomic_json(path, default=lambda: {'items': []}) as data:
+				data['items'].append(f'g{worker_id}-{i}')
+
+	greenlets = [gevent.spawn(work, w) for w in range(n_greenlets)]
+	gevent.joinall(greenlets, raise_error=True)
+
+
+class AtomicJsonTestBase(unittest.TestCase):
+	def setUp(self):
+		self.temp_dir = tempfile.mkdtemp()
+		self.path = str(Path(self.temp_dir) / 'data.json')
+
+	def tearDown(self):
+		shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+	def _items(self):
+		data = json.loads(Path(self.path).read_text())  # must be valid JSON (no torn write)
+		return data['items']
+
+
+class TestAtomicJson(AtomicJsonTestBase):
+	N_WORKERS = 4
+	PER_WORKER = 25
+
+	def test_yields_default_when_absent(self):
+		from secator.utils import atomic_json
+		with atomic_json(self.path, default=lambda: {'items': []}) as data:
+			self.assertEqual(data, {'items': []})
+			data['items'].append('x')
+		self.assertEqual(self._items(), ['x'])
+
+	def test_exception_leaves_file_unchanged(self):
+		from secator.utils import atomic_json
+		# Seed the file.
+		with atomic_json(self.path, default=lambda: {'items': []}) as data:
+			data['items'].append('seed')
+		# A block that raises must NOT write.
+		with self.assertRaises(RuntimeError):
+			with atomic_json(self.path, default=lambda: {'items': []}) as data:
+				data['items'].append('should-not-persist')
+				raise RuntimeError('boom')
+		self.assertEqual(self._items(), ['seed'])  # unchanged
+
+	def test_wholesale_replace(self):
+		from secator.utils import atomic_json
+		with atomic_json(self.path, default=lambda: {'items': []}) as data:
+			data['items'].append('old')
+		with atomic_json(self.path, default=lambda: {'items': []}) as data:
+			data.clear()
+			data.update({'items': ['new']})
+		self.assertEqual(self._items(), ['new'])
+
+	def test_concurrent_prefork_processes(self):
+		"""N separate OS processes append to one file — no lost updates."""
+		ctx = mp.get_context('fork')
+		procs = [
+			ctx.Process(target=_proc_worker, args=(self.path, w, self.PER_WORKER))
+			for w in range(self.N_WORKERS)
+		]
+		for p in procs:
+			p.start()
+		for p in procs:
+			p.join(60)
+			self.assertEqual(p.exitcode, 0)
+		items = self._items()
+		self.assertEqual(len(items), self.N_WORKERS * self.PER_WORKER)
+		self.assertEqual(len(set(items)), self.N_WORKERS * self.PER_WORKER)
+
+	def test_concurrent_gevent_greenlets(self):
+		"""N greenlets in one (isolated, monkey-patched) process append to one file."""
+		ctx = mp.get_context('spawn')
+		p = ctx.Process(target=_gevent_child, args=(self.path, self.N_WORKERS, self.PER_WORKER))
+		p.start()
+		p.join(60)
+		self.assertEqual(p.exitcode, 0)
+		items = self._items()
+		self.assertEqual(len(items), self.N_WORKERS * self.PER_WORKER)
+		self.assertEqual(len(set(items)), self.N_WORKERS * self.PER_WORKER)
+
+	def test_concurrent_mixed_processes_and_greenlets(self):
+		"""prefork processes AND a gevent-greenlet process share one file."""
+		fork = mp.get_context('fork')
+		spawn = mp.get_context('spawn')
+		procs = [
+			fork.Process(target=_proc_worker, args=(self.path, w, self.PER_WORKER))
+			for w in range(self.N_WORKERS)
+		]
+		gproc = spawn.Process(target=_gevent_child, args=(self.path, self.N_WORKERS, self.PER_WORKER))
+		for p in procs:
+			p.start()
+		gproc.start()
+		for p in procs + [gproc]:
+			p.join(60)
+			self.assertEqual(p.exitcode, 0)
+		items = self._items()
+		self.assertEqual(len(items), 2 * self.N_WORKERS * self.PER_WORKER)
+		self.assertEqual(len(set(items)), 2 * self.N_WORKERS * self.PER_WORKER)
+
+
+class TestReadJson(AtomicJsonTestBase):
+	def test_absent_returns_default(self):
+		from secator.utils import read_json
+		self.assertEqual(read_json(self.path, default=dict), {})
+		self.assertEqual(read_json(self.path, default=lambda: {'items': []}), {'items': []})
+
+	def test_corrupt_returns_default(self):
+		from secator.utils import read_json
+		Path(self.path).write_text('{ not valid json')
+		self.assertEqual(read_json(self.path, default=lambda: {'items': []}), {'items': []})
+
+	def test_present_returns_data(self):
+		from secator.utils import atomic_json, read_json
+		with atomic_json(self.path, default=lambda: {'items': []}) as data:
+			data['items'].append('a')
+		self.assertEqual(read_json(self.path, default=lambda: {'items': []}), {'items': ['a']})
+
+	def test_tolerates_concurrent_write(self):
+		"""A lock-free read during concurrent writers always sees a complete old-or-new file."""
+		from secator.utils import read_json
+		ctx = mp.get_context('fork')
+		procs = [ctx.Process(target=_proc_worker, args=(self.path, w, 25)) for w in range(4)]
+		for p in procs:
+			p.start()
+		# Snapshot-read repeatedly while writers run — must never raise / see a torn file.
+		for _ in range(200):
+			snap = read_json(self.path, default=lambda: {'items': []})
+			self.assertIsInstance(snap['items'], list)
+		for p in procs:
+			p.join(60)
+			self.assertEqual(p.exitcode, 0)
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/unit/test_json_driver.py
+++ b/tests/unit/test_json_driver.py
@@ -1,0 +1,201 @@
+# tests/unit/test_json_driver.py
+
+import json
+import multiprocessing as mp
+import tempfile
+import shutil
+import unittest
+from pathlib import Path
+
+
+# --- module-level workers (must be importable/picklable for multiprocessing) ---
+
+def _proc_worker(path, worker_id, count):
+	"""Append `count` uniquely-uuid'd findings to the SAME report.json (one process)."""
+	from secator.hooks.json import atomic_json_update
+	for i in range(count):
+		uid = f'{worker_id}-{i}'
+		atomic_json_update(
+			path,
+			lambda data, uid=uid: data['results'].setdefault('url', []).append({'_uuid': uid}),
+		)
+
+
+def _gevent_child(path, n_greenlets, count):
+	"""Run in a separate process: monkey-patch gevent, then hammer one file from N greenlets."""
+	import gevent.monkey
+	gevent.monkey.patch_all()
+	import gevent
+	from secator.hooks.json import atomic_json_update
+
+	def work(worker_id):
+		for i in range(count):
+			uid = f'g{worker_id}-{i}'
+			atomic_json_update(
+				path,
+				lambda data, uid=uid: data['results'].setdefault('url', []).append({'_uuid': uid}),
+			)
+
+	greenlets = [gevent.spawn(work, w) for w in range(n_greenlets)]
+	gevent.joinall(greenlets, raise_error=True)
+
+
+class JsonDriverTestBase(unittest.TestCase):
+	def setUp(self):
+		self.temp_dir = tempfile.mkdtemp()
+
+	def tearDown(self):
+		shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+	def _runner(self, rtype='task', name='httpx', ws='ws1', folder=None):
+		folder = folder or self.temp_dir
+		Path(folder).mkdir(parents=True, exist_ok=True)
+
+		class FakeRunner:
+			def __init__(inner):
+				inner.config = type('C', (), {'type': rtype, 'name': name})()
+				inner.context = {'workspace_id': ws}
+				inner.reports_folder = folder
+				inner.status = 'RUNNING'
+
+			def toDict(inner):
+				return {'name': name, 'status': inner.status, 'chunk': None, 'context': inner.context}
+
+		return FakeRunner()
+
+	def _url(self, url, ws='ws1'):
+		from secator.output_types import Url
+		return Url(url=url, _context={'workspace_id': ws, 'workspace_duplicate': False})
+
+
+class TestJsonDriverHooks(JsonDriverTestBase):
+	def test_update_finding_inserts_and_assigns_uuid(self):
+		from secator.hooks import json as mod
+		runner = self._runner()
+		item = self._url('http://x/a')
+		self.assertEqual(item._uuid, '')
+		returned = mod.update_finding(runner, item)
+		self.assertTrue(returned._uuid)  # uuid assigned
+
+		data = json.loads((Path(self.temp_dir) / 'report.json').read_text())
+		self.assertEqual(len(data['results']['url']), 1)
+		self.assertEqual(data['results']['url'][0]['url'], 'http://x/a')
+		self.assertEqual(data['results']['url'][0]['_uuid'], returned._uuid)
+
+	def test_update_finding_upserts_by_uuid(self):
+		from secator.hooks import json as mod
+		runner = self._runner()
+		item = self._url('http://x/a')
+		mod.update_finding(runner, item)          # insert
+		item.status_code = 200
+		mod.update_finding(runner, item)          # update same uuid, must not duplicate
+
+		data = json.loads((Path(self.temp_dir) / 'report.json').read_text())
+		self.assertEqual(len(data['results']['url']), 1)
+		self.assertEqual(data['results']['url'][0]['status_code'], 200)
+
+	def test_update_finding_ignores_non_output_type(self):
+		from secator.hooks import json as mod
+		runner = self._runner()
+		self.assertEqual(mod.update_finding(runner, {'not': 'an output type'}), {'not': 'an output type'})
+		self.assertFalse((Path(self.temp_dir) / 'report.json').exists())
+
+	def test_update_runner_writes_info(self):
+		from secator.hooks import json as mod
+		runner = self._runner()
+		mod.update_runner(runner)
+		data = json.loads((Path(self.temp_dir) / 'report.json').read_text())
+		self.assertEqual(data['info']['status'], 'RUNNING')
+		self.assertEqual(data['info']['name'], 'httpx')
+
+		# Runner info update must preserve already-written findings (findings + info share the file).
+		mod.update_finding(runner, self._url('http://x/a'))
+		runner.status = 'SUCCESS'
+		mod.update_runner(runner)
+		data = json.loads((Path(self.temp_dir) / 'report.json').read_text())
+		self.assertEqual(data['info']['status'], 'SUCCESS')
+		self.assertEqual(len(data['results']['url']), 1)
+
+	def test_hooks_structure(self):
+		from secator.hooks import json as mod
+		from secator.runners import Scan, Task, Workflow
+		self.assertIn(Task, mod.HOOKS)
+		self.assertIn(Workflow, mod.HOOKS)
+		self.assertIn(Scan, mod.HOOKS)
+		self.assertIn('on_item', mod.HOOKS[Task])
+		self.assertIn('on_end', mod.HOOKS[Task])
+
+	def test_query_backend_reads_live_file(self):
+		"""The live-written report.json is readable by the local (json) query backend mid-run."""
+		from secator.hooks import json as mod
+		from secator.query.json import JsonBackend
+		# JsonBackend expects <reports_dir>/<ws>/tasks/<id>/report.json
+		folder = Path(self.temp_dir) / 'ws1' / 'tasks' / 'abc123'
+		runner = self._runner(folder=str(folder))
+		mod.update_finding(runner, self._url('http://x/a'))
+		mod.update_finding(runner, self._url('http://x/b'))
+
+		backend = JsonBackend(workspace_id='ws1', config={'reports_dir': self.temp_dir})
+		results = backend.search({'_type': 'url'})
+		urls = sorted(r['url'] for r in results)
+		self.assertEqual(urls, ['http://x/a', 'http://x/b'])
+
+
+class TestJsonDriverConcurrency(JsonDriverTestBase):
+	N_WORKERS = 4
+	PER_WORKER = 25
+
+	def _assert_no_loss(self, path, expected_prefix_count):
+		data = json.loads(Path(path).read_text())          # must be valid JSON (no torn write)
+		uuids = [r['_uuid'] for r in data['results']['url']]
+		self.assertEqual(len(uuids), expected_prefix_count)  # no lost updates
+		self.assertEqual(len(set(uuids)), expected_prefix_count)  # no corruption/dupes
+
+	def test_concurrent_prefork_processes(self):
+		"""prefork pool analogue: N separate OS processes append to one report.json."""
+		path = str(Path(self.temp_dir) / 'report.json')
+		ctx = mp.get_context('fork')
+		procs = [
+			ctx.Process(target=_proc_worker, args=(path, w, self.PER_WORKER))
+			for w in range(self.N_WORKERS)
+		]
+		for p in procs:
+			p.start()
+		for p in procs:
+			p.join(60)
+			self.assertEqual(p.exitcode, 0)
+		self._assert_no_loss(path, self.N_WORKERS * self.PER_WORKER)
+
+	def test_concurrent_gevent_greenlets(self):
+		"""gevent pool analogue: N greenlets in one (monkey-patched) process append to one file."""
+		path = str(Path(self.temp_dir) / 'report.json')
+		# Run monkey-patched gevent in a child process so patch_all() doesn't leak into the suite.
+		ctx = mp.get_context('spawn')
+		p = ctx.Process(target=_gevent_child, args=(path, self.N_WORKERS, self.PER_WORKER))
+		p.start()
+		p.join(60)
+		self.assertEqual(p.exitcode, 0)
+		self._assert_no_loss(path, self.N_WORKERS * self.PER_WORKER)
+
+	def test_concurrent_mixed_processes_and_greenlets(self):
+		"""Both at once: prefork processes AND a gevent-greenlet process share one file."""
+		path = str(Path(self.temp_dir) / 'report.json')
+		fork = mp.get_context('fork')
+		spawn = mp.get_context('spawn')
+		procs = [
+			fork.Process(target=_proc_worker, args=(path, w, self.PER_WORKER))
+			for w in range(self.N_WORKERS)
+		]
+		gproc = spawn.Process(target=_gevent_child, args=(path, self.N_WORKERS, self.PER_WORKER))
+		for p in procs:
+			p.start()
+		gproc.start()
+		for p in procs + [gproc]:
+			p.join(60)
+			self.assertEqual(p.exitcode, 0)
+		# N_WORKERS process-appends + N_WORKERS greenlet-appends, each PER_WORKER items.
+		self._assert_no_loss(path, 2 * self.N_WORKERS * self.PER_WORKER)
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/unit/test_json_driver.py
+++ b/tests/unit/test_json_driver.py
@@ -12,13 +12,11 @@ from pathlib import Path
 
 def _proc_worker(path, worker_id, count):
 	"""Append `count` uniquely-uuid'd findings to the SAME report.json (one process)."""
-	from secator.hooks.json import atomic_json_update
+	from secator.utils import atomic_json
 	for i in range(count):
 		uid = f'{worker_id}-{i}'
-		atomic_json_update(
-			path,
-			lambda data, uid=uid: data['results'].setdefault('url', []).append({'_uuid': uid}),
-		)
+		with atomic_json(path, default=lambda: {'info': {}, 'results': {}}) as data:
+			data['results'].setdefault('url', []).append({'_uuid': uid})
 
 
 def _gevent_child(path, n_greenlets, count):
@@ -26,15 +24,13 @@ def _gevent_child(path, n_greenlets, count):
 	import gevent.monkey
 	gevent.monkey.patch_all()
 	import gevent
-	from secator.hooks.json import atomic_json_update
+	from secator.utils import atomic_json
 
 	def work(worker_id):
 		for i in range(count):
 			uid = f'g{worker_id}-{i}'
-			atomic_json_update(
-				path,
-				lambda data, uid=uid: data['results'].setdefault('url', []).append({'_uuid': uid}),
-			)
+			with atomic_json(path, default=lambda: {'info': {}, 'results': {}}) as data:
+				data['results'].setdefault('url', []).append({'_uuid': uid})
 
 	greenlets = [gevent.spawn(work, w) for w in range(n_greenlets)]
 	gevent.joinall(greenlets, raise_error=True)

--- a/tests/unit/test_json_driver.py
+++ b/tests/unit/test_json_driver.py
@@ -7,6 +7,8 @@ import shutil
 import unittest
 from pathlib import Path
 
+import pytest
+
 
 # --- module-level workers (must be importable/picklable for multiprocessing) ---
 
@@ -147,6 +149,15 @@ class TestJsonDriverConcurrency(JsonDriverTestBase):
 		self.assertEqual(len(uuids), expected_prefix_count)  # no lost updates
 		self.assertEqual(len(set(uuids)), expected_prefix_count)  # no corruption/dupes
 
+	def _join(self, procs, timeout=60):
+		"""Join workers; terminate any that time out so a regression can't hang the suite."""
+		for p in procs:
+			p.join(timeout)
+			if p.is_alive():
+				p.terminate()
+				p.join(5)
+			self.assertEqual(p.exitcode, 0, f'worker {p.pid} did not exit cleanly (exitcode={p.exitcode})')
+
 	def test_concurrent_prefork_processes(self):
 		"""prefork pool analogue: N separate OS processes append to one report.json."""
 		path = str(Path(self.temp_dir) / 'report.json')
@@ -157,24 +168,23 @@ class TestJsonDriverConcurrency(JsonDriverTestBase):
 		]
 		for p in procs:
 			p.start()
-		for p in procs:
-			p.join(60)
-			self.assertEqual(p.exitcode, 0)
+		self._join(procs)
 		self._assert_no_loss(path, self.N_WORKERS * self.PER_WORKER)
 
 	def test_concurrent_gevent_greenlets(self):
 		"""gevent pool analogue: N greenlets in one (monkey-patched) process append to one file."""
+		pytest.importorskip('gevent')
 		path = str(Path(self.temp_dir) / 'report.json')
 		# Run monkey-patched gevent in a child process so patch_all() doesn't leak into the suite.
 		ctx = mp.get_context('spawn')
 		p = ctx.Process(target=_gevent_child, args=(path, self.N_WORKERS, self.PER_WORKER))
 		p.start()
-		p.join(60)
-		self.assertEqual(p.exitcode, 0)
+		self._join([p])
 		self._assert_no_loss(path, self.N_WORKERS * self.PER_WORKER)
 
 	def test_concurrent_mixed_processes_and_greenlets(self):
 		"""Both at once: prefork processes AND a gevent-greenlet process share one file."""
+		pytest.importorskip('gevent')
 		path = str(Path(self.temp_dir) / 'report.json')
 		fork = mp.get_context('fork')
 		spawn = mp.get_context('spawn')
@@ -186,9 +196,7 @@ class TestJsonDriverConcurrency(JsonDriverTestBase):
 		for p in procs:
 			p.start()
 		gproc.start()
-		for p in procs + [gproc]:
-			p.join(60)
-			self.assertEqual(p.exitcode, 0)
+		self._join(procs + [gproc])
 		# N_WORKERS process-appends + N_WORKERS greenlet-appends, each PER_WORKER items.
 		self._assert_no_loss(path, 2 * self.N_WORKERS * self.PER_WORKER)
 


### PR DESCRIPTION
## What

Adds `secator/hooks/json.py` — a **live JSON driver** (not an exporter). It mirrors the mongodb/sqlite drivers but persists to the local filesystem: every runner writes/updates its **own** `report.json` in `runner.reports_folder` **as results are produced** (`on_item`) and as its status changes (`on_init`/`on_start`/`on_interval`/`on_end`), rather than a single end-of-run dump.

Wired into the driver/hooks system alongside the DB drivers:
- module-level `HOOKS` dict keyed by `Scan`/`Workflow`/`Task` (same shape as `hooks/mongodb.py`, `hooks/sqlite.py`), so `_apply_context_drivers` registers it from `context['drivers']` with no special-casing;
- added to `AVAILABLE_DRIVERS` and `DRIVER_PRIORITY` in `definitions.py`.

Use it with `secator x/w/s <target> --driver json` (or `drivers.defaults: [json]`).

The emitted format (`{"info": {...}, "results": {type: [items]}}`) is byte-compatible with the JSON **exporter** and with what the **`local` query backend** (`secator/query/json.py`) already reads — the per-runner-file layout under `<reports>/<ws>/<type>s/<id>/report.json` **is** the read/merge view, so no new merge code is needed.

## Concurrency design (the crux)

Results are produced by many workers writing the report tree at once. Handled for **both** Celery pools:

- **prefork pool** → separate OS processes (separate memory)
- **gevent pool** → greenlets in one process (cooperative)

**Approach chosen: per-runner-file sharding + locked read-modify-write + atomic swap.**

1. **Sharding does most of the work.** Each runner owns its own `report.json`, so two *different* runners never contend. The existing `reports_folder` (per-runner autoincrement dir) gives this for free, and the query backend already merges these files at read time.
2. The remaining hazard is two writers on the **same** file (a redelivered task, or `update_finding` racing `update_runner`). Every write is a locked RMW:
   - **in-process `threading.Lock` per path** — gevent monkey-patches `threading`, so this is greenlet-cooperative under the gevent pool and a real mutex under prefork threads. It serializes same-process writers *before* they touch the OS lock, so the blocking `flock` below is only ever contended **across processes** (rare), never stalling the gevent hub.
   - **`fcntl.flock(LOCK_EX)` on a stable sidecar `.lock` file** — mutual exclusion across prefork **processes**. The lock is a *separate* file (never replaced), so `os.replace()` can't pull the locked inode out from under a holder (the classic flock+rename pitfall).
   - **tempfile + `os.replace`** — atomic on POSIX, so a concurrent reader (e.g. the query backend mid-run) always sees a whole old-or-new file, never a torn write.

The lock serializes RMW ⇒ **no lost updates**; the atomic swap ⇒ **no torn reads**.

### Why this over the alternatives
- **Append-only JSONL** is trivially concurrency-safe for *new* findings, but `update_finding`/`update_runner` are **in-place** updates (upsert-by-`_uuid`, status transitions). JSONL would need compaction/last-wins-on-read and would break the existing `report.json` reader. Rejected.
- **Single mutable global JSON doc** (one file for the whole run) maximizes contention and would serialize every worker on one lock. Rejected in favor of per-runner sharding.
- Per-runner files + RMW keeps the diff small, reuses the existing folder + query layout, and is correct under both pools.

### Known ceilings (marked `ponytail:` in code)
- `fcntl.flock` blocks the gevent hub **only** under genuine cross-process contention on the *same* file (redelivery) — brief and rare. The in-process lock keeps same-process greenlets off the flock entirely.
- No `on_build` PENDING-placeholder hook (mongodb/sqlite mint one so a UI tree shows not-yet-run children). Locally the query backend discovers runners by walking report dirs, so a child appears once it starts. Easy to add if a live "pending children" view is wanted.

## Tests

`tests/unit/test_json_driver.py` (9 tests, all green; lint clean):

- **Hooks**: `update_finding` insert + uuid assignment, upsert-by-uuid (no dup), non-output-type passthrough, `update_runner` info write **preserving** already-written findings, `HOOKS` structure.
- **Mid-run queryability**: the live-written `report.json` is read back by the `local` `JsonBackend` while the runner is still "running".
- **Concurrency** (the requested test):
  - `test_concurrent_prefork_processes` — N=4 OS processes append to one `report.json`.
  - `test_concurrent_gevent_greenlets` — N greenlets in a `monkey.patch_all()`'d process append to one file (isolated in a child process so patching doesn't leak into the suite).
  - `test_concurrent_mixed_processes_and_greenlets` — prefork processes **and** a gevent-greenlet process share one file (200 appends).
  - Each asserts the final file is **valid JSON**, has **exactly** the expected count (no lost updates), and **no duplicate/dropped** uuids (no corruption).

Also verified end-to-end that `context['drivers']=['json']` registers `update_finding`/`update_runner` on `on_item`/`on_end` (identical wiring to mongodb/sqlite) and that firing the lifecycle writes a live `report.json` with `info` + findings.

## Deprecation path (exporter → driver)

The JSON **exporter** is intentionally **left in place** (no behavior change for existing runs). The driver supersedes it: a driver can piggy-back **any** lifecycle event, so the end-of-run single-dump exporter becomes redundant once the driver is the default local persistence. Suggested path: ship the driver → make it the default local backend → deprecate `exporters/json.py`. Not done here to keep the diff additive and reversible.

## Downstream benefit (noted, not depended on)

Because the driver writes `report.json` **live** in the exact format the `local` query backend reads, the local query backend could eventually work **mid-run** instead of only after the final dump. This is relevant to a sibling extractor refactor — this PR neither depends on nor touches that work.

## Open questions for the owner

1. **Default enablement**: leave `json` opt-in via `--driver json`, or add it to `drivers.defaults` / gate it behind an `addons.json.enabled` flag like sqlite?
2. **`on_build` placeholders**: worth adding PENDING child docs for a live tree view locally, or is dir-walking discovery enough?
3. **Exporter deprecation timing**: OK to schedule `exporters/json.py` removal once this is the default, or keep both indefinitely?
4. **`fsync` cost**: each write `fsync`s for durability — fine for typical scan volumes; want it made configurable for very high-finding-rate runs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtTyzcUmPYxM5nfp7MnMVd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a live JSON reporting driver that can persist runner metadata and findings to `report.json` during execution.
  * Enabled the JSON driver in supported driver options and adjusted driver execution priority.

* **Bug Fixes**
  * Improved JSON report reliability with atomic, lock-protected read-modify-write persistence to prevent lost updates and torn writes during concurrent runs.
  * Corrupted JSON is now reported via errors rather than silently overwritten.

* **Tests**
  * Added unit tests for the JSON driver behavior, query integration, and concurrency safety for atomic JSON persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->