### PR TITLE
perf(mongodb): index-seek untagged findings in tag_duplicates (was 12s O(workspace) scan)

### DIFF
--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -163,6 +163,9 @@ def update_finding(self, item):
 			finding = db['findings'].update_one({'_id': _id}, {'$set': update})
 			status = 'UPDATED'
 		else:
+			# Stamp an explicit untagged default so tag_duplicates can index-seek untagged
+			# findings (`_tagged: False`) instead of a `$ne: True` whole-workspace scan (#1315).
+			update.setdefault('_tagged', False)
 			finding = db['findings'].insert_one(update)
 			item._uuid = str(finding.inserted_id)
 			status = 'CREATED'
@@ -232,7 +235,10 @@ def tag_duplicates(ws_id: str = None, full_scan: bool = False, exclude_types=[],
 	db = client.main
 	start_time = time.time()
 	workspace_query = {'_context.workspace_id': str(ws_id), '_context.workspace_duplicate': False, '_tagged': True}
-	untagged_query = {'_context.workspace_id': str(ws_id), '_tagged': {'$ne': True}}
+	# `$in: [False, None]` (index-seekable) instead of `$ne: True` (whole-workspace scan). Matches
+	# findings stamped `_tagged: False` on insert AND legacy docs where the field is absent (indexed
+	# as null), so no backfill is required. See #1315.
+	untagged_query = {'_context.workspace_id': str(ws_id), '_tagged': {'$in': [False, None]}}
 	if full_scan:
 		del untagged_query['_tagged']
 	workspace_findings = load_findings(list(db.findings.find(workspace_query).sort('_timestamp', -1)), exclude_types)

--- a/tests/unit/test_mongodb_hooks.py
+++ b/tests/unit/test_mongodb_hooks.py
@@ -69,5 +69,21 @@ class TestMongoDocumentTooLarge(unittest.TestCase):
         self.assertIn("16MB", warnings[0].message)
 
 
+class TestMongoTaggedDefault(unittest.TestCase):
+    """#1315: new findings must be stamped `_tagged: False` on insert so tag_duplicates
+    can index-seek untagged findings instead of a `$ne: True` whole-workspace scan."""
+
+    def test_new_finding_stamped_untagged_on_insert(self):
+        from bson.objectid import ObjectId
+        client = MagicMock()
+        coll = client.main.__getitem__.return_value
+        coll.insert_one.return_value = MagicMock(inserted_id=ObjectId())
+        with patch.object(mongodb, "get_mongodb_client", return_value=client):
+            mongodb.update_finding(_FakeRunner(), Info(message="x"))
+        doc = coll.insert_one.call_args[0][0]
+        self.assertIn("_tagged", doc)
+        self.assertFalse(doc["_tagged"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Fixes the slow MongoDB query behind #1315: `tag_duplicates` looked up untagged findings with `{_tagged: {$ne: True}}`, which can't bound an index. mongod walked **every** finding in the workspace (350k–500k docs) to return the ~101 untagged ones — **11–12.6 s per run** on canary, plus an in-memory sort. Findings were never stamped `_tagged` on insert, which is why the code resorted to `$ne`.

## Changes (secator core)

- **Stamp `_tagged: False` on insert** (`update_finding`) — untagged findings become an explicit, index-seekable value (insert path only; updates never clobber a tagged doc).
- **`{_tagged: {$in: [False, None]}}`** instead of `$ne: True` — matches new (`False`) and legacy (absent → indexed as `null`) docs, so **no backfill** is required, and the predicate is index-bounded.

## Companion PR (index)

The supporting **`{_context.workspace_id, _tagged, _timestamp}`** index is added in **freelabz/secator-api#228** — index management lives in secator-api (alongside its ~18 existing findings indexes), not in secator core. Both should land together; without the index the query change alone still can't bound the lookup.

## Scope / follow-up

Addresses the **measured slow query**. Intentionally does **not** touch the separate O(workspace) *worker-memory* cost — `workspace_query` still materializes every tagged non-duplicate finding into memory via `list(...)`. That needs a dedup-algorithm change (projection / run-scoping) and stays tracked in #1315.

## Test

New `TestMongoTaggedDefault.test_new_finding_stamped_untagged_on_insert` asserts inserts carry `_tagged: False`. Full `test_mongodb_hooks.py` green, flake8 clean.

## Verification

Root-caused from mongod slow-query logs on `env-canary/mongo-0` during a passive scan (evidence in #1315).

Refs #1315

🤖 Generated with [Claude Code](https://claude.com/claude-code)
