### PR TITLE
feat(core): single-source target classifier (canonicalize + type + network reachability)

### DIFF
--- a/secator/utils.py
+++ b/secator/utils.py
@@ -10,6 +10,7 @@ import os
 import re
 import select
 import signal
+import socket
 import sys
 import tempfile
 import threading
@@ -18,7 +19,12 @@ import traceback
 import validators
 import warnings
 
+import dns.exception
+import dns.resolver
+import idna
+
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from functools import reduce
 from pathlib import Path
@@ -1061,6 +1067,179 @@ def validate_cidr_range(target):
 		return True
 	except ValueError:
 		return False
+
+
+# Network types that name a routable target (as opposed to slug / email / iban / ...).
+# HOST covers both bare hostnames and registrable domains (autodetect_type returns HOST for both).
+NETWORK_TYPES = (IP, CIDR_RANGE, HOST, HOST_PORT, URL)
+
+# Wildcard / regex markers. A token carrying any of these is a SCOPE entry (e.g. '*.example.com',
+# '.*\\.corp$'), never a concrete target, so classify_target must never call it a network target.
+# Fully anchored char-class, single bounded quantifier -> ReDoS-safe. `?`, `(`, `)`, `|` are NOT
+# listed because they legitimately appear in URLs (query strings); we fail closed on the rest.
+_SCOPE_META = re.compile(r'^.*[*\\^$\[\]].*$', re.DOTALL)
+
+
+@dataclass
+class TargetInfo:
+	"""Result of classify_target(). Single source of truth the API imports (never reimplement)."""
+	type: str          # autodetect_type() taxonomy: ip / cidr_range / host / url / slug / email / ...
+	is_network: bool    # ip|cidr: valid by construction (no DNS). host|url: DNS resolved. else False.
+	root: str           # url -> hostname ; cidr -> network address ; else the (canonical) token
+	reachable: bool     # ip|cidr: validity. host|url: DNS success. else False.
+
+
+def canonicalize_target(raw):
+	"""Normalize a single raw target token to the form a scanner/resolver would actually hit.
+
+	This closes classification-smuggling gaps: alternate IPv4 encodings (decimal 2130706433,
+	octal 0177.0.0.1, short 127.1, hex 0x7f.0.0.1 -- all via inet_aton semantics), IDNA/Unicode
+	hostnames, bracketed IPv6, and surrounding whitespace all collapse to their canonical string
+	BEFORE type detection runs. Pure function, no network I/O.
+
+	Args:
+		raw (str): A single target token (not a list -- use split_targets first).
+
+	Returns:
+		str: Canonical target string.
+	"""
+	if raw is None:
+		return ''
+	token = str(raw).strip()
+	if not token:
+		return ''
+
+	# Strip IPv6 brackets on a bare bracketed address: [2001:db8::1] -> 2001:db8::1.
+	# A bracket+port form ([::1]:443) is left untouched: unbracketing it is ambiguous (that is
+	# exactly why brackets exist), so it falls through to classify as non-network (fail closed).
+	if token.startswith('[') and token.endswith(']'):
+		token = token[1:-1]
+
+	# Alternate IPv4 encodings -> dotted-quad, using inet_aton (same parser nmap/ping/libc use).
+	# Only numeric-ish tokens reach a match; hostnames and out-of-range ints raise and fall through.
+	try:
+		token = socket.inet_ntoa(socket.inet_aton(token))
+		return token
+	except OSError:
+		pass
+
+	# IDNA-encode Unicode hostnames (bare host or URL netloc) to punycode.
+	if not token.isascii():
+		token = _idna_encode(token)
+
+	return token
+
+
+def _idna_encode(token):
+	"""Best-effort IDNA (punycode) encoding of a Unicode host or URL netloc. Pure, no I/O."""
+	scheme = rest = ''
+	host = token
+	if '://' in token:
+		scheme, _, after = token.partition('://')
+		scheme += '://'
+		# split host from path/query/port
+		slash = after.find('/')
+		host, rest = (after, '') if slash == -1 else (after[:slash], after[slash:])
+	try:
+		encoded = idna.encode(host, uts46=True).decode('ascii')
+	except (idna.IDNAError, UnicodeError):
+		return token  # not a valid IDN host -> leave as-is (will classify non-network)
+	return f'{scheme}{encoded}{rest}'
+
+
+def split_targets(raw):
+	"""Split a raw multi-target input into individual tokens on comma AND newline.
+
+	Consolidates the two split styles core already used ad hoc (CLI split(',') and stdin/file
+	splitlines()) into one reusable, whitespace-trimming, empty-dropping helper.
+
+	Args:
+		raw (str | list): Raw input, possibly containing commas and/or newlines, or a list thereof.
+
+	Returns:
+		list[str]: Non-empty, stripped tokens.
+	"""
+	if raw is None:
+		return []
+	if isinstance(raw, (list, tuple)):
+		out = []
+		for item in raw:
+			out.extend(split_targets(item))
+		return out
+	# Char-class split, no backtracking -> ReDoS-safe.
+	return [t.strip() for t in re.split(r'[,\n]', str(raw)) if t.strip()]
+
+
+def _resolve_host(host, timeout):
+	"""DNS-resolve a hostname (A then AAAA) with a short timeout. Network I/O.
+
+	Returns:
+		bool: True if it resolves, False on NXDOMAIN / no answer / timeout / any DNS error.
+	"""
+	if not host:
+		return False
+	resolver = dns.resolver.Resolver()
+	resolver.timeout = timeout
+	resolver.lifetime = timeout
+	for rdtype in ('A', 'AAAA'):
+		try:
+			resolver.resolve(host, rdtype)
+			return True
+		except dns.resolver.NoAnswer:
+			continue  # no A record, try AAAA
+		except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers, dns.exception.DNSException):
+			return False
+	return False
+
+
+def _target_host(canonical, ttype):
+	"""Extract the DNS-resolvable host from a canonical url / host / host:port token. Pure."""
+	if ttype == URL:
+		return (urlparse(canonical).hostname or '')
+	if ttype == HOST_PORT:
+		return canonical.rsplit(':', 1)[0]
+	return canonical
+
+
+def classify_target(token, *, resolve=True, timeout=2.0):
+	"""Classify a single target token. THE single-source classifier -- callers must not reimplement.
+
+	Type detection reuses the pure regex `autodetect_type`; all network I/O lives here behind
+	`resolve=True`. With `resolve=False` this is a pure no-I/O path (host/url reachability is left
+	False/unknown; ip/cidr are still resolved by construction).
+
+	Args:
+		token (str): A single target token (use split_targets first for multi-target input).
+		resolve (bool): If True, DNS-resolve host/url targets. If False, no network I/O at all.
+		timeout (float): Per-query DNS timeout in seconds (short; server-side safe).
+
+	Returns:
+		TargetInfo: {type, is_network, root, reachable}.
+	"""
+	canonical = canonicalize_target(token)
+	ttype = autodetect_type(canonical)
+	info = TargetInfo(type=ttype, is_network=False, root=canonical, reachable=False)
+
+	# Non-network types (slug/email/iban/uuid/path/mac/...) and scope entries (wildcard/regex,
+	# which fail closed) keep the False defaults.
+	if ttype not in NETWORK_TYPES or _SCOPE_META.match(canonical):
+		return info
+
+	if ttype == IP:
+		# Validity already proven by autodetect_type (validators/ipaddress) -- no DNS needed.
+		info.is_network = info.reachable = True
+	elif ttype == CIDR_RANGE:
+		info.root = str(ipaddress.ip_network(canonical, strict=False).network_address)
+		info.is_network = info.reachable = True
+	elif ttype in (URL, HOST, HOST_PORT):
+		if ttype == URL:
+			info.root = _target_host(canonical, ttype)
+		if resolve:
+			ok = _resolve_host(_target_host(canonical, ttype), timeout)
+			info.is_network = info.reachable = ok
+		# resolve=False -> pure path: leave is_network/reachable False (unverified).
+
+	return info
 
 
 def get_versions_from_string(string):

