### PR TITLE
fix(security): enforce generic target-scope allow-list on discovered targets

### DIFF
--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -4,6 +4,7 @@ import re
 from secator.config import CONFIG
 from secator.output_types import Error
 from secator.query.ast import substitute_ctx_constants
+from secator.scope import as_scope_list, host_in_scope
 from secator.utils import deduplicate, debug
 
 
@@ -124,6 +125,20 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		if combined:
 			debug('using scope-tagged targets as inputs', obj=combined, sub='extractors')
 			inputs = combined
+	# Enforce a generic target-scope allow/deny list on the resolved inputs. This is the
+	# single fan-in choke point every runner's inputs flow through (user-supplied AND
+	# dynamically discovered, e.g. subdomain_recon -> host_recon), so filtering here drops
+	# out-of-scope discovered targets before any downstream task acts on them. The API derives
+	# in_scope/out_of_scope from the run's authorized scope (mandate) and passes them as plain
+	# run-options; core stays authorization-agnostic. See secator/scope.py.
+	in_scope = as_scope_list(opts.get('in_scope'))
+	out_of_scope = as_scope_list(opts.get('out_of_scope'))
+	if inputs and (in_scope or out_of_scope):
+		kept = [t for t in inputs if host_in_scope(t, in_scope, out_of_scope)]
+		dropped = [t for t in inputs if t not in kept]
+		if dropped:
+			debug(f'dropped {len(dropped)} out-of-scope target(s): {dropped}', sub='scope')
+		inputs = kept
 	if computed_opts:
 		debug('computed_opts', obj=computed_opts, sub='extractors')
 	return inputs, opts, errors

