### PR TITLE
fix(external tasks): pickle error in sync mode with split chunks

### DIFF
--- a/secator/loader.py
+++ b/secator/loader.py
@@ -126,6 +126,23 @@ def discover_external_tasks():
 			task_name = path.stem
 			module_name = f'secator.tasks.{task_name}'
 
+			# Idempotent import: reuse an already-registered module instead of re-executing
+			# the file. Re-exec mints a SECOND class object and overwrites sys.modules, so a
+			# task instance built from the first object can no longer be pickled ("not the same
+			# object as ...") — the #1286 sync-mode chunk crash (task_store_eager_result pickles
+			# the eager chord result in-process). This runs twice when an external task imports a
+			# secator.tasks.* submodule: that triggers secator/tasks/__init__.py -> discover_tasks()
+			# re-entrantly while this @cache'd discovery is still executing (functools.cache is not
+			# re-entrancy safe). If the module is mid-initialisation the class isn't defined yet, so
+			# skip it here — the in-progress exec that registered it appends it when it completes.
+			existing = sys.modules.get(module_name)
+			if existing is not None:
+				cls = getattr(existing, task_name, None)
+				if inspect.isclass(cls):
+					cls.__external__ = True
+					output.append(cls)
+				continue
+
 			# console.print(f'Importing module {module_name} from {path}')
 			spec = importlib.util.spec_from_file_location(module_name, path)
 			if not spec:

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -452,5 +452,52 @@ class TestDiscoverExternalTasksSkipsDriversAndExporters(unittest.TestCase):
         self.assertNotIn('secator.tasks.skiptest_nonclass', sys.modules)
 
 
+class TestDiscoverExternalTasksIdempotent(unittest.TestCase):
+    """An external task class must stay pickle-stable across repeated discovery (regression for #1286).
+
+    When discovery runs more than once in a process — e.g. an external task imports a
+    ``secator.tasks.*`` submodule, which re-enters ``discover_tasks()`` while the ``@cache``'d
+    ``discover_external_tasks()`` is still executing (``functools.cache`` is not re-entrancy safe)
+    — re-executing the file used to mint a SECOND class object and overwrite ``sys.modules``. A
+    task instance built from the first object could then no longer be pickled ("not the same
+    object as ..."), which crashed ``--sync`` chunked runs where the eager chord result is
+    pickled in-process (``task_store_eager_result``).
+    """
+
+    def setUp(self):
+        self.template_dir = CONFIG.dirs.templates
+        self.template_dir.mkdir(parents=True, exist_ok=True)
+        self.task_path = self.template_dir / 'idemtest_task.py'
+        self.task_path.write_text('class idemtest_task:\n    __external__ = False\n')
+        clear_modules()
+        _clear_loader_caches()
+
+    def tearDown(self):
+        if self.task_path.exists():
+            self.task_path.unlink()
+        for key in list(sys.modules.keys()):
+            if 'idemtest_task' in key:
+                del sys.modules[key]
+        _clear_loader_caches()
+
+    def _discover_one(self):
+        from secator.loader import discover_external_tasks
+        return next(c for c in discover_external_tasks() if c.__name__ == 'idemtest_task')
+
+    def test_repeated_discovery_keeps_class_pickle_stable(self):
+        import pickle
+        from secator.loader import discover_external_tasks
+        cls1 = self._discover_one()
+        # Simulate discovery running a second time (re-entrant import / cache miss).
+        discover_external_tasks.cache_clear()
+        cls2 = self._discover_one()
+        # Idempotent: the second run must not mint a duplicate class object...
+        self.assertIs(cls1, cls2)
+        # ...and sys.modules must still resolve the name to that same object...
+        self.assertIs(getattr(sys.modules[cls1.__module__], 'idemtest_task'), cls1)
+        # ...so the first object stays pickleable (the #1286 --sync chunk failure).
+        pickle.dumps(cls1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #1286.

## Symptom

An **external** task with chunking (`input_chunk_size`) run in `--sync` mode crashes with:

```
EncodeError(PicklingError("Can't pickle <class 'secator.tasks.<name>.<name>'>:
it's not the same object as secator.tasks.<name>.<name>"))
```

Works fine on a worker; only `--sync` + chunks fail (in the `break_task` chord path).

## Root cause

`discover_external_tasks()` is a hand-rolled importer that **re-executes the task file and overwrites `sys.modules` on every call** — it isn't idempotent like a normal `import`. When discovery runs a second time in the same process, it mints a **second class object**. A task instance built from the *first* object can then no longer be pickled, because pickle resolves the class by name and `sys.modules[module].<name>` now points at the *second* object.

Why only `--sync`: `task_store_eager_result=True` makes the eager chord result get pickled **in-process** into the result backend, exercising the class-by-reference pickle path. Worker/async mode imports the task exactly once per process, so the two objects never coexist there.

What runs discovery twice: an external task that imports a `secator.tasks.*` submodule (e.g. `from secator.tasks._categories import ...`). That import triggers `secator/tasks/__init__.py` → `TASKS = discover_tasks()`, which **re-enters the `@cache`'d `discover_external_tasks()` while it is still executing** — and `functools.cache` is not re-entrancy safe, so the body runs again and re-execs every task file. (A task that imports nothing from `secator.tasks` never triggers it — which is why it looks tool-specific.)

## Fix

Make discovery idempotent, like a normal import: if the module is already in `sys.modules`, reuse its class instead of re-executing the file. If it's mid-initialisation (re-entrant), skip it — the in-progress exec appends the class when it finishes. One class object per task, stable in `sys.modules`, pickleable.

```python
existing = sys.modules.get(module_name)
if existing is not None:
    cls = getattr(existing, task_name, None)
    if inspect.isclass(cls):
        cls.__external__ = True
        output.append(cls)
    continue
```

## Reproduction & verification

Minimal external task (`input_chunk_size=1` + a `secator.tasks.*` import):
- **Before:** `secator x <task> a,b --sync` → the exact `PicklingError`; `get_task_class(name) is sys.modules[...].<name>` → `False`.
- **After:** run succeeds; identity `True`; all tasks still discovered.

Regression test `TestDiscoverExternalTasksIdempotent` asserts a task class stays identity- and pickle-stable across repeated discovery. It **fails without the fix** (`cls1 is not cls2`) and passes with it. `flake8` clean; loader/template/runner unit suites green (89 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)