### PR TITLE
fix: harden Redis connection resilience (broker + result backend)

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -59,6 +59,11 @@ app.conf.update(
 			'data_folder_out': CONFIG.dirs.celery_data,
 			'control_folder': CONFIG.dirs.celery_data,
 			'visibility_timeout': CONFIG.celery.broker_visibility_timeout,
+			# Keep the broker connection alive (redis transport) so a long task's idle
+			# consumer connection isn't silently reaped — same reasoning as the result
+			# backend below. Ignored by the filesystem broker.
+			'socket_keepalive': True,
+			'health_check_interval': 30,
 		},
 		'broker_connection_retry_on_startup': True,
 		'broker_pool_limit': CONFIG.celery.broker_pool_limit,
@@ -71,6 +76,19 @@ app.conf.update(
 		'result_backend_thread_safe': True,
 		'result_serializer': 'pickle',
 		'result_accept_content': ['application/x-python-serialize'],
+		# Redis connection resilience. A long task leaves its result-backend connection
+		# idle for its whole runtime; the network can silently reap it, and by default
+		# Celery does NOT retry result-backend ops (result_backend_always_retry=False) and
+		# the redis client has no keepalive/health-check. The next store_result then hits
+		# `ConnectionError: Connection reset by peer` and the task is marked FAILURE even
+		# though its work succeeded — which poisons any chord it belongs to and hangs the
+		# workflow. Keep the connection alive (keepalive + health-check) AND retry the
+		# store on a transient error so a reset can't fail the task.
+		'redis_socket_keepalive': True,
+		'redis_backend_health_check_interval': 30,
+		'redis_retry_on_timeout': True,
+		'result_backend_always_retry': True,
+		'result_backend_max_retries': 20,
 		# Task config
 		'task_acks_late': CONFIG.celery.task_acks_late,
 		'task_compression': 'gzip',


### PR DESCRIPTION
## Problem

A long-running task (e.g. `testssl`/`nmap` over many subdomains) leaves its Redis **result-backend** connection idle for its entire runtime. The network silently reaps the idle connection, and because Celery's result backend **does not retry by default** (`result_backend_always_retry=False`) and the redis client has **no keepalive/health-check**, the task's final `store_result` hits:

```
redis.exceptions.ConnectionError: Error while reading from redis:6379 : (104, 'Connection reset by peer')
```

The task is then marked **FAILURE even though its work succeeded**. When that task is a **chord header** (e.g. `testssl` in `subdomain_recon`'s `_group/vuln`), the chord is **poisoned** — Celery never dispatches the chord body — and the **whole workflow hangs** (stuck `RUNNING`/`progress=0`).

Diagnosed on a canary scan wedge: `testssl` showed `mongo=SUCCESS` but `celery=FAILURE` (ConnectionError in `store_result`), poisoning the chord so `search_vulns` never dispatched. It's intermittent (depends on the idle connection being reaped at an unlucky moment), which is why only long tasks under some runs hit it.

## Fix — two layers of defense

**Prevent the reap** (keep the connection alive):
- result backend: `redis_socket_keepalive=True`, `redis_backend_health_check_interval=30`
- broker transport: `socket_keepalive=True`, `health_check_interval=30`

**Survive a reset if it still happens** (retry instead of failing the task):
- `result_backend_always_retry=True` with bounded `result_backend_max_retries=20`
- `redis_retry_on_timeout=True`

All are Celery defaults that ship *off*, so they must be set explicitly. Values are safe universal defaults.

## Notes
- Only touches `secator/celery.py` app config; no behavior change for short tasks.
- Pairs with a separate chord-recovery watchdog (tracked in ops docs) for the case where a chord was *already* poisoned before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background task connection stability.
  * Added resilience for temporary broker and result-backend connectivity issues.
  * Enabled additional connection health checks and retry handling to reduce task interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->