### PR TITLE
fix(docker): bump alpine runtime to 3.23 (Go 1.25.10) for tool installs

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -26,7 +26,7 @@ RUN pipx install --pip-args="--no-cache-dir" . && \
     secator install addons dev
 
 
-FROM python:3.12-alpine3.22
+FROM python:3.12-alpine3.23
 ARG flavor=full
 ARG build_from_source=false
 ENV PYENV_ROOT="/opt/pyenv"


### PR DESCRIPTION
## Problem
The **platform (alpine)** CI (and thus the 0.42.0 release PR #1323) fails building the alpine image:
```
go install github.com/projectdiscovery/httpx/cmd/httpx@v1.9.0
go: httpx@v1.9.0 requires go >= 1.25.7 (running go 1.24.13; GOTOOLCHAIN=local)
[ERR] Failed to install httpx: INSTALL_FAILED
```
The runtime stage `python:3.12-alpine3.22` installs Go from apk = **1.24.13**, but httpx v1.9.0 now needs **Go ≥ 1.25.7**, and `GOTOOLCHAIN=local` prevents Go from auto-downloading a newer toolchain.

## Fix
Bump the runtime base to **`python:3.12-alpine3.23`** — Alpine 3.23 ships **go 1.25.10** (verified against the alpine community APKINDEX) and the tag exists on Docker Hub, keeping **Python 3.12**.

- Only `.docker/Dockerfile.alpine` (the `Dockerfile` symlink target); other distros passed and are untouched.
- The `alpine:3.21` **builder** stage does no `go install` and must keep Python 3.12 to match the runtime venv it copies over — left unchanged.

Once merged, re-run the 0.42.0 release PR's platform (alpine) job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime environment to use Alpine Linux 3.23 for improved platform support and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->