--- a/secator/scope.py
+++ b/secator/scope.py
@@ -1,0 +1,141 @@
+"""Generic target-scope allow/deny filtering.
+
+secator core has NO concept of mandates, bug-bounty programs, or any platform
+authorization model — and it must not. This module is a neutral host/target
+scope matcher: given a target string and plain scope entries (a host, a
+``*.wildcard``, a CIDR, or a regex), decide whether the target is in scope.
+
+The platform (secator-api) derives the effective authorized scope from whatever
+authorization model it uses and passes it in as generic ``in_scope`` /
+``out_of_scope`` run-options. Core then enforces that allow-list on EVERY target
+it acts on — including subdomains discovered mid-scan (subdomain_recon output
+fed into host_recon) — closing the scope-escape where dynamically-discovered
+targets were never checked against the run's authorized scope.
+
+The matching rules here intentionally mirror the platform's own scope matcher so
+a target that the ingress gate would reject is dropped identically mid-scan. The
+two copies share no code (separate repos, and core stays authorization-agnostic
+by design); keep the semantics in sync — see ``test_scope.py`` for the shared
+vectors.
+"""
+
+import ipaddress
+import re
+from urllib.parse import urlparse
+
+
+def _looks_like_regex(entry: str) -> bool:
+	"""Heuristic: does this scope entry use regex metacharacters?
+
+	A plain host/wildcard/CIDR entry (``app.acme.com``, ``*.acme.com``,
+	``1.2.3.0/24``) is matched with the structural host/network logic below. An
+	entry containing regex metacharacters other than the ``*``/``.`` used by
+	wildcards/hostnames is treated as a regex and matched against the raw target.
+	"""
+	regex_meta = set("[](){}|+?^$\\")
+	return any(c in regex_meta for c in entry)
+
+
+def _entry_matches_regex(target: str, entry: str) -> bool:
+	"""True if `entry` is a regex that matches the raw target string."""
+	try:
+		return re.search(entry, target) is not None
+	except re.error:
+		return False
+
+
+def _host_of(target: str) -> str:
+	"""Extract a comparable host from a target string (url/host/domain)."""
+	t = target.strip()
+	if "://" in t:
+		return urlparse(t).hostname or ""
+	return t.split("/")[0].split(":")[0]
+
+
+def _as_network(value: str):
+	try:
+		return ipaddress.ip_network(value, strict=False)
+	except ValueError:
+		return None
+
+
+def target_in_scope(target: str, scope: list) -> bool:
+	"""True if target string is covered by any scope entry.
+
+	Each entry is treated as a single-or-regex value: a plain host/wildcard/CIDR
+	is matched structurally (exact host, ``*.wildcard`` subdomain, IP-in-CIDR,
+	CIDR-subnet-of), while an entry containing regex metacharacters is matched as
+	a regex against the raw target string.
+	"""
+	target = target.strip()
+	# Regex entries: match against the raw target first.
+	for entry in scope:
+		entry = entry.strip()
+		if _looks_like_regex(entry) and _entry_matches_regex(target, entry):
+			return True
+	target_net = _as_network(target) if ("/" in target or target.replace(".", "").isdigit()) else None
+	# IP/CIDR matching
+	for entry in scope:
+		entry = entry.strip()
+		if _looks_like_regex(entry):
+			continue
+		entry_net = _as_network(entry)
+		if entry_net is not None:
+			if target_net is not None:
+				if target_net.subnet_of(entry_net):
+					return True
+			else:
+				host = _host_of(target)
+				try:
+					if ipaddress.ip_address(host) in entry_net:
+						return True
+				except ValueError:
+					pass
+	# A pure IP/CIDR target only matches via network containment (handled above);
+	# never fall through to hostname matching, otherwise "1.2.3.0/24" and
+	# "1.2.3.0/25" would match as equal hostnames ("1.2.3.0").
+	if target_net is not None:
+		return False
+	# hostname matching
+	host = _host_of(target).lower().rstrip(".")
+	if not host:
+		return False
+	for entry in scope:
+		if _looks_like_regex(entry):
+			continue
+		e = _host_of(entry).lower().rstrip(".")
+		if e.startswith("*."):
+			base = e[2:]
+			if host.endswith("." + base):
+				return True
+		elif host == e:
+			return True
+	return False
+
+
+def as_scope_list(val):
+	"""Coerce a scope run-option into a list of entries.
+
+	Accepts ``None`` (-> ``[]``), a comma-separated string (CLI form), or a list.
+	"""
+	if not val:
+		return []
+	if isinstance(val, str):
+		return [v.strip() for v in val.split(",") if v.strip()]
+	return [str(v).strip() for v in val if str(v).strip()]
+
+
+def host_in_scope(target: str, in_scope=None, out_of_scope=None) -> bool:
+	"""Allow/deny decision for a single target. Deny wins.
+
+	- ``out_of_scope`` match  -> out (deny wins over allow).
+	- non-empty ``in_scope``  -> target must match an allow entry.
+	- empty ``in_scope``      -> allow-all (subject to deny).
+	"""
+	in_scope = as_scope_list(in_scope)
+	out_of_scope = as_scope_list(out_of_scope)
+	if out_of_scope and target_in_scope(target, out_of_scope):
+		return False
+	if in_scope:
+		return target_in_scope(target, in_scope)
+	return True

