### PR TITLE
refactor(template): parse templates with yaml.safe_load

### DIFF
--- a/secator/template.py
+++ b/secator/template.py
@@ -42,7 +42,10 @@ class TemplateLoader(DotMap):
 			return self._load(f.read())
 
 	def _load(self, input):
-		return yaml.load(input, Loader=yaml.Loader)
+		# Templates are declarative config (mappings/lists/scalars); the plain
+		# SafeLoader covers everything they use, so there's no need for the full
+		# loader's arbitrary Python-object construction.
+		return yaml.safe_load(input)
 
 	def print(self):
 		"""Print config as highlighted yaml."""


### PR DESCRIPTION
Templates are declarative config (mappings / lists / scalars), so `SafeLoader` covers everything they use — the full loader's arbitrary Python-object construction isn't needed for template parsing. `safe_load` is the recommended default and keeps parsing predictable across the API, workers and CLI.

Verified: a representative profile/workflow/task template parses identically before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved template parsing security by using a safer YAML loading method, reducing the risk of executing unsafe content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->