### PR TITLE
refactor(runners): evaluate workflow conditions with a restricted AST evaluator

### DIFF
--- a/secator/runners/scan.py
+++ b/secator/runners/scan.py
@@ -5,6 +5,7 @@ from secator.config import CONFIG
 from secator.output_types.info import Info
 from secator.runners._base import Runner
 from secator.runners.workflow import Workflow
+from secator.safe_eval import safe_eval_condition
 from secator.utils import merge_opts
 
 
@@ -53,8 +54,7 @@ class Scan(Runner):
 			# Skip workflow if condition is not met
 			condition = workflow_opts.pop('if', None) if workflow_opts else None
 			local_ns = {'opts': DotMap(opts)}
-			safe_globals = {'__builtins__': {'len': len}}
-			if condition and not eval(condition, safe_globals, local_ns):
+			if condition and not safe_eval_condition(condition, local_ns, {'len': len}):
 				self.add_result(Info(message=f'Skipped workflow {name} because condition is not met: {condition}'))
 				continue
 

--- a/secator/runners/workflow.py
+++ b/secator/runners/workflow.py
@@ -5,6 +5,7 @@ from secator.output_types import Info
 from secator.runners._base import Runner
 from secator.runners._helpers import resolve_task_queue
 from secator.runners.task import Task
+from secator.safe_eval import safe_eval_condition
 from secator.tree import build_runner_tree, walk_runner_tree
 from secator.utils import merge_opts
 
@@ -83,8 +84,7 @@ class Workflow(Runner):
 				local_ns = {'opts': DotMap(opts), 'targets': self.inputs}
 				if condition:
 					# debug(f'{node.id} evaluating {condition} with opts {opts}', sub=self.config.name)
-					safe_globals = {'__builtins__': {'len': len}}
-					result = eval(condition, safe_globals, local_ns)
+					result = safe_eval_condition(condition, local_ns, {'len': len})
 					if not result:
 						debug(f'{node.id} skipped task because condition is not met: {condition}', sub=self.config.name)
 						# Persisted to the store via the runner's on_item hook.

--- a/secator/safe_eval.py
+++ b/secator/safe_eval.py
@@ -1,0 +1,100 @@
+"""Restricted AST evaluator for the workflow/scan/tree `if:`/`condition:` DSL.
+
+Only a small, explicit grammar is accepted (attribute access, comparisons,
+boolean ops, `in`, a fixed set of string/dict methods, and whitelisted
+functions like `len`/`re_match`). Anything outside that grammar is rejected
+before evaluation, so the accepted condition language is explicit rather than
+"whatever Python's eval() happens to allow".
+"""
+
+import ast
+
+ALLOWED_METHODS = {"startswith", "endswith", "lower", "upper", "strip", "lstrip", "rstrip", "get"}
+
+_ALLOWED_NODES = (
+	ast.Expression,
+	ast.BoolOp, ast.And, ast.Or,
+	ast.UnaryOp, ast.Not,
+	ast.Compare, ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE, ast.In, ast.NotIn,
+	ast.Name, ast.Load,
+	ast.Attribute,
+	ast.Constant,
+	ast.List, ast.Tuple,
+	ast.Call, ast.keyword,
+)
+
+
+def _validate(node, names, funcs):
+	if not isinstance(node, _ALLOWED_NODES):
+		raise ValueError(f"unsupported expression: {ast.dump(node)}")
+
+	if isinstance(node, ast.Attribute):
+		if "__" in node.attr:
+			raise ValueError(f"unsupported expression: attribute access to {node.attr!r}")
+		_validate(node.value, names, funcs)
+
+	elif isinstance(node, ast.Name):
+		if node.id not in names and node.id not in funcs:
+			raise ValueError(f"unsupported expression: unknown name {node.id!r}")
+
+	elif isinstance(node, ast.Call):
+		func = node.func
+		if isinstance(func, ast.Name) and func.id in funcs:
+			pass
+		elif isinstance(func, ast.Attribute) and func.attr in ALLOWED_METHODS and "__" not in func.attr:
+			_validate(func.value, names, funcs)
+		else:
+			raise ValueError(f"unsupported expression: call to {ast.dump(func)}")
+		for arg in node.args:
+			if isinstance(arg, ast.Starred):
+				raise ValueError("unsupported expression: starred argument")
+			_validate(arg, names, funcs)
+		for kw in node.keywords:
+			if kw.arg is None:  # **kwargs
+				raise ValueError("unsupported expression: **kwargs")
+			_validate(kw.value, names, funcs)
+
+	else:
+		for child in ast.iter_child_nodes(node):
+			_validate(child, names, funcs)
+
+
+def safe_eval_condition(expr, names, funcs=None):
+	"""Evaluate a condition expression restricted to the condition DSL grammar.
+
+	Args:
+		expr (str): condition expression, e.g. "item.type == 'url' and not opts.passive".
+		names (dict): variables available to the expression (e.g. item, opts, targets).
+		funcs (dict): whitelisted callables available to the expression (e.g. len, re_match).
+
+	Returns:
+		The result of evaluating `expr`.
+
+	Raises:
+		ValueError: if `expr` contains anything outside the allowed grammar.
+	"""
+	funcs = funcs or {}
+	tree = ast.parse(expr, mode='eval')
+	_validate(tree, names, funcs)
+	return eval(compile(tree, "<condition>", "eval"), {"__builtins__": {}}, {**names, **funcs})  # noqa: S307
+
+
+def demo():
+	assert safe_eval_condition("a == 1", {"a": 1}) is True
+	assert safe_eval_condition("a.startswith('x')", {"a": "xyz"}) is True
+	assert safe_eval_condition("len(items) == 0", {"items": []}, {"len": len}) is True
+	try:
+		safe_eval_condition("a.__class__", {"a": 1})
+		raise AssertionError("expected ValueError for dunder attribute access")
+	except ValueError:
+		pass
+	try:
+		safe_eval_condition("open('/etc/passwd')", {})
+		raise AssertionError("expected ValueError for disallowed call")
+	except ValueError:
+		pass
+	print("safe_eval self-check OK")
+
+
+if __name__ == "__main__":
+	demo()

