### PR TITLE
feat(loader): warn on duplicate scan/workflow/task names

### DIFF
--- a/secator/loader.py
+++ b/secator/loader.py
@@ -28,7 +28,10 @@ def _file_has_exporter(path):
 		return False
 
 
-def _warn_duplicate_names(entries, _seen=set()):
+_warned_duplicate_names = set()
+
+
+def _warn_duplicate_names(entries, _seen=None):
 	"""Warn when a config name is defined more than once.
 
 	A second scan/workflow/task with the same ``name`` silently shadows the first (name
@@ -38,9 +41,12 @@ def _warn_duplicate_names(entries, _seen=set()):
 	Args:
 		entries: iterable of ``(label, source)`` where ``label`` uniquely identifies a config
 			(e.g. ``workflow "host_recon"``) and ``source`` is the file/module it came from.
-		_seen: persistent set (module lifetime) so each duplicate is reported only once.
+		_seen: set of already-reported labels so each duplicate is reported only once. Defaults
+			to a module-level set that persists for the process lifetime.
 	"""
 	from collections import defaultdict
+	if _seen is None:
+		_seen = _warned_duplicate_names
 	groups = defaultdict(list)
 	for label, source in entries:
 		groups[label].append(source)
@@ -110,10 +116,15 @@ def discover_tasks():
 	external = discover_external_tasks()
 	internal = discover_internal_tasks()
 	tasks = external + internal
-	_warn_duplicate_names(
+	# External tasks: use the real per-file paths (a reused same-stem module would otherwise make
+	# every duplicate resolve to the first file and hide the shadowing). Internal tasks are properly
+	# imported, so their module __file__ is reliable.
+	entries = [(f'task "{name}"', source) for name, source in _external_task_sources]
+	entries += [
 		(f'task "{cls.__name__}"', getattr(sys.modules.get(cls.__module__), '__file__', None) or cls.__module__)
-		for cls in tasks
-	)
+		for cls in internal
+	]
+	_warn_duplicate_names(entries)
 	return tasks
 
 
@@ -148,10 +159,19 @@ def discover_internal_tasks():
 	return task_classes
 
 
+# Candidate ``(task_name, file path)`` pairs seen by the last discover_external_tasks() run — one
+# entry per source FILE, even when its module is reused (same stem in two dirs). Duplicate detection
+# reads this instead of cls.__module__: a reused module points every same-stem file at the first
+# file's path, which would hide exactly the shadowing we want to warn about.
+_external_task_sources = []
+
+
 @cache
 def discover_external_tasks():
 	"""Find external secator tasks."""
+	global _external_task_sources
 	output = []
+	sources = []
 	prev_state = sys.dont_write_bytecode
 	sys.dont_write_bytecode = True
 	for path in CONFIG.dirs.templates.glob('**/*.py'):
@@ -176,6 +196,7 @@ def discover_external_tasks():
 				if inspect.isclass(cls):
 					cls.__external__ = True
 					output.append(cls)
+					sources.append((task_name, str(path)))  # record THIS file, not the reused module's
 				continue
 
 			# console.print(f'Importing module {module_name} from {path}')
@@ -207,10 +228,12 @@ def discover_external_tasks():
 			debug(f'[bold green]Successfully loaded external task "{task_name}"[/] ({path})', sub='loader')
 			cls.__external__ = True
 			output.append(cls)
+			sources.append((task_name, str(path)))
 		except Exception as e:
 			sys.modules.pop(module_name, None)
 			console.print(f'[bold red]Could not load external module {path.name}. Reason: {str(e)}.[/] ({path})')
 	sys.dont_write_bytecode = prev_state
+	_external_task_sources = sources
 	return output
 
 

--- a/secator/loader.py
+++ b/secator/loader.py
@@ -28,6 +28,32 @@ def _file_has_exporter(path):
 		return False
 
 
