### PR TITLE
test(integration): don't pin secator.cloud's drifting nginx patch version

### DIFF
--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -45,10 +45,24 @@ class TestWorker(unittest.TestCase):
 		# vulns = [v for v in cmd.results if v._type == 'vulnerability']
 		port = Port(port=443, ip='34.149.194.179', state='open', _source='nmap')
 		url = Url('https://secator.cloud', status_code=200, _source='httpx')
-		tag = Tag(name='nginx-version', match='https://secator.cloud', category='info', value='nginx/1.30.3', _source='nuclei_url')
 		self.assertIn(port, cmd.findings)
 		self.assertIn(url, cmd.findings)
-		self.assertIn(tag, cmd.findings)
+		# The nginx patch version drifts as secator.cloud's base image updates (e.g.
+		# 1.30.3 -> 1.30.4), so assert the tag's stable fields instead of pinning the
+		# exact value (which is a compared Tag field and breaks on every bump).
+		nginx_tags = [
+			t for t in cmd.findings
+			if t._type == 'tag' and t.name == 'nginx-version'
+		]
+		self.assertTrue(
+			any(
+				t.category == 'info'
+				and t.match == 'https://secator.cloud'
+				and str(t.value).startswith('nginx/')
+				for t in nginx_tags
+			),
+			'expected an nginx-version info tag @ https://secator.cloud',
+		)
 		# self.assertEqual(vulns, [])
 
 	# def test_pd_pipe(self):


### PR DESCRIPTION
## Problem
`TestWorker.test_host_recon` fails:
```
AssertionError: 🏷️  [info] nginx-version nginx/1.30.3 found @ https://secator.cloud not found in <StreamView ...>
```
The test pins an exact `Tag(..., value='nginx/1.30.3', ...)`. `value` is a compared dataclass field, and **secator.cloud's nginx was upgraded to 1.30.4** (confirmed: `Server: nginx/1.30.4`), so the exact-Tag `assertIn` no longer matches. Pinning a live target's patch version breaks the test on every nginx bump.

## Fix
Assert the nginx-version tag's **stable** fields — `name='nginx-version'`, `category='info'`, `match='https://secator.cloud'`, and that `value` starts with `nginx/` — instead of the exact patch version. (Port/URL assertions unchanged; StreamView is iterable and supports repeated iteration, which the existing port/url `assertIn`s already rely on.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated host reconnaissance validation to accept varying nginx version values while continuing to verify the expected URL and port information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->