### PR TITLE
fix(query): allow empty query in secator q

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1126,8 +1126,11 @@ def list_aliases(silent):
 @click.pass_context
 def query(ctx, arg, output, output_folder, time_delta, fmt, workspace, report_filter, driver, dedupe, limit):
 	"""Query"""
+	# Empty query: return all results (subject to the enforced base query),
+	# optionally scoped by --report-filter / --workspace.
 	if not arg:
-		raise click.UsageError('Missing argument ARG (a query name, expression, or prompt).')
+		run_report_show(report_filter, output, time_delta, None, fmt, workspace, driver, dedupe, limit, output_folder)
+		return
 
 	# 1. Saved query name
 	if arg in CONFIG.queries:

--- a/tests/unit/test_query_cli.py
+++ b/tests/unit/test_query_cli.py
@@ -126,3 +126,12 @@ class TestQueryDispatch(unittest.TestCase):
 		self.assertEqual(result.exit_code, 0)
 		vulns = captured.get('results', {}).get('vulnerability', [])
 		self.assertEqual(sorted(v['name'] for v in vulns), ['XSS'])
+
+	def test_empty_query_returns_all(self):
+		# `secator q -rf tasks/1` (no query expression) must return all findings
+		# scoped by the report filter, not raise "Missing argument ARG".
+		result, captured = self._invoke(['query', '-rf', 'tasks/1', '-ws', WS, '--driver', 'local'])
+		self.assertIsNone(result.exception, str(result.exception))
+		self.assertEqual(result.exit_code, 0)
+		vulns = captured.get('results', {}).get('vulnerability', [])
+		self.assertEqual(sorted(v['name'] for v in vulns), ['SQLi', 'XSS'])


### PR DESCRIPTION
## Problem

`secator q -rf scans/2` (or any `secator q` invocation with no query expression) failed with:

```
Missing argument ARG (a query name, expression, or prompt).
```

instead of returning all findings scoped by the report filter. Fixes #1210.

## Root cause

The `query` command guarded against an empty `arg` and raised a `click.UsageError`. But the downstream `run_report_show` already handles an empty query (`mongo_query = {}`), applying only the enforced base query.

## Fix

Route the empty-`arg` case to `run_report_show` with `query=None` instead of raising, so an empty query returns all results (subject to the enforced base query), optionally scoped by `--report-filter` / `--workspace`.

## Test

Added `test_empty_query_returns_all` in `tests/unit/test_query_cli.py` asserting `secator q -rf tasks/1` returns all findings. All 137 query unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `secator query` command now accepts an empty query and displays all matching results.
  * Results can still be narrowed using report filters and workspace selection.
  * Empty queries no longer produce a usage error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->