+def _warn_duplicate_names(entries, _seen=set()):
+	"""Warn when a config name is defined more than once.
+
+	A second scan/workflow/task with the same ``name`` silently shadows the first (name
+	resolution keeps the first match), which is a confusing footgun — e.g. two workflow files
+	with the same ``name:`` key, or an external task shadowing a built-in one.
+
+	Args:
+		entries: iterable of ``(label, source)`` where ``label`` uniquely identifies a config
+			(e.g. ``workflow "host_recon"``) and ``source`` is the file/module it came from.
+		_seen: persistent set (module lifetime) so each duplicate is reported only once.
+	"""
+	from collections import defaultdict
+	groups = defaultdict(list)
+	for label, source in entries:
+		groups[label].append(source)
+	for label, sources in groups.items():
+		# Dedupe sources so the same file counted twice (re-entrant discovery) isn't a false positive.
+		distinct = list(dict.fromkeys(sources))
+		if len(distinct) > 1 and label not in _seen:
+			_seen.add(label)
+			console.print(f'[bold orange1]⚠  Duplicate {label} defined in {len(distinct)} places — only the first is used:[/]')  # noqa: E501
+			for source in distinct:
+				console.print(f'   [dim]{source}[/]')
+
+
 @cache
 def find_templates():
 	discover_tasks()  # always load tasks first
@@ -49,6 +75,10 @@ def find_templates():
 		config = TemplateLoader(input=path)
 		debug(f'Loaded template from {path}', sub='template')
 		results.append(config)
+	_warn_duplicate_names(
+		(f'{c.get("type")} "{c.get("name")}"', c.get('_path') or '<unknown>')
+		for c in results if c.get('type') and c.get('name')
+	)
 	return results
 
 
@@ -79,7 +109,12 @@ def discover_tasks():
 	"""Find all secator tasks (internal + external)."""
 	external = discover_external_tasks()
 	internal = discover_internal_tasks()
-	return external + internal
+	tasks = external + internal
+	_warn_duplicate_names(
+		(f'task "{cls.__name__}"', getattr(sys.modules.get(cls.__module__), '__file__', None) or cls.__module__)
+		for cls in tasks
+	)
+	return tasks
 
 
 @cache

