### PR TITLE
fix(wpscan): don't leak wpscan's version status into the finding status

### DIFF
--- a/secator/tasks/wpscan.py
+++ b/secator/tasks/wpscan.py
@@ -134,6 +134,11 @@ class wpscan(VulnHttp):
 					'type': wp_version,
 					'references': {},
 				})
+				# wpscan's version dict carries its own `status` ('outdated' = the WP
+				# *version* is outdated). Drop it so it doesn't leak into the finding's
+				# triage status field (NEW/ACKNOWLEDGED/FIXED), which would otherwise
+				# be set to 'outdated' and never match status filters.
+				vuln.pop('status', None)
 				yield vuln
 
 		# Main theme


### PR DESCRIPTION
## Problem
Vulnerabilities from the wpscan **"Wordpress outdated version"** finding ended up with triage `status: "outdated"` — a value the UI doesn't recognise (statuses are NEW/ACKNOWLEDGED/FIXED), so they never match `status` filters (e.g. the "To triage" `status:NEW` quickfilter).

## Root cause
`secator/tasks/wpscan.py` reuses wpscan's `version` dict as the vuln payload:
```python
vuln = version                 # version has its own status: 'outdated'
vuln.update({...})
yield vuln
```
wpscan's `version.status` ("the WordPress *version* is outdated") leaks into `Vulnerability.status` (the finding's *triage* status). Two unrelated meanings of "status" collide.

## Fix
`vuln.pop('status', None)` before `yield` so the finding gets the normal default status instead of wpscan's version-status. Other wpscan vuln branches build `Vulnerability(...)` explicitly and were never affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed outdated WordPress version findings being assigned an incorrect triage status.
  * Reports now preserve the correct vulnerability status when generated by WPScan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->