### PR TITLE
feat(query): add --save option to secator q

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1123,11 +1123,22 @@ def list_aliases(silent):
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api', 'sqlite']), default=None, help='Query backend driver')  # noqa: E501
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.option('-l', '--limit', type=int, default=0, help='Limit number of results (0 = no limit)')
+@click.option('--save', 'save', type=str, default=None, help='Save the query expression ARG under this name for later reuse (e.g. --save vuln_high)')  # noqa: E501
 @click.pass_context
-def query(ctx, arg, output, output_folder, time_delta, fmt, workspace, report_filter, driver, dedupe, limit):
+def query(ctx, arg, output, output_folder, time_delta, fmt, workspace, report_filter, driver, dedupe, limit, save):
 	"""Query"""
 	if not arg:
 		raise click.UsageError('Missing argument ARG (a query name, expression, or prompt).')
+
+	# 0. Save the expression under a name, then exit (reuse later with `secator q <name>`).
+	if save:
+		CONFIG.set(f'queries.{save}', arg)
+		if CONFIG.validate():
+			CONFIG.save()
+			console.print(f'[bold green]:tada: Saved query "{save}". Run it with[/] [bold]secator q {save}[/].')
+		else:
+			console.print(Error(message='Invalid config, not saving it.'))
+		return
 
 	# 1. Saved query name
 	if arg in CONFIG.queries:

--- a/tests/unit/test_query_cli.py
+++ b/tests/unit/test_query_cli.py
@@ -126,3 +126,27 @@ class TestQueryDispatch(unittest.TestCase):
 		self.assertEqual(result.exit_code, 0)
 		vulns = captured.get('results', {}).get('vulnerability', [])
 		self.assertEqual(sorted(v['name'] for v in vulns), ['XSS'])
+
+	def test_save_query_round_trips(self):
+		# `secator q "<expr>" --save <name>` persists the expression under <name>,
+		# and it becomes loadable/runnable as a named query.
+		from secator.cli import cli
+		from secator.config import CONFIG, Config
+		expr = "vulnerability.severity == 'critical'"
+		name = 'saved_crit'
+		CONFIG.queries.pop(name, None)
+		try:
+			# Patch Config.save (class level) so persistence doesn't clobber the real config file.
+			with mock.patch.object(Config, 'save', return_value=True) as mock_save:
+				result = self.cli_runner.invoke(cli, ['query', expr, '--save', name])
+			self.assertIsNone(result.exception, str(result.exception))
+			self.assertEqual(result.exit_code, 0)
+			mock_save.assert_called_once()
+			# Persisted under the name and resolvable by the named-query lookup path.
+			self.assertEqual(CONFIG.queries.get(name), expr)
+			result, captured = self._invoke(['query', name, '-ws', WS, '--driver', 'local'])
+			self.assertIsNone(result.exception, str(result.exception))
+			vulns = captured.get('results', {}).get('vulnerability', [])
+			self.assertEqual(sorted(v['name'] for v in vulns), ['SQLi'])
+		finally:
+			CONFIG.queries.pop(name, None)


### PR DESCRIPTION
Closes #1250.

Adds a `--save <NAME>` option to `secator q` that persists the query expression under a name so it can be reused later.

```
secator q "vulnerability.confidence == 'high' && vulnerability.severity == 'high'" --save vuln_high_and_above  # save
secator q vuln_high_and_above  # run the saved query on the workspace
```

### How
- New `--save` option on the `query`/`q` command. When set, the expression `ARG` is stored under `NAME` and the command exits (does not run the query).
- Storage reuses the **existing** `CONFIG.queries` (`Dict[str, str]`) config field — the same store the named-query lookup path already reads (`if arg in CONFIG.queries`) to run a saved query by name. Persisted via the standard `CONFIG.set()` / `validate()` / `save()` path (same as `secator config set`), so no new storage machinery is introduced.

### Assumption
The issue's second line (`secator q vuln_high_and_above`) — running a saved query by name — was already implemented and tested (`test_named_query`). This PR only adds the `--save` half plus a round-trip test.

### Test
`tests/unit/test_query_cli.py::test_save_query_round_trips` — saves an expression via the CLI, asserts it lands in `CONFIG.queries`, then runs it by name and checks the result set. All 6 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--save` option to the `query` command for storing expressions as named saved queries.
  * Saved queries are validated before being stored and can be reused in subsequent commands.

* **Bug Fixes**
  * Improved confidence that saved queries execute correctly and return expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->