--- a/tests/unit/test_loader_duplicate_names.py
+++ b/tests/unit/test_loader_duplicate_names.py
@@ -1,0 +1,59 @@
+"""Tests for the duplicate config-name warning (scans / workflows / tasks).
+
+A second config with the same `name` silently shadows the first (name resolution keeps the first
+match), so discovery warns about it — see secator.loader._warn_duplicate_names.
+"""
+import unittest
+from unittest.mock import patch
+
+from secator import loader
+
+
+def _printed(mock):
+	return '\n'.join(str(c.args[0]) for c in mock.call_args_list if c.args)
+
+
+class TestDuplicateNameWarning(unittest.TestCase):
+
+	def test_warns_on_duplicate_label(self):
+		with patch.object(loader.console, 'print') as mock:
+			loader._warn_duplicate_names(
+				[('workflow "host_recon"', 'a.yaml'), ('workflow "host_recon"', 'b.yaml')],
+				_seen=set(),
+			)
+		out = _printed(mock)
+		self.assertIn('Duplicate workflow "host_recon"', out)
+		self.assertIn('a.yaml', out)
+		self.assertIn('b.yaml', out)
+
+	def test_no_warning_when_unique(self):
+		with patch.object(loader.console, 'print') as mock:
+			loader._warn_duplicate_names(
+				[('workflow "a"', 'a.yaml'), ('workflow "b"', 'b.yaml')],
+				_seen=set(),
+			)
+		self.assertEqual(mock.call_count, 0)
+
+	def test_no_warning_when_same_source_repeated(self):
+		# Re-entrant discovery can list the same file twice; that must not be a false positive.
+		with patch.object(loader.console, 'print') as mock:
+			loader._warn_duplicate_names(
+				[('task "nmap"', 'nmap.py'), ('task "nmap"', 'nmap.py')],
+				_seen=set(),
+			)
+		self.assertEqual(mock.call_count, 0)
+
+	def test_warns_only_once_per_label(self):
+		seen = set()
+		entries = [('scan "s"', 'x.yaml'), ('scan "s"', 'y.yaml')]
+		with patch.object(loader.console, 'print') as mock:
+			loader._warn_duplicate_names(list(entries), _seen=seen)
+			first = mock.call_count
+			loader._warn_duplicate_names(list(entries), _seen=seen)
+			second = mock.call_count
+		self.assertGreater(first, 0)
+		self.assertEqual(first, second, 'duplicate should be reported only once per process')
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/unit/test_loader_duplicate_names.py
+++ b/tests/unit/test_loader_duplicate_names.py
@@ -3,6 +3,7 @@
 A second config with the same `name` silently shadows the first (name resolution keeps the first
 match), so discovery warns about it — see secator.loader._warn_duplicate_names.
 """
+import contextlib
 import unittest
 from unittest.mock import patch
 
@@ -53,6 +54,32 @@ class TestDuplicateNameWarning(unittest.TestCase):
 			second = mock.call_count
 		self.assertGreater(first, 0)
 		self.assertEqual(first, second, 'duplicate should be reported only once per process')
+
+	def test_discover_tasks_warns_on_same_stem_external_shadowing(self):
+		# Two external files with the same stem in different dirs: discover_external_tasks reuses
+		# the first module for the second, so both classes are identical and cls.__module__ points
+		# both at the first file — hiding the duplicate. The per-file sources side channel keeps
+		# both real paths so the shadowing is still reported.
+		nmap = type('nmap', (), {})
+		patches = [
+			patch.object(loader, 'discover_external_tasks', return_value=[nmap, nmap]),
+			patch.object(loader, 'discover_internal_tasks', return_value=[]),
+			patch.object(loader, '_external_task_sources', [('nmap', '/a/nmap.py'), ('nmap', '/b/nmap.py')]),
+			patch.object(loader, '_warned_duplicate_names', set()),
+		]
+		with contextlib.ExitStack() as stack:
+			mock = stack.enter_context(patch.object(loader.console, 'print'))
+			for p in patches:
+				stack.enter_context(p)
+			loader.discover_tasks.cache_clear()
+			try:
+				loader.discover_tasks()
+			finally:
+				loader.discover_tasks.cache_clear()
+		out = _printed(mock)
+		self.assertIn('Duplicate task "nmap"', out)
+		self.assertIn('/a/nmap.py', out)
+		self.assertIn('/b/nmap.py', out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

If two config files declare the same `name:`, the second **silently shadows** the first — name resolution (`TemplateLoader(name=...)`) keeps the first match, and the other config just never runs. No error, no warning. This bites in practice: a workflow accidentally overwritten by another with the same `name` looked like a target-filtering bug until the duplicate `name` was spotted.

## Change

Discovery now warns when a `<type> "<name>"` is defined in more than one place, listing every source so the shadowing is visible:

```
⚠  Duplicate workflow "host_recon_custom" defined in 2 places — only the first is used:
   /path/to/a.yaml
   /path/to/b.yaml
```

- **`find_templates()`** — covers scans, workflows, and YAML task/profile templates.
- **`discover_tasks()`** — covers task classes (an external task shadowing a built-in, or two external task files sharing a class name).

Details:
- Reported **once per name per process** (persistent `_seen` set) so it isn't noisy.
- Dedupes identical sources, so re-entrant task discovery (a user task file importing `secator.tasks`) can't produce a false positive.
- Verified built-in tasks/templates produce **no** false warnings.

## Tests

`tests/unit/test_loader_duplicate_names.py`: warns on a real duplicate (with both paths), stays quiet when names are unique, stays quiet when the same source is listed twice, and reports only once per label. Existing discovery-heavy suites (tree/celery/runners_helpers) still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added warnings when templates or tasks share duplicate names.
  * Prevented repeated warnings for the same duplicate label.
  * Avoided warnings when entries are repeated only from the same source.
  * Preserved existing first-match behavior when resolving duplicate names.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->