### PR TITLE
feat(runners): query fan-in by id+type+projection so extractors don't OOM (RC#6)

### DIFF
--- a/docs/design/fanin-query-extractors.md
+++ b/docs/design/fanin-query-extractors.md
@@ -74,14 +74,62 @@ path of **every** runner. A correct refactor needs either:
 
 Option 2 is the lazy, high-value first step: for `maigret`/`nmap` the `_type`
 filter alone cuts the fan-in by orders of magnitude and the projection removes
-the per-object heap cost, with **zero** change to condition semantics. It should
-be its own reviewable PR on top of this one.
+the per-object heap cost, with **zero** change to condition semantics.
+
+## Implemented — Option 2 (this stacked PR, on `fix/query-id-in-backends`)
+
+Driver-branched: **db (mongodb worker)** = fetch by id + `_type` + projection;
+**local** = unchanged in-memory `_results`.
+
+Key decision: the worker rehydrates the fan-in via `hooks.mongodb.get_results`
+(a direct, filter-free fetch-by-id), **not** `QueryEngine.search()`. The engine's
+enforced base query (`_tagged`, `is_false_positive: {$ne:True}`) is correct for a
+*user* query but **wrong** for rehydrating chain fan-in — during a live scan the
+just-produced findings are untagged, so `_tagged:True` would drop them all and
+change extractor targets. So `get_results` is the right primitive; PR #1's
+QueryEngine id-query support remains the client/report path foundation.
+
+Changes:
+- `hooks/mongodb.py::get_results(uuids, types=None, fields=None)` — push a
+  `_type` `$in` filter + include-projection into the Mongo query so an extractor
+  rehydrates only the subset (and fields) it needs.
+- `runners/_helpers.py::process_extractor` — when `ctx['fetch_by_type']` is set,
+  source this extractor's candidates from the fetch (id+type+projection) instead
+  of the fully-materialised set. Condition eval + formatting run unchanged on the
+  reduced set. `_extractor_fields()` computes a **bounded, over-inclusive**
+  projection (every identifier the field/group_by/condition mention, plus
+  mandatory identity/context), so it only ever omits fields the extractor never
+  references — never under-projects (semantics identical).
+- `runners/_base.py` — `_split_fanin()` keeps the fan-in **by id** (cheap) for a
+  child runner under the mongodb addon and materialises only carried
+  non-persisted objects (Target/Info); `_run_extractors` wires the `fetch_by_type`
+  closure. Root/sync/local runners keep the eager path.
+- `celery.py` — `mark_runner_started`/`mark_runner_completed` use the same split;
+  `chain_output()` re-forwards `prior_result_ids + results` so the accumulated
+  fan-in keeps flowing downstream **as ids**, never rehydrated (this is the #9
+  "don't hold the whole set" win — `forward_results` was already id-only for the
+  mongodb path, so the materialisation was solely in `get_results`).
+
+Tested (`tests/unit/test_fanin_query.py`): projection correctness; fetch used
+instead of the (poison) full set; condition still runs on the fetched subset;
+**db path == local path** targets; a **300k-id** fan-in stays < 5 MB peak
+(`tracemalloc`); `get_results` pushes the type filter + projection;
+`_split_fanin` driver-branch.
+
+Nuance (documented, acceptable): a child no longer holds prior *finding* objects
+in `self.results`, so it can't incidentally dedupe its own output against the
+fan-in via `self.uuids` — cross-finding dedup already happens at persistence /
+`tag_duplicates`, and `self_results` (own-source) is unaffected.
+
+**Follow-up (not needed yet):** Option 1 — a translator for the common
+`type.field [op] literal` conditions to push the predicate into Mongo too. Only
+worth it if a same-type fan-in (all one `_type`) with a very selective condition
+proves to still be too large post-projection.
 
 ## Rollout
 
-1. **This PR** — backend id-query support + tests (id filters provably work on
-   mongodb/api; local documented). Safe, isolated, no behaviour change to
-   existing queries.
-2. Next — Option 2 extractor refactor (type-filter + projection push-down,
-   Python condition on the reduced set) + a 300k-result memory-bound test.
-3. Later (if needed) — Option 1 condition translator for the common shapes.
+1. **PR #1** (`fix/query-id-in-backends`) — backend id-query support + tests.
+2. **This stacked PR** — Option 2 extractor push-down + memory-bound tests.
+   ⚠️ Needs a real mongodb-worker integration run (a scan with a large fan-in)
+   before merge — the unit tests cover the logic, not the live distributed chain.
+3. Later (if needed) — Option 1 condition translator.

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -140,6 +140,18 @@ def chain_results(results):
 	return out
 
 
