### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,11 +309,11 @@ To go deeper with `secator`, check out:
 
 ## Stats
 
-<a href="https://star-history.com/#freelabz/secator&Date">
+<a href="https://star-history.dera.page/#freelabz/secator&type=Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=freelabz/secator&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=freelabz/secator&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=freelabz/secator&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=freelabz/secator&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=freelabz/secator&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=freelabz/secator&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change updates the chart to use the new star-history.dera.page domain so it renders correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Star History embeds to use the new Star History page URLs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->