### PR TITLE
fix(grype): update parsing for v0.115.0 output

### DIFF
--- a/secator/tasks/grype.py
+++ b/secator/tasks/grype.py
@@ -62,7 +62,7 @@ class grype(VulnCode):
 	}
 	install_version = 'v0.115.0'
 	install_cmd_pre = {'*': ['curl']}
-	install_cmd = f'curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b {CONFIG.dirs.bin} {install_version}'  # noqa: E501
+	install_cmd = f'curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b {CONFIG.dirs.bin} [install_version]'  # noqa: E501
 	github_handle = 'anchore/grype'
 
 	@staticmethod

--- a/secator/tasks/grype.py
+++ b/secator/tasks/grype.py
@@ -60,7 +60,7 @@ class grype(VulnCode):
 		TIMEOUT: OPT_NOT_SUPPORTED,
 		USER_AGENT: OPT_NOT_SUPPORTED,
 	}
-	install_version = 'v0.91.2'
+	install_version = 'v0.115.0'
 	install_cmd_pre = {'*': ['curl']}
 	install_cmd = f'curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b {CONFIG.dirs.bin}'  # noqa: E501
 	github_handle = 'anchore/grype'
@@ -69,22 +69,38 @@ class grype(VulnCode):
 	def item_loader(self, line):
 		"""Load vulnerabilty dicts from grype line output."""
 		split = [i for i in line.split('  ') if i]
-		if len(split) not in [5, 6] or split[0] == 'NAME':
+		kev = split and split[-1].strip() == '(kev)'  # grype flags KEV vulns with a trailing marker in the RISK column
+		if kev:
+			split = split[:-1]
+		if len(split) not in [7, 8] or split[0] == 'NAME':
 			return
 		versions_fixed = None
-		if len(split) == 5:  # no version fixed
-			product, version, product_type, vuln_id, severity = tuple(split)
-		elif len(split) == 6:
-			product, version, versions_fixed, product_type, vuln_id, severity = tuple(split)
+		if len(split) == 7:  # no version fixed
+			product, version, product_type, vuln_id, severity, epss, risk = tuple(split)
+		elif len(split) == 8:
+			product, version, versions_fixed, product_type, vuln_id, severity, epss, risk = tuple(split)
 		extra_data = {
 			'lang': product_type.strip(),
 			'product': product.strip(),
 			'version': version.strip(),
+			'risk': risk.strip(),
 		}
-		if versions_fixed:
+		epss_score = 0.0
+		if '%' in epss:  # e.g. '47.6% (98th)' -> 0.476
+			try:
+				epss_score = float(epss.split('%')[0].strip()) / 100
+			except ValueError:
+				pass
+		wont_fix = versions_fixed is not None and versions_fixed.strip() == "(won't fix)"
+		if wont_fix:
+			extra_data['versions_fixed'] = []
+		elif versions_fixed:
 			extra_data['versions_fixed'] = [c.strip() for c in versions_fixed.split(', ')]
+		tags = (['kev'] if kev else []) + (['wont_fix'] if wont_fix else [])
 		vuln_id = vuln_id.strip()
 		severity = severity.lower().strip()
+		if severity == 'negligible':
+			severity = 'low'
 		matched_at = self.inputs[0]
 		if Path(matched_at).exists():
 			matched_at = str(Path(matched_at).resolve())
@@ -96,7 +112,8 @@ class grype(VulnCode):
 			'severity': severity,
 			'provider': 'grype',
 			'cvss_score': -1,
-			'tags': [],
+			'epss_score': epss_score,
+			'tags': list(tags),
 		}
 		if vuln_id.startswith('GHSA'):
 			data['provider'] = 'github.com'
@@ -104,12 +121,16 @@ class grype(VulnCode):
 			vuln = VulnCode.lookup_cve_from_ghsa(vuln_id)
 			if vuln:
 				data.update(vuln)
-				data['severity'] = data['severity'] or severity
+				data['severity'] = data['severity'] if data['severity'] not in ('', 'unknown') else severity
 				extra_data['ghsa_id'] = vuln_id
 		elif vuln_id.startswith('CVE'):
 			vuln = VulnCode.lookup_cve(vuln_id)
 			if vuln:
 				data.update(vuln.toDict())
-				data['severity'] = data['severity'] or severity
+				data['severity'] = data['severity'] if data['severity'] not in ('', 'unknown') else severity
+		# grype's EPSS and tags are authoritative; re-assert them after the CVE/GHSA lookup which clobbers them
+		data['epss_score'] = epss_score
+		if tags:
+			data['tags'] = list(dict.fromkeys(data.get('tags', []) + tags))
 		data['extra_data'] = extra_data
 		yield data