--- a/secator/utils.py
+++ b/secator/utils.py
@@ -1073,12 +1073,6 @@ def validate_cidr_range(target):
 # HOST covers both bare hostnames and registrable domains (autodetect_type returns HOST for both).
 NETWORK_TYPES = (IP, CIDR_RANGE, HOST, HOST_PORT, URL)
 
-# Wildcard / regex markers. A token carrying any of these is a SCOPE entry (e.g. '*.example.com',
-# '.*\\.corp$'), never a concrete target, so classify_target must never call it a network target.
-# Fully anchored char-class, single bounded quantifier -> ReDoS-safe. `?`, `(`, `)`, `|` are NOT
-# listed because they legitimately appear in URLs (query strings); we fail closed on the rest.
-_SCOPE_META = re.compile(r'^.*[*\\^$\[\]].*$', re.DOTALL)
-
 
 @dataclass
 class TargetInfo:
@@ -1109,11 +1103,13 @@ def canonicalize_target(raw):
 	if not token:
 		return ''
 
-	# Strip IPv6 brackets on a bare bracketed address: [2001:db8::1] -> 2001:db8::1.
-	# A bracket+port form ([::1]:443) is left untouched: unbracketing it is ambiguous (that is
-	# exactly why brackets exist), so it falls through to classify as non-network (fail closed).
-	if token.startswith('[') and token.endswith(']'):
-		token = token[1:-1]
+	# Strip IPv6 brackets, keeping any :port, but ONLY when the bracketed content is a real IP
+	# literal (what brackets are for): [2001:db8::1] -> 2001:db8::1 , [2001:db8::1]:443 ->
+	# 2001:db8::1:443. A non-IP like [a-z].example.com keeps its brackets -> caught as a scope entry.
+	if token.startswith('['):
+		end = token.find(']')
+		if end != -1 and _is_ip_literal(token[1:end]):
+			token = token[1:end] + token[end + 1:]
 
 	# Alternate IPv4 encodings -> dotted-quad, using inet_aton (same parser nmap/ping/libc use).
 	# Only numeric-ish tokens reach a match; hostnames and out-of-range ints raise and fall through.
