### PR TITLE
fix(target validation): ignore all invalid targets, not just one

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -1369,7 +1369,8 @@ class Runner:
 	def _validate_inputs(self, inputs):
 		"""Input type is not supported by runner"""
 		# supported_types = ', '.join(self.config.input_types) if self.config.input_types else 'any'
-		for _input in inputs:
+		# iterate over a copy: we mutate self.inputs (same list) via .remove() below
+		for _input in list(inputs):
 			input_type = autodetect_type(_input)
 			if self.config.input_types and input_type not in self.config.input_types:
 				runner_name = format_runner_name(self)

--- a/tests/unit/test_target_validation.py
+++ b/tests/unit/test_target_validation.py
@@ -1,0 +1,38 @@
+"""Tests for issue #1287: when multiple invalid targets are passed, ALL must be ignored.
+
+Root cause was a mutate-while-iterate bug in Runner._validate_inputs: it iterated over
+`self.inputs` while calling `self.inputs.remove(...)`, so removing an element shifted the
+iterator and skipped the following (also-invalid) target.
+"""
+import unittest
+
+from secator.decorators import task
+from secator.definitions import URL
+from secator.output_types import Info
+from secator.runners import PythonRunner
+
+
+@task()
+class UrlOnlyTask(PythonRunner):
+    """Only accepts URL inputs; host:port targets must be rejected."""
+    input_types = [URL]
+    output_types = [Info]
+
+    def yielder(self):
+        for inp in self.inputs:
+            yield Info(message=f"Processing {inp}")
+
+
+class TestMultipleInvalidTargets(unittest.TestCase):
+
+    def test_two_invalid_targets_both_ignored(self):
+        """Both host:port targets are invalid for a URL-only task and must both be dropped."""
+        runner = UrlOnlyTask(inputs=['localhost:8085', 'localhost:1090'])
+        self.assertEqual(
+            runner.inputs, [],
+            f"Both invalid targets should be ignored, got leftover: {runner.inputs}"
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

Fixes #1287. When two (or more) invalid targets are passed, only one is filtered out — the other leaks through to execution. Reproduced by the reporter with:

```
secator x ffuf localhost:8085,localhost:1090
```

`localhost:1090` is correctly skipped (`host:port` not supported by ffuf), but `localhost:8085` — equally invalid — is not, and ffuf runs against it.

## Root cause

`Runner._validate_inputs` (`secator/runners/_base.py`) iterates over `inputs` while removing matching elements from `self.inputs` — and `inputs` **is** `self.inputs` (passed straight through from `run_validators('validate_input', self.inputs, ...)`). Removing an element during iteration shifts the list under the iterator, so the element right after each removed one is skipped. With two consecutive invalid targets, only the first is checked/removed and the second slips through.

This is why the reporter couldn't reproduce it with `httpx abcd,abdc` — the outcome depends on the ordering/adjacency of the invalid entries in the deduplicated input list.

## Fix

Iterate over a copy (`for _input in list(inputs)`) so every target is evaluated regardless of removals. One-line, root-cause fix in the single shared validator all runners route through.

## Test

Added `tests/unit/test_target_validation.py`: a URL-only task given two `host:port` targets must drop **both**. Fails before the fix (one leftover), passes after. Existing runner/target-filtering suites remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved target validation so multiple invalid inputs are correctly ignored.
  * Prevented valid inputs from being skipped during validation when invalid entries are removed.

* **Tests**
  * Added coverage for scenarios involving multiple invalid target inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->