### PR TITLE
fix(config): allow unsetting int/float config keys

### DIFF
--- a/secator/config.py
+++ b/secator/config.py
@@ -453,7 +453,7 @@ class Config(DotMap):
 					console.print(f'[bold orange1]Value "{item}" not found in {key}[/].')
 					return
 			value = current
-		else:
+		elif value is not None:
 			# Try to convert value to expected type
 			try:
 				if isinstance(existing_value, list):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -84,6 +84,19 @@ class TestConfig(unittest.TestCase):
 		yaml_data = Config.read_yaml(self.config_test)
 		self.assertEqual(yaml_data['tasks']['overrides']['nuclei']['input_chunk_size'], 100)
 
+	def test_unset_numeric_key(self):
+		"""Unsetting an int field must drop it from the partial config, not raise TypeError."""
+		from secator.config import Config
+		config = Config.parse(path=self.config_test)
+		default = config.runners.progress_update_frequency
+		config.set('runners.progress_update_frequency', '30')
+		config.save()
+		self.assertEqual(Config.read_yaml(self.config_test)['runners']['progress_update_frequency'], 30)
+		config.unset('runners.progress_update_frequency')
+		config.save()
+		self.assertNotIn('progress_update_frequency', Config.read_yaml(self.config_test).get('runners', {}))
+		self.assertEqual(Config.parse(path=self.config_test).runners.progress_update_frequency, default)
+
 	def _parse_with_env(self, **env):
 		"""Parse a fresh config with the given SECATOR_* env vars set, then clean them up."""
 		from secator.config import Config


### PR DESCRIPTION
Closes #1052

`secator config unset <int-key>` (e.g. `runners.progress_update_frequency`) raised `TypeError: int() argument must be ... not 'NoneType'`. `Config.unset()` calls `set(key, None)`, but the type-coercion branch ran `int(None)` before the `set_partial` handler could interpret `None` as "reset to default". Coercion is now skipped when the value is `None`, so the existing reset path runs — same for `float`/`Path` keys.

New `test_unset_numeric_key` fails with that exact `TypeError` without the one-line source change and passes with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration handling when removing numeric settings.
  * Unset numeric values are now removed cleanly without conversion errors.
  * Default values are restored when removed settings are loaded again.

* **Tests**
  * Added coverage for saving, unsetting, and reloading numeric configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->