### PR TITLE
fix(runners): nested target filter dropping task inputs since #1312

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -431,6 +431,10 @@ def mark_runner_started(results, runner, enable_hooks=True):
 			'targets': runner.inputs,
 			'ancestor_id': runner.ancestor_id,
 			'node_chain_start': True,
+			# This resolution PRODUCES the scope-tagged Targets, so it must query the upstream
+			# targets, not the (not-yet-existing) scope it is about to assign — see
+			# build_extractor_query / freelabz/secator#1328.
+			'scope_producer': True,
 			'workspace_name': runner.workspace_name,
 			'results': [],  # extractors query the store
 		})

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -246,7 +246,12 @@ def build_extractor_query(extractor, ctx):
 	# Additional narrowing the old per-item eval applied within the run.
 	parent_scope = ctx.get('parent_scope')
 	ancestor_id = ctx.get('ancestor_id')
-	if _type == 'target' and parent_scope:
+	# `scope_producer` marks the mark_runner_started pass that RESOLVES a workflow's own
+	# targets_ in order to emit the scope-tagged Targets (see secator/celery.py). That pass must
+	# query the UPSTREAM targets — filtering by `parent_scope` here would look for the very scope
+	# it is about to create, always yield nothing, and leave every task in the workflow with no
+	# inputs (freelabz/secator#1328). Consumers (task extractors) still filter by the scope.
+	if _type == 'target' and parent_scope and not ctx.get('scope_producer', False):
 		query['_context.scope'] = parent_scope
 	elif ancestor_id and not ctx.get('node_chain_start', False):
 		query['_context.ancestor_id'] = str(ancestor_id)

--- a/tests/unit/test_target_filter_scope.py
+++ b/tests/unit/test_target_filter_scope.py
@@ -1,0 +1,105 @@
+"""Regression tests for target filtering through a scan -> workflow -> task chain.
+
+freelabz/secator#1328: since the store-backed extractor rework (#1312), a scan that filters
+targets into a workflow (`targets_` in the scan template) AND a task inside that workflow that
+also filters targets (`targets_` in the workflow template) left the task with NO inputs.
+
+Root cause: the `mark_runner_started` pass that resolves a workflow's own `targets_` to EMIT the
+scope-tagged Targets was itself scoped by `parent_scope` in build_extractor_query, so it queried
+the very scope it was about to create, found nothing, and emitted nothing — leaving every task in
+the workflow that filters (or relies on the scope fallback) with no targets.
+"""
+import unittest
+from unittest.mock import patch
+
+from secator.decorators import task
+from secator.output_types import Target
+from secator.runners import Scan
+from secator.runners.command import Command
+from secator.template import TemplateLoader
+
+
+# --- Pure-python mock task: record the inputs it RESOLVED to (after target filtering) ---
+RESOLVED = {}
+
+
+@task()
+class mockscantask(Command):
+	cmd = 'true'
+	input_types = []  # accept any input
+	output_types = [Target]
+
+	def _run_extractors(self):
+		super()._run_extractors()
+		# Target filtering is applied here; capture what the task ended up with.
+		RESOLVED[self.unique_name] = sorted(self.inputs)
+
+	def yielder(self):
+		for name in self.inputs:
+			yield Target(name=name)
+
+
+def _wf(name, task_targets_):
+	"""A one-task workflow; the task filters targets by `type: target, field: name`."""
+	tasks = {'mockscantask/mytask': {}}
+	if task_targets_ is not None:
+		tasks['mockscantask/mytask'] = {'targets_': task_targets_}
+	return TemplateLoader(input={'type': 'workflow', 'name': name, 'tasks': tasks})
+
+
+class TestTargetFilterScope(unittest.TestCase):
+
+	INPUTS = ['host-a.test', 'host-b.test', 'host-c.test']
+
+	def setUp(self):
+		RESOLVED.clear()
+		# Register the mock task and serve inline workflow templates by name.
+		import secator.runners.task as task_mod
+		import secator.loader as loader_mod
+		self._orig_discover = task_mod.discover_tasks
+		task_mod.discover_tasks = lambda: list(self._orig_discover()) + [mockscantask]
+		self._templates = []
+		self._patch_ft = patch.object(loader_mod, 'find_templates', side_effect=lambda: self._templates)
+		self._patch_ft.start()
+
+	def tearDown(self):
+		import secator.runners.task as task_mod
+		task_mod.discover_tasks = self._orig_discover
+		self._patch_ft.stop()
+
+	def _run_scan(self, wf2_scan_targets_, mytask_targets_):
+		"""Scan: wf1 (no filter) then wf2 (scan-level targets_ = `wf2_scan_targets_`).
+		wf2 contains one task that filters by `mytask_targets_`. Returns mytask's resolved inputs."""
+		self._templates = [
+			_wf('wf1', None),
+			_wf('wf2', mytask_targets_),
+		]
+		scan_cfg = TemplateLoader(input={
+			'type': 'scan', 'name': 'myscan',
+			'workflows': {'wf1': {}, 'wf2': {'targets_': wf2_scan_targets_}},
+		})
+		scan = Scan(scan_cfg, self.INPUTS, run_opts={'sync': True}, context={})
+		list(scan)
+		return next((inp for name, inp in RESOLVED.items() if 'mytask' in name), None)
+
+	def test_identity_filter_passes_all_targets(self):
+		"""#1328: task with `targets_` under a scan-filtered workflow must receive the workflow's
+		targets (here: all of them), not an empty list."""
+		mytask_inputs = self._run_scan(
+			wf2_scan_targets_={'type': 'target', 'field': 'name'},
+			mytask_targets_={'type': 'target', 'field': 'name'},
+		)
+		self.assertEqual(mytask_inputs, sorted(self.INPUTS))
+
+	def test_scan_level_subset_filter_is_honored(self):
+		"""When the scan-level filter selects a SUBSET, the nested task must receive exactly that
+		subset (not all targets) — proves the fix keeps the scope filter on the consumer side."""
+		mytask_inputs = self._run_scan(
+			wf2_scan_targets_={'type': 'target', 'field': 'name', 'condition': "name == 'host-a.test'"},
+			mytask_targets_={'type': 'target', 'field': 'name'},
+		)
+		self.assertEqual(mytask_inputs, ['host-a.test'])
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/unit/test_target_filter_scope.py
+++ b/tests/unit/test_target_filter_scope.py
@@ -30,21 +30,24 @@ class mockscantask(Command):
 	output_types = [Target]
 
 	def _run_extractors(self):