+def chain_output(runner):
+	"""Chain-forward a runner's results plus any lazily-held fan-in ids (RC#6).
+
+	When the fan-in was kept by id (not rehydrated), ``runner.results`` holds only
+	this runner's own + carried objects; the prior fan-in ids are re-emitted here so
+	the accumulated set keeps flowing downstream unchanged, without ever
+	materializing it. ``chain_results`` dedupes and reduces objects to ids.
+	"""
+	prior = runner.prior_result_ids or []
+	return chain_results(list(prior) + runner.results)
+
+
 @retry(Exception, tries=3, delay=2)
 def update_state(celery_task, task, force=False):
 	"""Update task state to add metadata information."""
@@ -295,7 +307,7 @@ def abandon_task(name, targets, opts, results, delivery_count=None):
 	))
 	task.mark_completed()
 	if CONFIG.addons.mongodb.enabled:
-		return chain_results(task.results)
+		return chain_output(task)
 	return task.results
 
 
@@ -387,7 +399,7 @@ def run_command(self, results, name, targets, opts={}):
 	update_state(self, task, force=True)
 
 	if CONFIG.addons.mongodb.enabled:
-		return chain_results(task.results)
+		return chain_output(task)
 	return task.results
 
 
@@ -449,11 +461,10 @@ def mark_runner_started(results, runner, enable_hooks=True):
 		results = forward_results(results)
 	runner.enable_hooks = enable_hooks
 
-	# Query results from db when mongodb is enabled
+	# Load prior results from db when mongodb is enabled. For a child runner this keeps
+	# the fan-in by id (RC#6) instead of rehydrating the whole set onto the heap.
 	if IN_WORKER and CONFIG.addons.mongodb.enabled:
-		from secator.hooks.mongodb import get_results
-
-		results = get_results(results)
+		runner.prior_result_ids, results = runner._split_fanin(results)
 
 	# Add results to runner so it can compute status
 	# and extract dynamic targets
@@ -469,6 +480,8 @@ def mark_runner_started(results, runner, enable_hooks=True):
 			k: v for k, v in runner.dynamic_opts.items() if k.rstrip('_') == 'targets'
 		}
 		ctx = {'ancestor_id': runner.ancestor_id, 'node_chain_start': True}
+		if runner.prior_result_ids is not None:
+			ctx['fetch_by_type'] = runner._make_fanin_fetch(runner.prior_result_ids)
 		scoped_inputs, _, _ = run_extractors(runner.results, target_extractor_opts, runner.inputs, ctx=ctx)
 		for name in scoped_inputs:
 			t = TargetOutput(name=name)
@@ -490,7 +503,7 @@ def mark_runner_started(results, runner, enable_hooks=True):
 
 	# Return only uuids when mongodb is enabled
 	if IN_WORKER and CONFIG.addons.mongodb.enabled:
-		return chain_results(runner.results)
+		return chain_output(runner)
 
 	return runner.results
 
@@ -517,11 +530,10 @@ def mark_runner_completed(results, runner, enable_hooks=True):
 	results = forward_results(results)
 	runner.enable_hooks = enable_hooks
 
-	# Query results from db when mongodb is enabled
+	# Load prior results from db when mongodb is enabled (fan-in kept by id for a child
+	# runner, RC#6 — mark_completed only needs own-source results + db state).
 	if IN_WORKER and CONFIG.addons.mongodb.enabled:
-		from secator.hooks.mongodb import get_results
-
-		results = get_results(results)
+		runner.prior_result_ids, results = runner._split_fanin(results)
 
 	# Add results to runner so it can compute status
 	# and run duplicate checks
@@ -539,7 +551,7 @@ def mark_runner_completed(results, runner, enable_hooks=True):
 
 	# Return only uuids when mongodb is enabled
 	if IN_WORKER and CONFIG.addons.mongodb.enabled:
-		return chain_results(runner.results)
+		return chain_output(runner)
 
 	return runner.results
 

--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -49,11 +49,16 @@ def get_runner_dbg(runner):
 	}
 
 