--- a/secator/tree.py
+++ b/secator/tree.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Union
+from secator.safe_eval import safe_eval_condition
 from secator.template import TemplateLoader
 from dotmap import DotMap
 
@@ -161,7 +162,7 @@ def prune_runner_tree(tree: RunnerTree, opts: dict, inputs: list = None) -> Runn
 	scan-level options like domain_recon_passive are visible as opts.passive
 	inside that workflow's tasks (mirroring build_celery_workflow behaviour).
 	"""
-	safe_globals = {'__builtins__': {'len': len}}
+	funcs = {'len': len}
 
 	def strip_prefix(parent_opts, workflow_name):
 		prefix = workflow_name.split('/')[0] + '_'
@@ -181,7 +182,7 @@ def prune_runner_tree(tree: RunnerTree, opts: dict, inputs: list = None) -> Runn
 		if node.condition:
 			local_ns = {'opts': DotMap(current_opts), 'targets': inputs or []}
 			try:
-				if not eval(node.condition, safe_globals, local_ns):
+				if not safe_eval_condition(node.condition, local_ns, funcs):
 					node.remove()
 			except Exception:
 				pass
@@ -191,7 +192,7 @@ def prune_runner_tree(tree: RunnerTree, opts: dict, inputs: list = None) -> Runn
 		if root.condition:
 			local_ns = {'opts': DotMap(opts), 'targets': inputs or []}
 			try:
-				if not eval(root.condition, safe_globals, local_ns):
+				if not safe_eval_condition(root.condition, local_ns, funcs):
 					tree.root_nodes.remove(root)
 			except Exception:
 				pass

--- a/tests/unit/test_safe_eval.py
+++ b/tests/unit/test_safe_eval.py
@@ -1,0 +1,105 @@
+import unittest
+
+from dotmap import DotMap
+
+from secator.safe_eval import safe_eval_condition
+
+FUNCS = {'len': len}
+
+# Fixtures shared by the corpus below: one DotMap per condition-DSL variable
+# name real conditions bind to (item/opts/port/url/ip/target), plus targets.
+NAMES = {
+	'ip': DotMap({'alive': True}),
+	'item': DotMap({
+		'id': 'item-1',
+		'is_directory': True,
+		'name': 'net_cidr',
+		'status_code': 200,
+		'stored_response_path': '/tmp/resp.html',
+		'type': 'url',
+		'verified': False,
+		'_source': 'gf_urls',
+		'_context': {'scope': 'example.com', 'ancestor_id': 'abc'},
+	}),
+	'opts': DotMap({
+		'probe': False,
+		'ports': '80,443',
+		'scanners': True,
+		'hunt_secrets': True,
+		'fuzzers': ['arjun'],
+		'crawlers': ['cariddi'],
+		'passive': False,
+		'mode': 'filesystem',
+		'brute_dns': True,
+		'nuclei': True,
+	}),
+	'port': DotMap({'host': '10.0.0.1', 'port': 22, 'service_name': 'SSH'}),
+	'url': DotMap({'verified': False, 'is_root': True}),
+	'target': DotMap({'type': 'domain'}),
+	'targets': ['10.0.0.1'],
+}
+
+# (condition, expected result)
+VALID_CONDITIONS = [
+	('ip.alive', True),
+	('item.id', 'item-1'),
+	('item.is_directory', True),
+	("item.name == 'email_address'", False),
+	("item.name in ['lfi']", False),
+	("item.name == 'net_cidr' and len(targets) == 0", False),
+	('item._source.startswith("gf")', True),
+	("item._source.startswith('urlparser') or item._source.startswith('arjun') or item._source.startswith('x8')", False),  # noqa: E501
+	('item.status_code != 0', True),
+	("item.stored_response_path != ''", True),
+	("item.type == 'url'", True),
+	('not item.verified', True),
+	('not opts.probe', True),
+	('not url.verified or opts.hunt_secrets', True),
+	('opts.ports', '80,443'),
+	('port.host in targets and opts.scanners', True),
+	("port.port == 22 or 'ssh' in port.service_name.lower()", True),
+	("target.type != 'email'", True),
+	('url.is_root', True),
+	('item._context.get("scope") == "example.com"', True),
+	("'arjun' in opts.fuzzers", True),
+	("'cariddi' in opts.crawlers and not opts.passive", True),
+	('len(targets) == 0', False),
+	("not opts.mode or opts.mode in ['filesystem', 'git']", True),
+	('opts.brute_dns and not opts.passive', True),
+	('opts.nuclei and not opts.passive', True),
+]
+
+INVALID_EXPRESSIONS = [
+	'item.__class__',
+	'opts.mode.__class__.__base__',
+	'[x for x in targets]',
+	'(lambda: 1)()',
+	"open('/etc/passwd')",
+	'unknown_name == 1',
+	"opts.mode.format('x')",
+]
+
+
+class TestSafeEvalCorpus(unittest.TestCase):
+	"""Every real condition used across workflow/scan/tree configs must evaluate."""
+
+	def test_valid_conditions_accepted(self):
+		for expr, expected in VALID_CONDITIONS:
+			with self.subTest(expr=expr):
+				self.assertEqual(safe_eval_condition(expr, NAMES, FUNCS), expected)
+
+
+class TestSafeEvalRejectsOutsideDSL(unittest.TestCase):
+	"""Constructs outside the condition DSL must be rejected, not silently run."""
+
+	def test_disallowed_constructs_raise(self):
+		for expr in INVALID_EXPRESSIONS:
+			with self.subTest(expr=expr):
+				with self.assertRaises(ValueError):
+					safe_eval_condition(expr, NAMES, FUNCS)
+
+
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Replaces raw eval() for if:/condition: with a restricted evaluator that only permits the condition DSL (attribute access, comparisons, boolean ops, in, len, re_match, and a fixed set of string/dict methods); makes the accepted grammar explicit; no change to valid conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved safety when evaluating workflow, scan, tree, and extractor conditions.
  * Unsupported expressions, unsafe attribute access, unknown names, and disallowed function calls are now rejected.

* **Bug Fixes**
  * Preserved existing condition handling, workflow skipping, tree pruning, and regex matching behavior.

* **Tests**
  * Added coverage for valid condition expressions and rejected unsafe constructs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->