+		"""Capture the inputs the task resolved to (target filtering is applied here)."""
 		super()._run_extractors()
-		# Target filtering is applied here; capture what the task ended up with.
 		RESOLVED[self.unique_name] = sorted(self.inputs)
 
 	def yielder(self):
+		"""Echo each resolved input back as a Target so downstream filters have data."""
 		for name in self.inputs:
 			yield Target(name=name)
 
 
-def _wf(name, task_targets_):
-	"""A one-task workflow; the task filters targets by `type: target, field: name`."""
-	tasks = {'mockscantask/mytask': {}}
-	if task_targets_ is not None:
-		tasks['mockscantask/mytask'] = {'targets_': task_targets_}
-	return TemplateLoader(input={'type': 'workflow', 'name': name, 'tasks': tasks})
+def _wf(name, task_node, task_targets_):
+	"""A one-task workflow. `task_node` is the task node id (distinct per workflow so the two
+	workflows' task executions never collide in RESOLVED); `task_targets_` is its optional filter."""
+	opts = {'targets_': task_targets_} if task_targets_ is not None else {}
+	return TemplateLoader(input={
+		'type': 'workflow', 'name': name,
+		'tasks': {f'mockscantask/{task_node}': opts},
+	})
 
 
 class TestTargetFilterScope(unittest.TestCase):
@@ -52,8 +55,8 @@ class TestTargetFilterScope(unittest.TestCase):
 	INPUTS = ['host-a.test', 'host-b.test', 'host-c.test']
 
 	def setUp(self):
+		"""Register the mock task and serve inline workflow templates by name."""
 		RESOLVED.clear()
-		# Register the mock task and serve inline workflow templates by name.
 		import secator.runners.task as task_mod
 		import secator.loader as loader_mod
 		self._orig_discover = task_mod.discover_tasks
@@ -63,16 +66,18 @@ class TestTargetFilterScope(unittest.TestCase):
 		self._patch_ft.start()
 
 	def tearDown(self):
+		"""Restore task discovery and the find_templates patch."""
 		import secator.runners.task as task_mod
 		task_mod.discover_tasks = self._orig_discover
 		self._patch_ft.stop()
 
 	def _run_scan(self, wf2_scan_targets_, mytask_targets_):
-		"""Scan: wf1 (no filter) then wf2 (scan-level targets_ = `wf2_scan_targets_`).
-		wf2 contains one task that filters by `mytask_targets_`. Returns mytask's resolved inputs."""
+		"""Scan: `recon` (wf1, no filter) then `wf2` (scan-level targets_ = `wf2_scan_targets_`).
+		wf2 holds task node `mytask` (filter = `mytask_targets_`); wf1 holds a distinctly-named task.
+		Returns the list of inputs every `mytask` execution (wf2 only) resolved to."""
 		self._templates = [
-			_wf('wf1', None),
-			_wf('wf2', mytask_targets_),
+			_wf('wf1', 'recontask', None),
+			_wf('wf2', 'mytask', mytask_targets_),
 		]
 		scan_cfg = TemplateLoader(input={
 			'type': 'scan', 'name': 'myscan',
@@ -80,25 +85,30 @@ class TestTargetFilterScope(unittest.TestCase):
 		})
 		scan = Scan(scan_cfg, self.INPUTS, run_opts={'sync': True}, context={})
 		list(scan)
