### PR TITLE
feat(security): run raw-socket tools via caps not sudo (drop GTFObins nmap root)

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -41,10 +41,18 @@ RUN apk add --no-cache \
 
 RUN adduser -D secator
 
-# Allow runing 'nmap' with sudo; for priviledged scans
-RUN echo "secator ALL=(ALL) NOPASSWD: /usr/bin/nmap *" >> /etc/sudoers && \
-    echo "secator ALL=(ALL) NOPASSWD: /usr/bin/arp-scan *" >> /etc/sudoers && \
-    echo "secator ALL=(ALL) NOPASSWD: /sbin/arp *" >> /etc/sudoers
+# Raw-socket tools (nmap/arp-scan/arp) need CAP_NET_RAW/CAP_NET_ADMIN.
+# full flavor: no baked-in sudoers grant here -- tools are installed below, then
+# switched to file capabilities (see the setcap block after tool install). A
+# `NOPASSWD: /usr/bin/nmap *` sudoers entry is a GTFObins root shell (a shell
+# injection in a worker can `sudo nmap --script=/tmp/x.nse ...` -> root).
+# lite flavor: tools are installed at runtime, so there are no baked binaries to
+# setcap yet -- keep the old sudo grants here. Prefer the full image in prod.
+RUN if [ "$flavor" = "lite" ]; then \
+	echo "secator ALL=(ALL) NOPASSWD: /usr/bin/nmap *" >> /etc/sudoers && \
+	echo "secator ALL=(ALL) NOPASSWD: /usr/bin/arp-scan *" >> /etc/sudoers && \
+	echo "secator ALL=(ALL) NOPASSWD: /sbin/arp *" >> /etc/sudoers; \
+	fi
 
 # Allow user to install commands
 RUN echo "secator ALL=(ALL) NOPASSWD: /sbin/apk add *" >> /etc/sudoers && \
@@ -74,6 +82,19 @@ RUN if [ "$flavor" != "lite" ]; then \
 	sed -i '/secator ALL=(ALL) NOPASSWD: \/usr\/bin\/flock \/tmp\/install.lock apk add \*/d' /etc/sudoers && \
 	sed -i '/secator ALL=(ALL) NOPASSWD: \/usr\/bin\/flock \/tmp\/install.lock ln -sf \/usr\/lib\/libpcap.so/d' /etc/sudoers; \
 	fi
+
+# full flavor: grant CAP_NET_RAW/CAP_NET_ADMIN directly on the raw-socket tool
+# binaries instead of sudo (no baked sudoers entry to abuse via GTFObins).
+RUN if [ "$flavor" != "lite" ]; then \
+	apk add --no-cache libcap && \
+	setcap cap_net_raw,cap_net_admin+eip /usr/bin/nmap && \
+	setcap cap_net_raw,cap_net_admin+eip /usr/bin/arp-scan && \
+	setcap cap_net_raw,cap_net_admin+eip /sbin/arp && \
+	setcap cap_net_raw,cap_net_admin+eip /home/secator/.local/bin/naabu; \
+	fi
 USER secator
+
+# full flavor: switch secator to caps mode so requires_sudo commands run unprivileged.
+RUN if [ "$flavor" != "lite" ]; then secator config set security.privileged_mode caps; fi
 
 ENTRYPOINT ["secator"]

--- a/secator/config.py
+++ b/secator/config.py
@@ -119,6 +119,7 @@ class Security(StrictModel):
 	auto_install_commands: bool = True
 	force_source_install: bool = False
 	prompt_sudo_password: bool = True
+	privileged_mode: str = 'sudo'  # 'sudo' (prepend sudo) or 'caps' (rely on file capabilities)
 
 
 class HTTP(StrictModel):

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -250,8 +250,8 @@ class Command(Runner):
 		# Run on_cmd hook
 		self.run_hooks('on_cmd', sub='init')
 
-		# Add sudo to command if it is required
-		if self.requires_sudo:
+		# Add sudo to command if it is required (skip when relying on file capabilities instead)
+		if self.requires_sudo and CONFIG.security.privileged_mode != 'caps':
 			self.cmd = f'sudo {self.cmd}'
 			if self._has_sensitive_cmd_opts:
 				self.cmd_redacted = f'sudo {self.cmd_redacted}'

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -360,3 +360,41 @@ class TestCommandConfigOverrides(unittest.TestCase):
 				self.assertEqual(cmd_b.input_chunk_size, 100)
 		finally:
 			CONFIG.tasks.overrides = original_overrides