-def get_results(uuids):
+def get_results(uuids, types=None, fields=None):
 	"""Get results from MongoDB based on a list of uuids.
 
 	Args:
 		uuids (list[str | Output]): List of uuids, but can also be a mix of uuids and output types.
+		types (list[str], optional): If set, only fetch findings whose ``_type`` is in this
+			list (pushed into the Mongo query). Lets an extractor rehydrate just the subset
+			it needs instead of the whole fan-in (RC#6 heap OOM).
+		fields (list[str], optional): If set, a Mongo include-projection so only these fields
+			(plus ``_id``) come back — bounds per-object memory for huge same-type fan-ins.
 
 	Returns:
 		Generator of findings.
@@ -63,12 +68,18 @@ def get_results(uuids):
 	del_uuids = []
 	for r in uuids:
 		if isinstance(r, tuple(OUTPUT_TYPES)):
-			yield r
+			if types is None or getattr(r, '_type', None) in types:
+				yield r
 			del_uuids.append(r)
 	uuids = [ObjectId(u) for u in uuids if u not in del_uuids and ObjectId.is_valid(u)]
-	for r in db.findings.find({'_id': {'$in': uuids}}):
+	query = {'_id': {'$in': uuids}}
+	if types is not None:
+		query['_type'] = {'$in': list(types)}
+	projection = {f: 1 for f in fields} if fields else None
+	for r in db.findings.find(query, projection):
 		finding = load_finding(r)
-		yield finding
+		if finding is not None:
+			yield finding
 
 
 def update_runner(self):

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -110,6 +110,10 @@ class Runner:
 		# Runner state
 		self.uuids = set()
 		self.results = []
+		# RC#6: when a mongodb fan-in is passed by id, we keep the raw id strings here
+		# (cheap) instead of rehydrating every finding onto the heap. None means the
+		# eager/local path (prior results materialized into self.results as before).
+		self.prior_result_ids = None
 		self.results_count = 0
 		self.threads = []
 		self.output = ''
@@ -193,11 +197,7 @@ class Runner:
 
 		# Add prior results to runner results
 		self.debug(f'adding {len(results)} prior results to runner', sub='init')
-		if CONFIG.addons.mongodb.enabled:
-			self.debug(f'loading {len(results)} results from MongoDB', sub='init')
-			from secator.hooks.mongodb import get_results
-
-			results = get_results(results)
+		self.prior_result_ids, results = self._split_fanin(results)
 		for result in results:
 			self.add_result(result, print=False, output=False, hooks=False, queue=not self.has_parent)
 
@@ -676,10 +676,54 @@ class Runner:
 			if error:
 				self.add_result(error)
 
+	def _query_fanin_enabled(self):
+		"""Whether to use the lazy query fan-in path (RC#6).
+
+		Active only for a child runner under the mongodb addon: those are the ones
+		that receive a large accumulated fan-in by id. Root/sync/local runners keep
+		the eager in-memory path unchanged.
+		"""
+		return bool(CONFIG.addons.mongodb.enabled and self.has_parent)
+
+	def _split_fanin(self, results):
+		"""Split incoming prior results for the lazy query path.
+
+		Returns ``(prior_ids, results)``:
+		- lazy path on: keep persisted-finding **id strings** as ``prior_ids`` (cheap,
+		  for re-forwarding + lazy per-extractor querying) and materialize only the
+		  carried non-id objects (Target/Info etc.).
+		- otherwise: ``(None, ...)`` with results rehydrated in full as before.
+		"""
+		if not CONFIG.addons.mongodb.enabled:
+			return None, results
+		if self._query_fanin_enabled():
+			prior_ids = [r for r in results if isinstance(r, str)]
+			objects = [r for r in results if not isinstance(r, str)]
+			self.debug(
+				f'lazy fan-in: kept {len(prior_ids)} ids, materialized {len(objects)} carried objects', sub='init')
+			return prior_ids, objects
+		from secator.hooks.mongodb import get_results
+		return None, list(get_results(results))
+
+	def _make_fanin_fetch(self, ids):
+		"""Build a ``fetch_by_type(type, fields)`` callable that rehydrates only the
+		findings of the requested type from the fan-in ids (+ carried in-memory
+		objects of that type, e.g. scope-tagged Targets)."""
+		from secator.hooks.mongodb import get_results
+		carried = self.results
+
+		def fetch(_type, fields=None):
+			out = list(get_results(ids, types=[_type], fields=fields))
+			out += [r for r in carried if getattr(r, '_type', None) == _type]
+			return out
+		return fetch
+
 	def _run_extractors(self):
 		"""Run extractors on results and targets."""
 		self.debug('running extractors', sub='init')
 		ctx = {'opts': DotMap(self.run_opts), 'targets': self.inputs, 'ancestor_id': self.ancestor_id}
+		if self.prior_result_ids is not None:
+			ctx['fetch_by_type'] = self._make_fanin_fetch(self.prior_result_ids)
 		inputs, run_opts, errors = run_extractors(self.results, self.run_opts, self.inputs, ctx=ctx, dry_run=self.dry_run)
 		for error in errors:
 			self.add_result(error)

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -187,6 +187,40 @@ def extract_from_results(results, extractors, ctx=None):
 	return all_results, errors
 
 
+# Tokens that appear in extractor conditions but are never finding fields, so
+# they must not pollute the DB projection.
+_FIELD_STOPWORDS = {
+	'and', 'or', 'not', 'in', 'is', 'if', 'else', 'None', 'True', 'False',
+	'len', 're_match', 'item',
+}
+
+
+def _extractor_fields(parsed_extractor):
+	"""Bounded Mongo include-projection for an extractor.
+
+	Collects every identifier its field / group_by templates and condition could
+	reference, plus mandatory identity/context fields. Deliberately over-inclusive
+	(unknown projected fields are ignored by Mongo, and any real referenced field
+	is kept so condition/format semantics are identical) — it only ever *omits*
+	fields the extractor never mentions, which is what bounds per-object memory for
+	huge same-type fan-ins. Returns None (→ no projection, full objects) if the
+	extractor can't be parsed.
+	"""
+	if not parsed_extractor:
+		return None
+	_type, _field, _condition, _group_by = parsed_extractor
+	fields = {'_type', '_context', '_source', '_uuid', 'name'}
+	for tmpl in (_field, _group_by, _condition):
+		if not tmpl:
+			continue
+		# Strip string literals so quoted values aren't treated as field names.
+		text = re.sub(r"'[^']*'|\"[^\"]*\"", ' ', str(tmpl))
+		for tok in re.findall(r'[A-Za-z_]\w*', text):
+			if tok not in _FIELD_STOPWORDS:
+				fields.add(tok)
+	return sorted(fields)
+
+
 def parse_extractor(extractor):
 	"""Parse extractor.
 
@@ -237,6 +271,15 @@ def process_extractor(results, extractor, ctx=None):
 	if not parsed_extractor:
 		return results
 	_type, _field, _condition, _group_by = parsed_extractor
+
+	# RC#6: when a fan-in fetch is provided (mongodb id fan-in), source this
+	# extractor's candidates from the DB (id + _type filter + field projection)
+	# instead of the fully-materialized fan-in — the whole set is never
+	# rehydrated onto the worker heap. The condition eval + formatting below are
+	# unchanged; they just run on the (much smaller, projected) queried subset.
+	fetch = ctx.get('fetch_by_type')
+	if fetch is not None:
+		results = fetch(_type, _extractor_fields(parsed_extractor))
 
 	# Evaluate condition for each result
 	if _condition:

--- a/tests/unit/test_fanin_query.py
+++ b/tests/unit/test_fanin_query.py
@@ -1,0 +1,228 @@
+# tests/unit/test_fanin_query.py
+"""RC#6 fan-in: extractors compute targets by querying the DB (id + _type filter
++ projection) instead of materializing/rehydrating the whole accumulated result
+set onto the worker heap. Local (no mongodb addon) keeps the in-memory path."""
+
+import tracemalloc
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+from secator.output_types import Url, Ip, Target
+from secator.runners._helpers import (
+	_extractor_fields,
+	parse_extractor,
+	process_extractor,
+	run_extractors,
+)
+
+
+class _Poison(list):
+	"""A stand-in for the full fan-in that raises if anything iterates it — proves
+	the query path never materializes the whole set."""
+
+	def __iter__(self):
+		raise AssertionError('the full fan-in was iterated/materialized')
+
+
+class TestExtractorProjection(unittest.TestCase):
+	def test_includes_referenced_and_mandatory_fields(self):
+		parsed = parse_extractor({'type': 'url', 'field': 'url', 'condition': "not url.verified"})
+		fields = _extractor_fields(parsed)
+		# referenced fields present
+		self.assertIn('url', fields)
+		self.assertIn('verified', fields)
+		# mandatory identity/context always present
+		for f in ('_type', '_context', '_source', '_uuid', 'name'):
+			self.assertIn(f, fields)
+		# a field the extractor never mentions is omitted (this is what bounds memory)
+		self.assertNotIn('stored_response_path', fields)
+		# operator/keyword tokens are not treated as fields
+		self.assertNotIn('not', fields)
+
+	def test_string_literals_not_treated_as_fields(self):
+		parsed = parse_extractor({'type': 'ip', 'field': 'host', 'condition': "item.alive == 'stored_response_path'"})
+		fields = _extractor_fields(parsed)
+		self.assertIn('alive', fields)
+		# the quoted value must not leak in as a projected field
+		self.assertNotIn('stored_response_path', fields)
+
+
+class TestProcessExtractorFetch(unittest.TestCase):
+	def setUp(self):
+		self.ips = [Ip(ip='10.0.0.1', host='h1'), Ip(ip='10.0.0.2', host='h2')]
+		self.urls = [Url(url='http://a'), Url(url='http://b')]
+		self.all = self.ips + self.urls
+
+	def _fetch(self, calls=None):
+		def fetch(_type, fields=None):
+			if calls is not None:
+				calls.append((_type, fields))
+			return [r for r in self.all if r._type == _type]
+		return fetch
+
+	def test_fetch_used_instead_of_full_set(self):
+		calls = []
+		ctx = {'fetch_by_type': self._fetch(calls)}
+		# The full set is poison — must never be touched when a fetch is provided.
+		out = process_extractor(_Poison(self.all), 'ip.host', ctx=ctx)
+		self.assertEqual(sorted(out), ['h1', 'h2'])
+		self.assertEqual(calls[0][0], 'ip')  # queried only the extractor's type
+		# projection was requested (no condition -> still a bounded field list)
+		self.assertIsNotNone(calls[0][1])
+
+	def test_condition_still_runs_on_fetched_subset(self):
+		ctx = {'fetch_by_type': self._fetch()}
+		out = process_extractor(_Poison(self.all), {'type': 'ip', 'field': 'host', 'condition': "item.ip == '10.0.0.2'"}, ctx=ctx)  # noqa: E501
+		self.assertEqual(out, ['h2'])
+
+	def test_run_extractors_query_matches_in_memory(self):
+		"""Coordinator #1 vs #2: the query (db) path yields the SAME targets as the
+		in-memory (local) path for identical inputs + extractor."""
+		opts = {'targets_': ['ip.host']}
+		# local / in-memory path (no fetch)
+		local_inputs, _, _ = run_extractors(list(self.all), dict(opts), [])
+		# db / query path (fetch sources candidates; full set is poison)
+		ctx = {'fetch_by_type': self._fetch()}
+		db_inputs, _, _ = run_extractors(_Poison(self.all), dict(opts), [], ctx=ctx)
+		self.assertEqual(sorted(local_inputs), sorted(db_inputs))
+		self.assertEqual(sorted(db_inputs), ['h1', 'h2'])
+
+
+class TestFanInMemoryBound(unittest.TestCase):
+	def test_300k_fanin_does_not_materialize(self):
+		"""Coordinator #3: a 300k-id fan-in stays within a tiny heap bound because
+		only the (few) findings of the extractor's type are ever fetched/built."""
+		# 300k cheap id strings — allocated BEFORE measuring so we bound only the
+		# extractor work, not the id list itself.
+		ids = ['%024x' % i for i in range(300_000)]
+		fetched = [Ip(ip='10.0.0.1', host='only-host')]
+
+		fetch_calls = {'n': 0}
+
+		def fetch(_type, fields=None):
+			fetch_calls['n'] += 1
+			# The fetch is handed the extractor's type only; it returns a tiny subset,
+			# never one object per id.
+			return list(fetched) if _type == 'ip' else []
+
+		ctx = {'fetch_by_type': fetch}
+		tracemalloc.start()
+		try:
+			inputs, _, _ = run_extractors(_Poison(ids), {'targets_': ['ip.host']}, [], ctx=ctx)
+			_, peak = tracemalloc.get_traced_memory()
+		finally:
+			tracemalloc.stop()
+
+		self.assertEqual(inputs, ['only-host'])
+		self.assertEqual(fetch_calls['n'], 1)
+		# Materializing 300k Ip objects would be tens/hundreds of MB. The query path
+		# builds one — bound generously at 5MB to stay platform-robust.
+		self.assertLess(peak, 5 * 1024 * 1024, f'peak {peak} bytes — fan-in likely materialized')
+
+
+class TestSplitFanin(unittest.TestCase):
+	"""Runner._split_fanin: driver-branch. mongodb off -> eager/local (unchanged);
+	mongodb on + child -> keep ids cheap, materialize only carried objects."""
+
+	def setUp(self):
+		# Reference the LIVE module the code reads (robust to test_config's
+		# clear_modules(), which otherwise leaves a module-top CONFIG stale).
+		import secator.runners._base as base_mod
+
+		self.base_mod = base_mod
+		Runner = base_mod.Runner
+
+		class _FakeRunner:
+			has_parent = True
+
+			def debug(self, *a, **k):
+				pass
+
+			_query_fanin_enabled = Runner._query_fanin_enabled
+			_split_fanin = Runner._split_fanin
+
+		self.FakeRunner = _FakeRunner
+		self._orig = base_mod.CONFIG.addons.mongodb.enabled
+
+	def tearDown(self):
+		self.base_mod.CONFIG.addons.mongodb.enabled = self._orig
+
+	def _set_mongodb(self, value):
+		self.base_mod.CONFIG.addons.mongodb.enabled = value
+
+	def test_local_path_unchanged_when_mongodb_off(self):
+		self._set_mongodb(False)
+		r = self.FakeRunner()
+		results = [Url(url='http://a'), Target(name='t')]
+		prior_ids, out = r._split_fanin(results)
+		self.assertIsNone(prior_ids)
+		self.assertEqual(out, results)
+
+	def test_lazy_path_keeps_ids_and_carried_objects(self):
+		self._set_mongodb(True)
+		r = self.FakeRunner()  # has_parent True -> lazy
+		target = Target(name='sub.example.com')
+		results = ['%024x' % 1, '%024x' % 2, target]  # 2 finding ids + 1 carried object
+		prior_ids, out = r._split_fanin(results)
+		self.assertEqual(prior_ids, ['%024x' % 1, '%024x' % 2])
+		self.assertEqual(out, [target])  # only the carried object is materialized
+
+	def test_root_runner_stays_eager(self):
+		self._set_mongodb(True)
+		r = self.FakeRunner()
+		r.has_parent = False  # root -> eager path (calls get_results)
+		with patch('secator.hooks.mongodb.get_results', side_effect=lambda x: list(x)) as gr:
+			prior_ids, out = r._split_fanin(['x'])
+			self.assertIsNone(prior_ids)
+			gr.assert_called_once()
+
+
+class TestGetResultsFilter(unittest.TestCase):
+	"""get_results(uuids, types, fields) pushes the _type filter + projection into
+	the Mongo query so an extractor rehydrates only the subset it needs."""
+
+	def setUp(self):
+		pytest.importorskip('pymongo')
+
+	def test_type_and_projection_pushed_to_query(self):
+		from unittest.mock import MagicMock
+		import secator.hooks.mongodb as m
+
+		captured = {}
+
+		def _find(query, projection=None):
+			captured['query'] = query
+			captured['projection'] = projection
+			return [{'_id': m.ObjectId(), '_type': 'ip', 'ip': '10.0.0.1', 'host': 'h1', '_context': {}}]
+
+		client = MagicMock()
+		client.main.findings.find.side_effect = _find
+
+		ids = ['%024x' % 1, '%024x' % 2]
+		with patch.object(m, 'get_mongodb_client', return_value=client):
+			out = list(m.get_results(ids, types=['ip'], fields=['host', '_type', '_context']))
+
+		self.assertEqual(captured['query']['_type'], {'$in': ['ip']})
+		self.assertIn('_id', captured['query'])
+		self.assertEqual(captured['projection'], {'host': 1, '_type': 1, '_context': 1})
+		self.assertEqual(len(out), 1)
+		self.assertEqual(out[0]._type, 'ip')
+
+	def test_carried_objects_filtered_by_type(self):
+		from unittest.mock import MagicMock
+		import secator.hooks.mongodb as m
+
+		client = MagicMock()
+		client.main.findings.find.side_effect = lambda q, p=None: []
+		# Build carried objects from the SAME OUTPUT_TYPES generation get_results
+		# uses, so isinstance() holds even after test_config's clear_modules().
+		UrlCls = next(c for c in m.OUTPUT_TYPES if c.get_name() == 'url')
+		TargetCls = next(c for c in m.OUTPUT_TYPES if c.get_name() == 'target')
+		carried_url = UrlCls(url='http://a')
+		carried_target = TargetCls(name='t')
+		with patch.object(m, 'get_mongodb_client', return_value=client):
+			# only 'target'-typed carried objects should pass through
+			out = list(m.get_results([carried_url, carried_target], types=['target']))
+		self.assertEqual([o._type for o in out], ['target'])


### PR DESCRIPTION
## ⚠️ Stacked on #1297

Base is `fix/query-id-in-backends` (**#1297**), not `main` — review/merge that first. This PR's own diff is just the extractor push-down.

## Why

RC#6 (fan-in Python-heap OOM): a child runner received the **full accumulated fan-in** and rehydrated **every** finding onto the worker heap (`get_results` in `_base.__init__` / `mark_runner_*`) *before* computing its targets. Huge sets OOM the worker during setup — confirmed live zombies: 52k `maigret`, 303k `nmap`.

This pushes extractor target-computation down to a **targeted DB fetch** so the whole set is never materialized.

## Design (driver-branched, per product-owner steer)

| driver | fan-in handling |
|---|---|
| **db (mongodb worker)** | keep the fan-in **by id** (cheap); per extractor, fetch only that `_type`'s findings with a bounded field **projection** via `get_results(ids, types, fields)`. The Python `condition` + formatting run **unchanged** on the reduced subset. |
| **local (json)** | **unchanged** in-memory `_results` path — report JSON is written only at end-of-run, so it can't be queried live. |

**Why `get_results`, not `QueryEngine.search()`:** the engine's enforced base query (`_tagged`, `is_false_positive:{$ne:True}`) is correct for a *user* query but **wrong** for rehydrating chain fan-in — during a live scan the just-produced findings are untagged, so `_tagged:True` would drop them all and change extractor targets. `get_results` is the filter-free fetch-by-id primitive. #1297's QueryEngine id-query support remains the **client/report-path** foundation.

**#9 folded in:** the fan-in flows downstream as ids (`chain_output` re-emits `prior_result_ids`); `forward_results` was already id-only for the mongodb path, so the sole materialization was `get_results` — now gone.

## Changes
- `hooks/mongodb.py`: `get_results(uuids, types=None, fields=None)` — push `_type` `$in` + include-projection into the Mongo query.
- `runners/_helpers.py`: `process_extractor` fetch-by-type branch; `_extractor_fields()` — a **bounded, over-inclusive** projection (every identifier the field/group_by/condition mention + mandatory identity/context) so it only ever omits fields the extractor never references (never under-projects → semantics identical).
- `runners/_base.py`: `_split_fanin` / `_make_fanin_fetch` / `_query_fanin_enabled`; `_run_extractors` wires the fetch. `prior_result_ids` is not in `toDict()` (no Mongo doc bloat) and only lives within one task invocation.
- `celery.py`: `chain_output()`; `mark_runner_started`/`completed` use the split.
- `docs/design/fanin-query-extractors.md`: updated to record the implementation + decisions.

## Tests — `tests/unit/test_fanin_query.py`
1. **local == db** targets for the same input/extractor (`test_run_extractors_query_matches_in_memory`).
2. db path derives targets via id+filter+projection **without** touching the full set — a `_Poison` full-set raises if iterated (`test_fetch_used_instead_of_full_set`, `test_condition_still_runs_on_fetched_subset`).
3. **300k-id fan-in** stays **< 5 MB** peak via `tracemalloc`, fetch called once, returns 1 object (`test_300k_fanin_does_not_materialize`).
4. `get_results` pushes the type filter + projection; `_split_fanin` driver-branch; projection correctness.

Full unit suite: **640 passed, 347 skipped**; lint clean. (Tests are written to survive `test_config`'s `clear_modules()` module-reload pollution.)

## Nuance (documented, acceptable)
A child no longer holds prior *finding* objects in `self.results`, so it can't incidentally dedupe its own output against the fan-in via `self.uuids` — cross-finding dedup already happens at persistence / `tag_duplicates`, and `self_results` (own-source) is unaffected.

## Before merge
Unit tests cover the logic, not the live distributed chain. Needs one **mongodb-worker integration run** (a scan with a large fan-in) to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtTyzcUmPYxM5nfp7MnMVd