### PR TITLE
fix(command): don't crash on sudo prompt when TTY detection is wrong (#1332)

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -928,7 +928,18 @@ class Command(Runner):
 		for _ in range(3):
 			user = getpass.getuser()
 			self._print(rf'\[sudo] password for {user}: ▌', rich=True)
-			sudo_password = getpass.getpass()
+			try:
+				sudo_password = getpass.getpass()
+			except (EOFError, ValueError, OSError):
+				# has_tty can disagree with the real stdin (closed / redirected under Celery or
+				# gevent, dumb terminals): getpass then blows up on termios / a closed stream.
+				# Degrade to the same graceful error as the no-TTY case instead of crashing.
+				error = (
+					'Sudo password required but no usable TTY (non-interactive mode). '
+					'Retry without sudo-requiring options (e.g. use nmap -sT instead of -sS), '
+					'or configure passwordless sudo.'
+				)
+				return -1, error
 			result = subprocess.run(
 				['sudo', '-S', '-p', '', 'true'],
 				input=sudo_password + '\n',

--- a/tests/unit/test_prompt_sudo.py
+++ b/tests/unit/test_prompt_sudo.py
@@ -1,0 +1,37 @@
+import types
+import unittest
+from unittest.mock import patch
+
+from secator.runners.command import Command
+
+
+class TestPromptSudo(unittest.TestCase):
+	"""_prompt_sudo must never crash the task on a missing/broken TTY (issue #1332)."""
+
+	def _stub(self, has_tty=True):
+		# _prompt_sudo only touches these attributes — avoid a full Command __init__.
+		return types.SimpleNamespace(has_tty=has_tty, _print=lambda *a, **k: None)
+
+	@patch('subprocess.run', return_value=types.SimpleNamespace(returncode=1))
+	@patch('getpass.getuser', return_value='test')
+	@patch('getpass.getpass', side_effect=ValueError('I/O operation on closed file'))
+	def test_getpass_failure_degrades_gracefully(self, *_):
+		stub = self._stub(has_tty=True)  # heuristic says TTY, but stdin is actually broken
+		password, error = Command._prompt_sudo(stub, 'sudo masscan')
+		self.assertEqual(password, -1)  # -1 + non-empty error => caller yields Error and returns
+		self.assertTrue(error)
+
+	@patch('subprocess.run', return_value=types.SimpleNamespace(returncode=1))
+	def test_no_tty_returns_error(self, _):
+		stub = self._stub(has_tty=False)
+		password, error = Command._prompt_sudo(stub, 'sudo masscan')
+		self.assertEqual(password, -1)
+		self.assertTrue(error)
+
+	def test_no_sudo_is_noop(self):
+		stub = self._stub()
+		self.assertEqual(Command._prompt_sudo(stub, 'nmap -sT target'), (None, []))
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Closes #1332.

## Problem
Despite #1184 and #1324, sudo password prompts still crash the task in non-interactive contexts (Celery workers, dumb terminals):

```
File ".../secator/runners/command.py", line 931, in _prompt_sudo
  sudo_password = getpass.getpass()
...
ValueError: I/O operation on closed file.
```

## Root cause
Both prior fixes decide **up front** whether a TTY exists (`has_tty`) and skip `getpass` when it doesn't. That heuristic is unreliable: under Celery/gevent (stdin closed or redirected) or on dumb terminals with `TERM` set, `has_tty` reports `True`, yet `getpass.getpass()` still fails on `termios` / a closed stream (`termios.error` → `ValueError: I/O operation on closed file`) — and the exception escapes before the graceful `(-1, error)` path can return, crashing the whole runner.

## Fix
Wrap the `getpass.getpass()` call and, on `(EOFError, ValueError, OSError)`, return the same graceful `(-1, error)` the no-TTY branch already produces. The caller yields an `Error` and stops the runner cleanly. TTY detection stays as a fast path; this catches the cases it gets wrong — defense-in-depth rather than yet another detection tweak.

## Tests
`tests/unit/test_prompt_sudo.py`: getpass-raises → graceful degrade, no-TTY → error, no-sudo → no-op. 3 passed, flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when sudo authentication cannot access an interactive terminal.
  * Displays a clear non-interactive-mode error instead of exposing unexpected failures.
  * Commands that do not require sudo continue to run without prompting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->