### PR TITLE
fix(command): tty issue dumb terminals

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -220,7 +220,8 @@ class Command(Runner):
 		try:
 			self.has_tty = self.run_opts.get('tty', sys.stdin.isatty())
 		except (ValueError, AttributeError, OSError):
-			self.has_tty = self.run_opts.get('tty', False)
+			is_not_dumb = os.environ.get('TERM', '').lower() != 'dumb'
+			self.has_tty = self.run_opts.get('tty', is_not_dumb)
 
 		# Stat update
 		self.last_updated_stat = None


### PR DESCRIPTION
Follow up of our previous PR #1184 : we fallback to auto-detecting using the `TERM` variable if it's set so that we can still ask for sudo password even if the concurrency failed with an exception because of mishandling of stdin from Celery. Much more convenient for local uses.