--- a/tests/unit/test_scope.py
+++ b/tests/unit/test_scope.py
@@ -1,0 +1,67 @@
+import unittest
+
+from secator.runners._helpers import run_extractors
+from secator.scope import as_scope_list, host_in_scope, target_in_scope
+
+
+class TestScopeMatcher(unittest.TestCase):
+	"""Semantics must mirror the platform (secator-api) mandate scope matcher."""
+
+	def test_apex_does_not_cover_subdomain(self):
+		# The bug: a scope of `claris.com` (apex only) must NOT cover discovered subdomains.
+		self.assertTrue(target_in_scope('claris.com', ['claris.com']))
+		self.assertFalse(target_in_scope('www.claris.com', ['claris.com']))
+
+	def test_wildcard_covers_subdomain(self):
+		self.assertTrue(target_in_scope('www.claris.com', ['*.claris.com']))
+		self.assertFalse(target_in_scope('claris.com', ['*.claris.com']))
+
+	def test_cidr_and_regex(self):
+		self.assertTrue(target_in_scope('10.0.0.5', ['10.0.0.0/24']))
+		self.assertFalse(target_in_scope('10.0.1.5', ['10.0.0.0/24']))
+		self.assertTrue(target_in_scope('https://api.acme.com/v1/', [r'^https?://api\.acme\.com/']))
+
+	def test_host_extracted_from_url(self):
+		self.assertTrue(target_in_scope('https://www.claris.com/login', ['*.claris.com']))
+
+	def test_deny_wins(self):
+		self.assertFalse(host_in_scope('secret.claris.com', ['*.claris.com'], ['secret.claris.com']))
+		self.assertTrue(host_in_scope('www.claris.com', ['*.claris.com'], ['secret.claris.com']))
+
+	def test_empty_in_scope_allows_all(self):
+		self.assertTrue(host_in_scope('anything.example', [], []))
+
+	def test_as_scope_list_coercion(self):
+		self.assertEqual(as_scope_list('a.com, b.com'), ['a.com', 'b.com'])
+		self.assertEqual(as_scope_list(['a.com', ' b.com ']), ['a.com', 'b.com'])
+		self.assertEqual(as_scope_list(None), [])
+
+
+class TestRunExtractorsScopeFilter(unittest.TestCase):
+	"""The fan-in choke point must drop out-of-scope discovered targets."""
+
+	def test_discovered_subdomain_filtered_against_allowlist(self):
+		# Simulates subdomain_recon feeding host_recon: claris.com in scope (apex only),
+		# www.claris.com discovered -> must be dropped before host_recon scans it.
+		discovered = ['claris.com', 'www.claris.com', 'api.claris.com']
+		inputs, _opts, errors = run_extractors(
+			[], {'in_scope': ['claris.com']}, inputs=discovered
+		)
+		self.assertEqual(errors, [])
+		self.assertEqual(inputs, ['claris.com'])
+
+	def test_wildcard_scope_keeps_subdomains(self):
+		discovered = ['claris.com', 'www.claris.com', 'evil.com']
+		inputs, _opts, _errors = run_extractors(
+			[], {'in_scope': ['*.claris.com', 'claris.com']}, inputs=discovered
+		)
+		self.assertEqual(sorted(inputs), ['claris.com', 'www.claris.com'])
+
+	def test_no_scope_option_is_noop(self):
+		discovered = ['claris.com', 'www.claris.com']
+		inputs, _opts, _errors = run_extractors([], {}, inputs=discovered)
+		self.assertEqual(sorted(inputs), ['claris.com', 'www.claris.com'])
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Problem

Domain scans discover subdomains via `subdomain_recon` and fan them into `host_recon` and the `url_*` workflows (`configs/scans/domain.yaml`: `host_recon.targets_: [{type: subdomain, field: host}]`). Those **dynamically-discovered** targets were never checked against any scope, so a run authorized for an apex only (e.g. `claris.com`, not `*.claris.com`) would still scan every discovered subdomain — a **scope escape**.

Core has no concept of the platform's mandates and must stay that way, so this adds a *generic* scope filter that the platform (secator-api) feeds.

## Fix

- **`secator/scope.py`** — neutral host allow/deny matcher (`host_in_scope`, `target_in_scope`). Rules (regex / CIDR / `*.` wildcard / exact host) mirror the platform matcher so a target the ingress gate would reject is dropped identically mid-scan. Deny wins; empty `in_scope` = allow-all (unchanged behavior).
- **`run_extractors`** (`secator/runners/_helpers.py`) — the single fan-in choke point every runner's inputs flow through. Filter resolved `inputs` (user-supplied **and** discovered) against `in_scope`/`out_of_scope` run-options; dropped targets logged under `debug(sub='scope')`. Run-options propagate scan→workflow→task verbatim, so `host_recon` gets the scope for free.

The platform side (deriving `in_scope`/`out_of_scope` from the mandate and injecting them) is a companion PR in **secator-api**.

## Tests

`tests/unit/test_scope.py` — matcher semantics (apex vs wildcard, CIDR, regex, deny-wins) + `run_extractors` dropping a discovered out-of-scope subdomain. All pass; no regression in extractor/helper tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible target-scope matching for hosts, subdomains, IP addresses, CIDR ranges, URLs, and regular expressions.
  * Added allowlists and denylists for controlling which resolved or discovered targets are processed.
  * Deny rules take precedence over allow rules, with safe handling of invalid scope values.

* **Bug Fixes**
  * Prevented out-of-scope inputs from being passed to extractors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->