-		return next((inp for name, inp in RESOLVED.items() if 'mytask' in name), None)
+		# unique_name is '<class>_<node>[_N]', so this matches wf2's mytask only (wf1 uses 'recontask').
+		return [inp for uname, inp in RESOLVED.items() if uname.startswith('mockscantask_mytask')]
 
 	def test_identity_filter_passes_all_targets(self):
 		"""#1328: task with `targets_` under a scan-filtered workflow must receive the workflow's
 		targets (here: all of them), not an empty list."""
-		mytask_inputs = self._run_scan(
+		results = self._run_scan(
 			wf2_scan_targets_={'type': 'target', 'field': 'name'},
 			mytask_targets_={'type': 'target', 'field': 'name'},
 		)
-		self.assertEqual(mytask_inputs, sorted(self.INPUTS))
+		self.assertTrue(results, 'wf2 mytask never executed')
+		for inputs in results:
+			self.assertEqual(inputs, sorted(self.INPUTS))
 
 	def test_scan_level_subset_filter_is_honored(self):
 		"""When the scan-level filter selects a SUBSET, the nested task must receive exactly that
 		subset (not all targets) — proves the fix keeps the scope filter on the consumer side."""
-		mytask_inputs = self._run_scan(
+		results = self._run_scan(
 			wf2_scan_targets_={'type': 'target', 'field': 'name', 'condition': "name == 'host-a.test'"},
 			mytask_targets_={'type': 'target', 'field': 'name'},
 		)
-		self.assertEqual(mytask_inputs, ['host-a.test'])
+		self.assertTrue(results, 'wf2 mytask never executed')
+		for inputs in results:
+			self.assertEqual(inputs, ['host-a.test'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1328.

## Problem

Since #1312 (store-backed extractors), a scan that filters targets into a workflow **and** a task inside that workflow that also filters targets leaves the task with **no inputs**:

```yaml
# scan
type: scan
workflows:
  wf1:
  wf2:
    targets_: { type: target, field: name }   # scan-level filter into wf2
```
```yaml
# workflow wf2
type: workflow
tasks:
  mytask:
    targets_: { type: target, field: name }   # workflow-level filter into mytask
```

`mytask` receives no targets, though it should get the same targets passed to `wf2`. Worked before #1312.

## Root cause (traced end-to-end)

A workflow with a scan-level `targets_` gets a `parent_scope`. Its `mark_runner_started` re-resolves the workflow's own `targets_` to **emit scope-tagged `Target` findings** that its tasks then consume (`secator/celery.py`). But `build_extractor_query` unconditionally added `_context.scope == parent_scope` to that query — so the **producing** pass searched for the exact scope it was about to create, matched nothing, and emitted **zero** scope-tagged targets. Every task that then filters by scope resolved to an empty set.

Debug trace on `main`:

```
# wf2 emit (producer)  -> query {_type:target, scan_id, scope:wf2} -> 0 results -> 0 emitted
# mytask (consumer)    -> query {_type:target, scan_id, scope:wf2} -> 0 results -> no inputs
```

## Fix

The producing pass sets `scope_producer` in its extractor context; `build_extractor_query` skips the self-referential scope filter when set, so it queries the **upstream** targets and emits them tagged. Consumer (task) extractors are unchanged and still filter by scope — so a scan-level **subset** filter is still honored.

Two-line change (+ comments) in `secator/celery.py` and `secator/runners/_helpers.py`.

## Tests

`tests/unit/test_target_filter_scope.py` runs a real scan → workflow → task (sync) with a mock task and asserts the task's resolved inputs:

- `test_identity_filter_passes_all_targets` — the #1328 case
- `test_scan_level_subset_filter_is_honored` — a scan-level subset filter still reaches the nested task exactly (guards the consumer-side scoping)

Both **fail on `main`, pass with the fix**. Full unit suite: identical failure set before/after (the pre-existing environment-dependent failures — network/tool/config-dir — are unchanged; the fix adds `+2` passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved target resolution for nested workflows and scope-based filtering.
  * Workflow-level and task-level filters now correctly preserve matching targets.
  * Fixed upstream target handling for scope-producing workflow steps.

* **Tests**
  * Added regression coverage for target filtering across scans, workflows, and tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->