@@ -1192,6 +1188,15 @@ def _resolve_host(host, timeout):
 	return False
 
 
+def _is_ip_literal(host):
+	"""True if host is a v4 or v6 IP literal. Pure -- ipaddress does no DNS."""
+	try:
+		ipaddress.ip_address(host)
+		return True
+	except ValueError:
+		return False
+
+
 def _target_host(canonical, ttype):
 	"""Extract the DNS-resolvable host from a canonical url / host / host:port token. Pure."""
 	if ttype == URL:
@@ -1220,9 +1225,10 @@ def classify_target(token, *, resolve=True, timeout=2.0):
 	ttype = autodetect_type(canonical)
 	info = TargetInfo(type=ttype, is_network=False, root=canonical, reachable=False)
 
-	# Non-network types (slug/email/iban/uuid/path/mac/...) and scope entries (wildcard/regex,
-	# which fail closed) keep the False defaults.
-	if ttype not in NETWORK_TYPES or _SCOPE_META.match(canonical):
+	# Non-network types keep the False defaults. This also fails scope entries closed: wildcard /
+	# regex forms (*.example.com, .*\.corp$, [a-z].example.com) are rejected by autodetect_type's
+	# strict validators to STRING, so they are never in NETWORK_TYPES.
+	if ttype not in NETWORK_TYPES:
 		return info
 
 	if ttype == IP:
@@ -1232,12 +1238,17 @@ def classify_target(token, *, resolve=True, timeout=2.0):
 		info.root = str(ipaddress.ip_network(canonical, strict=False).network_address)
 		info.is_network = info.reachable = True
 	elif ttype in (URL, HOST, HOST_PORT):
+		host = _target_host(canonical, ttype)
 		if ttype == URL:
-			info.root = _target_host(canonical, ttype)
-		if resolve:
-			ok = _resolve_host(_target_host(canonical, ttype), timeout)
+			info.root = host
+		if _is_ip_literal(host):
+			# An IP literal hiding in url/host:port (8.8.8.8:443, http://8.8.8.8/) is network
+			# BY CONSTRUCTION -- never gate its network-ness on DNS (it won't resolve as a name).
+			info.is_network = info.reachable = True
+		elif resolve:
+			ok = _resolve_host(host, timeout)
 			info.is_network = info.reachable = ok