+
+
+class TestCommandPrivilegedMode(unittest.TestCase):
+	"""Gate test for security.privileged_mode: 'caps' must not prepend sudo, 'sudo' (default) must."""
+
+	def test_sudo_mode_prepends_sudo(self):
+		from secator.config import CONFIG
+
+		class SudoTestCmd(Command):
+			cmd = 'test'
+			requires_sudo = True
+			file_flag = None
+
+		original_mode = CONFIG.security.privileged_mode
+		CONFIG.security.privileged_mode = 'sudo'
+		try:
+			with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=SudoTestCmd):
+				cmd = SudoTestCmd(['target1'])
+				self.assertTrue(cmd.cmd.startswith('sudo '))
+		finally:
+			CONFIG.security.privileged_mode = original_mode
+
+	def test_caps_mode_does_not_prepend_sudo(self):
+		from secator.config import CONFIG
+
+		class CapsTestCmd(Command):
+			cmd = 'test'
+			requires_sudo = True
+			file_flag = None
+
+		original_mode = CONFIG.security.privileged_mode
+		CONFIG.security.privileged_mode = 'caps'
+		try:
+			with unittest.mock.patch('secator.runners.task.Task.get_task_class', return_value=CapsTestCmd):
+				cmd = CapsTestCmd(['target1'])
+				self.assertFalse(cmd.cmd.startswith('sudo '))
+		finally:
+			CONFIG.security.privileged_mode = original_mode


### PR DESCRIPTION
## Problem

The prod worker Docker image (`.docker/Dockerfile.alpine`) grants the `secator`
user `NOPASSWD: /usr/bin/nmap *` (+ `arp-scan`, `arp`) in `/etc/sudoers`. That's
a classic [GTFObins](https://gtfobins.github.io/gtfobins/nmap/) root shell —
`sudo nmap --script=/tmp/x.nse <target>` executes arbitrary NSE Lua as root —
so any shell-injection vulnerability reached inside a worker process escalates
straight to root.

## Fix

Run the raw-socket tools (nmap, arp-scan, arp, naabu) via **Linux file
capabilities** (`CAP_NET_RAW`/`CAP_NET_ADMIN`) instead of `sudo`, gated by a new
config flag so local/dev installs keep the simpler sudo path:

- `secator/config.py`: `Security.privileged_mode: str = 'sudo'` — `'sudo'`
  (default, prepends `sudo`) or `'caps'` (rely on setcap'd binaries). Overridable
  via `SECATOR_SECURITY_PRIVILEGED_MODE`.
- `secator/runners/command.py`: the `requires_sudo` sudo-prepend (`self.cmd`/
  `self.cmd_redacted`) is now gated by `CONFIG.security.privileged_mode != 'caps'`.
- `.docker/Dockerfile.alpine` (flavor-aware):
  - **full** image (prod): no `NOPASSWD` sudoers grant for nmap/arp-scan/arp.
    After tools are baked in, `setcap cap_net_raw,cap_net_admin+eip` is applied
    to the installed binaries (`/usr/bin/nmap`, `/usr/bin/arp-scan`, `/sbin/arp`,
    `/home/secator/.local/bin/naabu`), and `security.privileged_mode` is set to
    `caps` for the `secator` user.
  - **lite** image: unchanged — tools install at runtime so there's nothing baked
    to `setcap`, so it keeps the old `NOPASSWD` sudoers grants and default
    sudo mode. This is a known deploy-time residual; prod should prefer the
    full image.

## Test plan

- [x] Added `tests/unit/test_command.py::TestCommandPrivilegedMode` — with
      `privileged_mode = 'caps'` a `requires_sudo` command's `self.cmd` does NOT
      get `sudo ` prepended; with `'sudo'` (default) it does. `2 passed`.
- [x] `flake8` clean on the changed Python files.
- [ ] Dockerfile change is CI-validated only (tool install needs network access
      not available in this environment) — full build happens on this PR's CI.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P5vSjfkBuGAAHdKxHS3ySm