### PR TITLE
fix(tasks): validate bbot presets and wpprobe mode on the construction path

### DIFF
--- a/secator/tasks/bbot.py
+++ b/secator/tasks/bbot.py
@@ -203,6 +203,17 @@ class bbot(Command):
 	opt_value_map = {
 		'presets': lambda x: ' '.join(x.split(','))
 	}
+
+	@staticmethod
+	def on_cmd(self):
+		# `presets` is `shlex: False` and comma->space expanded into argv above, so an
+		# unknown token could inject an extra bbot flag. Restrict to known presets.
+		presets = self.get_opt_value('presets')
+		if presets:
+			for token in re.split(r'[,\s]+', str(presets).strip()):
+				if token and token not in BBOT_PRESETS:
+					raise ValueError(f'Invalid bbot preset: {token}')
+
 	item_loaders = [JSONSerializer()]
 	output_discriminator = output_discriminator
 	output_map = {

--- a/secator/tasks/wpprobe.py
+++ b/secator/tasks/wpprobe.py
@@ -10,6 +10,8 @@ from secator.definitions import OUTPUT_PATH, THREADS, URL
 from secator.output_types import Vulnerability, Tag, Info, Warning, Error
 from secator.tasks._categories import OPTS
 
+WPPROBE_MODES = ['scan', 'update', 'update-db']
+
 
 @task()
 class wpprobe(Command):
@@ -22,7 +24,7 @@ class wpprobe(Command):
 	input_flag = '-u'
 	opt_prefix = '-'
 	opts = {
-		'mode': {'type': click.Choice(['scan', 'update', 'update-db']), 'default': 'scan', 'help': 'WPProbe mode', 'required': True, 'internal': True},  # noqa: E501
+		'mode': {'type': click.Choice(WPPROBE_MODES), 'default': 'scan', 'help': 'WPProbe mode', 'required': True, 'internal': True},  # noqa: E501
 		'output_path': {'type': str, 'default': None, 'help': 'Output JSON file path', 'internal': True, 'display': False},  # noqa: E501
 	}
 	meta_opts = {
@@ -41,6 +43,11 @@ class wpprobe(Command):
 	@staticmethod
 	def on_cmd(self):
 		mode = self.get_opt_value('mode')
+		# `mode` is `internal` (not shlex-quoted) and interpolated into the command
+		# below; click.Choice is only enforced by the CLI parser, so re-validate it
+		# here for the API/Celery construction path.
+		if mode not in WPPROBE_MODES:
+			raise ValueError(f'Invalid mode: {mode}')
 		if mode == 'update' or mode == 'update-db':
 			self.cmd = f'{wpprobe.cmd} {mode}'
 			return

--- a/tests/unit/test_task_opt_validation.py
+++ b/tests/unit/test_task_opt_validation.py
@@ -1,0 +1,27 @@
+import pytest
+
+from secator.tasks.bbot import bbot
+from secator.tasks.wpprobe import wpprobe
+
+
+class _Fake:
+	def __init__(self, values):
+		self.values = values
+
+	def get_opt_value(self, key):
+		return self.values.get(key)
+
+
+def test_bbot_rejects_flag_injection_via_presets():
+	with pytest.raises(ValueError):
+		bbot.on_cmd(_Fake({'presets': 'web-basic,-c modules.x.exec=id'}))
+
+
+def test_bbot_accepts_known_presets():
+	assert bbot.on_cmd(_Fake({'presets': 'web-basic,spider'})) is None
+	assert bbot.on_cmd(_Fake({'presets': None})) is None
+
+
+def test_wpprobe_rejects_invalid_mode():
+	with pytest.raises(ValueError):
+		wpprobe.on_cmd(_Fake({'mode': 'scan; id'}))


### PR DESCRIPTION
Two task options bypass the framework's shlex quoting and are only validated by the Click CLI parser, not when a runner is constructed from API/Celery input:

- **wpprobe `mode`** — `internal: True`, interpolated into the command in `on_cmd`. Now re-validated against the known WPProbe modes (mirrors trufflehog's existing runtime check).
- **bbot `presets`** — `shlex: False` and comma→space expanded into argv, so an unknown token could introduce an extra bbot flag. Each token is now required to be a known `BBOT_PRESETS` entry.

Tests: `tests/unit/test_task_opt_validation.py` (injection rejected, known values accepted). Part of `feature:worker-hardening`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of BBOT preset values, rejecting unknown or malformed entries.
  * Added validation for supported WPProbe modes to prevent invalid command options.
  * Strengthened protection against injected command-line arguments.

* **Tests**
  * Added coverage for valid, missing, and invalid BBOT presets.
  * Added coverage for invalid WPProbe modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->