-		# resolve=False -> pure path: leave is_network/reachable False (unverified).
+		# genuine hostname + resolve=False -> pure path: leave is_network/reachable False (unverified).
 
 	return info
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -154,6 +154,114 @@ Content-Type: text/html"""
 		self.assertEqual(result, {})
 
 
+from unittest import mock
+import dns.resolver
+from secator.utils import canonicalize_target, split_targets, classify_target
+
+
+class TestCanonicalizeTarget(unittest.TestCase):
+	def test_canonicalize_and_classify_network_forms(self):
+		# (raw, expected canonical, expected type) -- all must canonicalize to the real host
+		# and classify as a network type. Covers the smuggling vectors + IDN + bracketed IPv6.
+		cases = [
+			(' 1.2.3.4', '1.2.3.4', IP),          # whitespace
+			('2130706433', '127.0.0.1', IP),      # decimal inet_aton
+			('0177.0.0.1', '127.0.0.1', IP),      # octal
+			('127.1', '127.0.0.1', IP),           # short form
+			('0x7f.0.0.1', '127.0.0.1', IP),      # hex
+			('täst.de', 'xn--tst-qla.de', HOST),  # IDN host -> punycode
+			('[2001:db8::1]', '2001:db8::1', IP),  # bracketed IPv6
+		]
+		for raw, canon, ttype in cases:
+			with self.subTest(raw=raw):
+				self.assertEqual(canonicalize_target(raw), canon)
+				# resolve=False keeps it pure; type detection still sees the canonical (network) form.
+				self.assertEqual(classify_target(raw, resolve=False).type, ttype)
+
+	def test_canonicalize_empty(self):
+		self.assertEqual(canonicalize_target('  '), '')
+		self.assertEqual(canonicalize_target(None), '')
+
+
+class TestSplitTargets(unittest.TestCase):
+	def test_split_on_comma_and_newline(self):
+		self.assertEqual(
+			split_targets('a.com,b.com\n1.2.3.4 , \n c.com'),
+			['a.com', 'b.com', '1.2.3.4', 'c.com'],
+		)
+		self.assertEqual(split_targets(['a.com,b.com', 'c.com']), ['a.com', 'b.com', 'c.com'])
+		self.assertEqual(split_targets(''), [])
+
+
+class TestClassifyTarget(unittest.TestCase):
+	def test_type_detection(self):
+		# type mirrors autodetect_type across network + one non-network example
+		cases = [
+			('1.2.3.4', IP),
+			('192.168.1.0/24', CIDR_RANGE),
+			('example.com', HOST),               # registrable domain -> HOST
+			('sub.example.com', HOST),           # bare hostname -> HOST
+			('https://example.com/path', URL),
+			('test@example.com', EMAIL),         # non-network
+		]
+		for token, ttype in cases:
+			with self.subTest(token=token):
+				self.assertEqual(classify_target(token, resolve=False).type, ttype)
+
+	def test_ip_cidr_network_by_construction_no_dns(self):
+		# ip/cidr are network+reachable WITHOUT any DNS call, even with resolve=True.
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=AssertionError('DNS called')):
+			ip = classify_target('1.2.3.4', resolve=True)
+			self.assertTrue(ip.is_network and ip.reachable)
+			self.assertEqual(ip.root, '1.2.3.4')
+			cidr = classify_target('10.0.0.0/8', resolve=True)
+			self.assertTrue(cidr.is_network and cidr.reachable)
+			self.assertEqual(cidr.root, '10.0.0.0')  # cidr root = network address
+
+	def test_is_network_dns_resolves(self):
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', return_value=mock.MagicMock()) as m:
+			info = classify_target('example.com', resolve=True)
+			self.assertTrue(info.is_network and info.reachable)
+			m.assert_called()
+
+	def test_is_network_dns_nxdomain(self):
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=dns.resolver.NXDOMAIN):
+			info = classify_target('nope.invalid', resolve=True)
+			self.assertFalse(info.is_network)
+			self.assertFalse(info.reachable)
+
+	def test_url_root_is_hostname_and_resolves(self):
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', return_value=mock.MagicMock()):
+			info = classify_target('https://sub.example.com:8443/a?b=c', resolve=True)
+			self.assertEqual(info.root, 'sub.example.com')
+			self.assertTrue(info.is_network)
+
+	def test_resolve_false_is_pure_no_io(self):
+		# The pure path must NOT touch DNS: a resolver that raises if called proves it.
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=AssertionError('DNS called')):
+			host = classify_target('example.com', resolve=False)
+			self.assertEqual(host.type, HOST)
+			self.assertFalse(host.is_network)  # unverified without DNS
+			# autodetect_type itself is pure regex -> also must not call DNS
+			self.assertEqual(autodetect_type('example.com'), HOST)
+
+	def test_scope_and_near_miss_forms_never_network(self):
+		# Adversarial: wildcard/regex scope entries and near-miss junk must classify non-network,
+		# never smuggled in as a network target.
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', return_value=mock.MagicMock()):
+			for token in [
+				'*.example.com',      # wildcard scope
+				'.*\\.corp$',         # regex scope
+				'example.*',
+				'[a-z].example.com',  # char-class
+				'exa mple.com',       # space
+				'[::1]:443',          # bracketed IPv6 + port -> ambiguous, fail closed
+			]:
+				with self.subTest(token=token):
+					self.assertFalse(classify_target(token, resolve=True).is_network,
+						f'{token} slipped through as network')
+
+
 from secator.utils import remove_duplicates
 from secator.output_types import Vulnerability
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -255,11 +255,27 @@ class TestClassifyTarget(unittest.TestCase):
 				'example.*',
 				'[a-z].example.com',  # char-class
 				'exa mple.com',       # space
-				'[::1]:443',          # bracketed IPv6 + port -> ambiguous, fail closed
 			]:
 				with self.subTest(token=token):
 					self.assertFalse(classify_target(token, resolve=True).is_network,
 						f'{token} slipped through as network')
+
+	def test_ip_literal_host_is_network_no_dns(self):
+		# Fail-open regression: an IP literal hiding in host:port / [IPv6]:port / URL host is a
+		# concrete target the scanner WILL hit -> must be network BY CONSTRUCTION, never via DNS.
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=AssertionError('DNS called')):
+			for token in [
+				'8.8.8.8:443',
+				'192.168.1.1:22',
+				'[2001:db8::1]:443',   # canonicalizes to a valid IPv6 literal
+				'2001:db8::1:443',     # bare 8-group IPv6 literal
+				'http://8.8.8.8:443/',  # URL whose host is an IPv4 literal
+				'https://[2001:db8::1]/',  # URL whose host is a bracketed IPv6 literal
+			]:
+				with self.subTest(token=token):
+					info = classify_target(token, resolve=True)
+					self.assertTrue(info.is_network and info.reachable,
+						f'{token} was NOT classified network by construction')
 
 
 from secator.utils import remove_duplicates


### PR DESCRIPTION
**PR 1/5** of the platform target-scoping rework. Foundation only — no gate/behavior change yet; the API (PR3) imports this as the single source of truth.

## What it adds (`secator/utils.py`)
- `canonicalize_target(raw)` — pure: normalizes to what a scanner/resolver actually hits (alternate IPv4 via `inet_aton`: decimal/octal/short/hex; IDNA Unicode hosts; IPv6 brackets). This is what defeats classification-smuggling — the classifier's "valid IP" == the scanner's.
- `split_targets(raw)` — comma+newline split (consolidates the two ad-hoc splitters core had).
- `classify_target(token, *, resolve=True, timeout=2.0) -> TargetInfo{type, is_network, root, reachable}` — the contract the API imports.

## Security posture
- **No hand-rolled IP/CIDR regex** — `ipaddress`/`inet_aton`/`validators`/`tldextract`.
- **IP literals are network by construction, never via DNS** (v4/v6, with/without port, bracketed, URL-host) — closes a fail-open escape found in review (`8.8.8.8:443` was being let through). Only genuine hostnames resolve.
- **Fail-safe direction:** ambiguous/scope/junk (`*.x`, `.*\.corp$`, `[a-z].x`, `a|b`) classify **non-network** — scope entries are never valid targets.
- `autodetect_type` left **pure** (no network I/O); resolving lives only behind `classify_target(resolve=True)`, proven by a resolver-raises test.

## Tests
24/24 pass, incl. adversarial: smuggling/IDN/bracket forms, IP-literal-no-DNS, scope-never-network (with DNS mocked to succeed), purity assertion.

## Reviewer notes (mine)
Reviewed the diff + re-ran the adversarial cases live. Found & bounced one fail-open escape (IP:port), now fixed at root cause; the agent also removed a `_SCOPE_META` guard that was itself mis-flagging legit `https://[IPv6]/` URLs. `host`/`domain` both map to core's `HOST` — the API will derive the host↔domain distinction via `tldextract` root (PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)