### PR TITLE
fix(lint,test): cli.py lint + deterministic empty-arg query test

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1137,8 +1137,8 @@ def query(ctx, arg, output, output_folder, time_delta, fmt, workspace, report_fi
 		else:
 			console.print(Error(message='Invalid config, not saving it.'))
 		return
-	
-  # Empty query: return all results (subject to the enforced base query),
+
+	# Empty query: return all results (subject to the enforced base query),
 	# optionally scoped by --report-filter / --workspace.
 	if not arg:
 		run_report_show(report_filter, output, time_delta, None, fmt, workspace, driver, dedupe, limit, output_folder)

--- a/tests/unit/test_query_cli.py
+++ b/tests/unit/test_query_cli.py
@@ -144,8 +144,12 @@ class TestQueryDispatch(unittest.TestCase):
 		self.assertEqual(sorted(v['name'] for v in vulns), ['SQLi', 'XSS'])
 
 	def test_empty_arg_no_filter_shows_all(self):
-		"""bare secator q (no args, no filters) should succeed and return all results."""
-		result, captured = self._invoke(['query', '--driver', 'local'])
+		"""bare secator q (no args) should succeed and return the current workspace's results."""
+		from secator.config import CONFIG
+		# bare `secator q` (no -ws) reads the CURRENT workspace; point current at the
+		# seeded workspace so the test doesn't depend on the dev/CI-configured one.
+		with mock.patch.object(CONFIG.workspaces, 'current', WS):
+			result, captured = self._invoke(['query', '--driver', 'local'])
 		self.assertIsNone(result.exception, str(result.exception))
 		self.assertEqual(result.exit_code, 0)
 		vulns = captured.get('results', {}).get('vulnerability', [])


### PR DESCRIPTION
Fixes two **pre-existing failures on `main`** (surfaced by #1211, the current HEAD) — unrelated to any feature work; both reproduce on a clean `main` checkout.

## Lint (`secator test lint` → `flake8 secator/`)
`secator/cli.py` in the empty-query branch had:
- `1140:1 W293` — a whitespace-only blank line
- `1141:3 E114` — a comment indented with 2 spaces instead of the file's tabs

Normalized to tabs. `flake8 secator/` now clean.

## Unit (`tests/unit/test_query_cli.py::test_empty_arg_no_filter_shows_all`)
The test seeds data in workspace `query_ws` but invokes **bare `secator q`** (no `-ws`), which reads `CONFIG.workspaces.current` — `''`/`default` on CI, whatever the dev configured locally — so it read the wrong workspace dir and returned `[]`. The bare-query behavior is *by design* (the local json driver scopes by directory, and #1211 didn't add all-workspace search), so this is a **test determinism bug**, not a code bug. Pin `CONFIG.workspaces.current` to the seeded workspace for that test. All 8 tests in the file pass.

Unblocks the CI on other open PRs (e.g. #1326) once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the query command when no workspace is specified, ensuring it uses the current workspace correctly.

* **Style**
  * Cleaned up whitespace and indentation in the command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->