--- a/secator/tasks/grype.py
+++ b/secator/tasks/grype.py
@@ -62,7 +62,7 @@ class grype(VulnCode):
 	}
 	install_version = 'v0.115.0'
 	install_cmd_pre = {'*': ['curl']}
-	install_cmd = f'curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b {CONFIG.dirs.bin}'  # noqa: E501
+	install_cmd = f'curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b {CONFIG.dirs.bin} {install_version}'  # noqa: E501
 	github_handle = 'anchore/grype'
 
 	@staticmethod

--- a/tests/fixtures/grype_output.txt
+++ b/tests/fixtures/grype_output.txt
@@ -1,5 +1,7 @@
-NAME        INSTALLED  FIXED-IN  TYPE    VULNERABILITY        SEVERITY
-pip         23.0.1     25.3      python  GHSA-4xh5-x5gv-qwph  Medium
-pip         23.0.1     23.3      python  GHSA-mq26-g339-26xf  Medium
-setuptools  66.1.1     78.1.1    python  GHSA-5rjg-fvgr-3xxf  High
-setuptools  66.1.1     70.0.0    python  GHSA-cx63-2mw6-8hw5  High
+NAME        INSTALLED  FIXED IN  TYPE    VULNERABILITY        SEVERITY  EPSS         RISK
+pip         23.0.1     25.3      python  GHSA-4xh5-x5gv-qwph  Medium    0.4% (35th)  0.2
+pip         23.0.1     23.3      python  GHSA-mq26-g339-26xf  Medium    0.5% (37th)  0.3
+setuptools  66.1.1     78.1.1    python  GHSA-5rjg-fvgr-3xxf  High      0.4% (30th)  0.2
+setuptools  66.1.1     70.0.0    python  GHSA-cx63-2mw6-8hw5  High      0.3% (25th)  0.2
+pip         23.0.1     23.3      python  CVE-2023-44487       High      100.0% (99th)  78.8   (kev)
+ncurses     6.1        (won't fix)  deb   CVE-2023-45918       Negligible  N/A          N/A

--- a/tests/integration/outputs.py
+++ b/tests/integration/outputs.py
@@ -90,7 +90,7 @@ OUTPUTS_TASKS = {
 		Url(url='https://danielmiessler.com/predictions/', status_code=200, content_length=23, _source='gospider'),
 	],
 	'grype': [
-		Vulnerability(name='CVE-2024-24790', provider='grype', id='CVE-2024-24790', matched_at='redis:7.4.1', ip='', confidence='medium', severity='critical', cvss_score=-1, _source='grype'),
+		Vulnerability(name='CVE-2024-46981', provider='grype', id='CVE-2024-46981', matched_at='redis:7.4.1', ip='', confidence='medium', severity='critical', cvss_score=-1, _source='grype'),
 	],
 	'h8mail': [UserAccount(username='test', email='test@test.com', _source='h8mail')],
 	'httpx': [


### PR DESCRIPTION
## Summary

Grype `v0.115.0` changed its table output (added `EPSS` and `RISK` columns plus `(kev)` / `(won't fix)` markers), which broke the parser. This updates the `grype` task to match and bumps the pinned `install_version`.

## Changes

- **7/8 columns** instead of 5/6 (new trailing `EPSS`, `RISK`).
- **EPSS** parsed into the real `epss_score` field (`47.6% (98th)` → `0.476`).
- **`(kev)` marker** handled — it splits into an extra token, so KEV rows were previously being *silently dropped*. Now emits a `kev` tag.
- **`(won't fix)`** → empty `versions_fixed` list + `wont_fix` tag.
- **`negligible`** severity → `low`.
- Re-assert `epss_score` / `tags` / severity **after** the CVE/GHSA lookup, which was clobbering grype's authoritative values (also fixes severity being reset to `unknown` when the lookup returns no severity).
- Bump `install_version` to `v0.115.0`, update test fixture.

## Testing

- `secator test unit --tasks grype --test test_tasks` — passing
- `secator test lint` — clean
- Verified live against `node:14`: KEV tag (CVE-2023-44487), `wont_fix` + empty list (CVE-2023-45918), `negligible`→`low` (CVE-2023-48795), EPSS surviving the CVE lookup (CVE-2023-50387).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enhanced Grype vulnerability reports, including EPSS scores, risk levels, KEV status, and “won’t fix” indicators.
  * Improved parsing across multiple Grype output formats and normalized negligible severity findings to low.

* **Bug Fixes**
  * Preserved authoritative Grype severity, EPSS, and tags during vulnerability enrichment.
  * Updated the Grype scanner to version 0.115.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->