### PR TITLE
feat(command): serialize + cache interactive sudo prompt (concurrency-safe)

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -27,6 +27,14 @@ from secator.utils import debug, rich_escape as _s, signal_to_name
 
 logger = logging.getLogger(__name__)
 
+# Serialize interactive sudo prompts and cache the verified password for the process lifetime.
+# Under the gevent worker (default -c 100) many tasks call getpass on the same tty at once and
+# corrupt its termios state (issue #1332); the lock prompts one at a time and the cache lets the
+# rest reuse the password instead of re-prompting. threading.Lock is gevent-cooperative once
+# monkey-patched, and a plain lock otherwise.
+_SUDO_PROMPT_LOCK = threading.Lock()
+_SUDO_PASSWORD_CACHE = None
+
 
 class Command(Runner):
 	"""Base class to execute an external command."""
@@ -902,6 +910,7 @@ class Command(Runner):
 		Returns:
 			tuple: (sudo password, error).
 		"""
+		global _SUDO_PASSWORD_CACHE
 		sudo_password = None
 
 		# Check if sudo is required by the command
@@ -930,6 +939,10 @@ class Command(Runner):
 				return configured, None
 			return -1, 'Configured sudo password (security.sudo_password) is incorrect.'
 
+		# Reuse a password already entered this process (by a prior task) — no re-prompt, no tty.
+		if _SUDO_PASSWORD_CACHE is not None:
+			return _SUDO_PASSWORD_CACHE, None
+
 		# Check if we have a tty
 		if not self.has_tty:
 			error = (
@@ -938,34 +951,39 @@ class Command(Runner):
 			)
 			return -1, error
 
-		# If not, prompt the user for a password
-		self._print('[bold red]Please enter sudo password to continue.[/]', rich=True)
-		for _ in range(3):
-			user = getpass.getuser()
-			self._print(rf'\[sudo] password for {user}: ▌', rich=True)
-			try:
-				sudo_password = getpass.getpass()
-			except (EOFError, ValueError, OSError):
-				# has_tty can disagree with the real stdin (closed / redirected under Celery or
-				# gevent, dumb terminals): getpass then blows up on termios / a closed stream.
-				# Degrade to the same graceful error as the no-TTY case instead of crashing.
-				error = (
-					'Sudo password required but no usable TTY (non-interactive mode). '
-					'Retry without sudo-requiring options (e.g. use nmap -sT instead of -sS), '
-					'or configure passwordless sudo.'
+		# Prompt one task at a time (lock) so concurrent greenlets don't race on the tty, and cache
+		# the verified password so tasks queued behind the lock reuse it instead of re-prompting.
+		with _SUDO_PROMPT_LOCK:
+			if _SUDO_PASSWORD_CACHE is not None:  # another task prompted while we waited
+				return _SUDO_PASSWORD_CACHE, None
+			self._print('[bold red]Please enter sudo password to continue.[/]', rich=True)
+			for _ in range(3):
+				user = getpass.getuser()
+				self._print(rf'\[sudo] password for {user}: ▌', rich=True)
+				try:
+					sudo_password = getpass.getpass()
+				except (EOFError, ValueError, OSError):
+					# has_tty can disagree with the real stdin (closed / redirected under Celery or
+					# gevent, dumb terminals): getpass then blows up on termios / a closed stream.
+					# Degrade to the same graceful error as the no-TTY case instead of crashing.
+					error = (
+						'Sudo password required but no usable TTY (non-interactive mode). '
+						'Retry without sudo-requiring options (e.g. use nmap -sT instead of -sS), '
+						'or configure passwordless sudo.'
+					)
+					return -1, error
+				result = subprocess.run(
+					['sudo', '-S', '-p', '', 'true'],
+					input=sudo_password + '\n',
+					text=True,
+					capture_output=True,
 				)
-				return -1, error
-			result = subprocess.run(
-				['sudo', '-S', '-p', '', 'true'],
-				input=sudo_password + '\n',
-				text=True,
-				capture_output=True,
-			)
-			if result.returncode == 0:
-				return sudo_password, None  # Password is correct
-			self._print('Sorry, try again.')
-		error = 'Sudo password verification failed after 3 attempts.'
-		return -1, error
+				if result.returncode == 0:
+					_SUDO_PASSWORD_CACHE = sudo_password
+					return sudo_password, None  # Password is correct
+				self._print('Sorry, try again.')
+			error = 'Sudo password verification failed after 3 attempts.'
+			return -1, error
 
 	def _wait_for_end(self):
 		"""Wait for process to finish and process output and return code."""

--- a/tests/unit/test_prompt_sudo.py
+++ b/tests/unit/test_prompt_sudo.py
@@ -2,12 +2,19 @@ import types
 import unittest
 from unittest.mock import patch
 
+import secator.runners.command as command
 from secator.config import CONFIG
 from secator.runners.command import Command
 
 
 class TestPromptSudo(unittest.TestCase):
 	"""_prompt_sudo must never crash the task on a missing/broken TTY (issue #1332)."""
+
+	def setUp(self):
+		command._SUDO_PASSWORD_CACHE = None  # avoid the in-process cache leaking across tests
+
+	def tearDown(self):
+		command._SUDO_PASSWORD_CACHE = None
 
 	def _stub(self, has_tty=True):
 		# _prompt_sudo only touches these attributes — avoid a full Command __init__.
@@ -52,6 +59,27 @@ class TestPromptSudo(unittest.TestCase):
 				password, error = Command._prompt_sudo(stub, 'sudo masscan')
 		self.assertEqual(password, -1)
 		self.assertTrue(error)
+
+	@patch('getpass.getuser', return_value='test')
+	@patch('getpass.getpass', return_value='typed-pw')
+	def test_successful_prompt_caches_password(self, *_):
+		stub = self._stub(has_tty=True)
+		# sudo -n true => needs password (rc 1); sudo -S with the typed password => ok (rc 0)
+		runs = [types.SimpleNamespace(returncode=1), types.SimpleNamespace(returncode=0)]
+		with patch('subprocess.run', side_effect=runs):
+			password, error = Command._prompt_sudo(stub, 'sudo masscan')
+		self.assertEqual(password, 'typed-pw')
+		self.assertIsNone(error)
+		self.assertEqual(command._SUDO_PASSWORD_CACHE, 'typed-pw')  # cached for later tasks
+
+	@patch('getpass.getpass', side_effect=AssertionError('must not re-prompt when cached'))
+	def test_cached_password_reused_without_prompt(self, _):
+		command._SUDO_PASSWORD_CACHE = 'cached-pw'
+		stub = self._stub(has_tty=True)
+		with patch('subprocess.run', return_value=types.SimpleNamespace(returncode=1)):  # sudo -n: needs pw
+			password, error = Command._prompt_sudo(stub, 'sudo masscan')
+		self.assertEqual(password, 'cached-pw')  # reused, getpass never called
+		self.assertIsNone(error)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Experimental follow-up to try the interactive-lock idea. Stacked on #1335 (base it there; retarget once the stack lands).

## Why even a foreground worker prompts intermittently
The foreground worker runs the **gevent pool at `-c 100`** — up to 100 tasks as greenlets in one process. `getpass.getpass()` isn't atomic: it does `tcsetattr` (echo off) → **blocking tty read** → `tcsetattr` (restore), and gevent yields to the hub on that read. When a scan dispatches two sudo tasks at once (chunked `nmap -sS`, `masscan`), two greenlets sit inside `getpass` on the **same controlling terminal**; one's restoring `tcsetattr` then fails with `EIO` → the #1332 crash. Whether it happens is pure greenlet-timing luck, which is why it feels random. (sudo's ~15-min credential cache hides it after the first success, so it mostly bites the first cold-cache batch.)

## What
- A process-wide `threading.Lock` (gevent-cooperative once monkey-patched) around the interactive prompt → **one task prompts at a time**, no concurrent `tcsetattr` on the tty.
- An in-process password cache → tasks queued behind the lock (and any later task) **reuse the verified password** instead of re-prompting. You type it **once per worker run**.
- Double-checked inside the lock, so greenlets that passed the outer cache-miss don't each prompt.

Independent of #1335's configured-password path (which short-circuits earlier); this fixes the interactive experience for users who don't set a password.

## Tests
`tests/unit/test_prompt_sudo.py`: successful prompt populates the cache; a cached password is reused without calling getpass. 7 passed, flake8 clean.

## Caveat
The verified password lives in a module global for the worker's lifetime (in-memory only, never serialized/broker) — same exposure profile as #1335 and sudo's own timestamp. Reasonable for a trusted worker; flagging it explicitly since this is a "try it out" PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)