### PR TITLE
fix(core): canonicalize [IPv6]:port without absorbing the port into the address

### DIFF
--- a/secator/utils.py
+++ b/secator/utils.py
@@ -1010,16 +1010,34 @@ def is_host_port(target):
 	Returns:
 		bool: True if the target is a host:port, False otherwise.
 	"""
-	split = target.split(':')
-	if not (validators.domain(split[0]) or validators.ipv4(split[0]) or validators.ipv6(split[0]) or split[0] == 'localhost'):  # noqa: E501
+	host, port = _split_host_port(target)
+	if not port:
+		return False
+	if not (validators.domain(host) or validators.ipv4(host) or validators.ipv6(host) or host == 'localhost'):
 		return False
 	try:
-		port = int(split[1])
+		port = int(port)
 		if port < 1 or port > 65535:
 			return False
 	except ValueError:
 		return False
 	return True
+
+
+def _split_host_port(target):
+	"""Split a host:port token into (host, port_str), unwrapping a bracketed IPv6 host.
+
+	[2001:db8::1]:443 -> ('2001:db8::1', '443') -- the brackets, not the last colon, delimit the
+	host, since an IPv6 literal contains colons of its own. A bare hostname/IP with no port yields
+	(host, ''). Pure, no I/O.
+	"""
+	if target.startswith('[') and ']:' in target:
+		host, _, port = target[1:].partition(']:')
+		return host, port
+	host, sep, port = target.rpartition(':')
+	if not sep:
+		return port, ''  # no colon -> rpartition puts the whole token in the last field
+	return host, port
 
 
 def autodetect_type(target):
@@ -1103,13 +1121,16 @@ def canonicalize_target(raw):
 	if not token:
 		return ''
 
-	# Strip IPv6 brackets, keeping any :port, but ONLY when the bracketed content is a real IP
-	# literal (what brackets are for): [2001:db8::1] -> 2001:db8::1 , [2001:db8::1]:443 ->
-	# 2001:db8::1:443. A non-IP like [a-z].example.com keeps its brackets -> caught as a scope entry.
+	# Bracketed IPv6, but ONLY when the bracketed content is a real IP literal (what brackets are for).
+	# Bare [2001:db8::1] -> 2001:db8::1 (brackets unwrapped). With a trailing :port the brackets are
+	# the canonical RFC 3986 host:port separator and MUST be kept -- unwrapping [2001:db8::1]:443 to
+	# 2001:db8::1:443 re-parses as a DIFFERENT valid IPv6 (443 becomes a hextet), absorbing the port.
+	# So keep the bracketed form and let is_host_port / _target_host split host from port.
+	# A non-IP like [a-z].example.com keeps its brackets -> caught as a scope entry.
 	if token.startswith('['):
 		end = token.find(']')
-		if end != -1 and _is_ip_literal(token[1:end]):
-			token = token[1:end] + token[end + 1:]
+		if end != -1 and _is_ip_literal(token[1:end]) and token[end + 1:] == '':
+			token = token[1:end]
 
 	# Alternate IPv4 encodings -> dotted-quad, using inet_aton (same parser nmap/ping/libc use).
 	# Only numeric-ish tokens reach a match; hostnames and out-of-range ints raise and fall through.
@@ -1202,7 +1223,7 @@ def _target_host(canonical, ttype):
 	if ttype == URL:
 		return (urlparse(canonical).hostname or '')
 	if ttype == HOST_PORT:
-		return canonical.rsplit(':', 1)[0]
+		return _split_host_port(canonical)[0]
 	return canonical
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -156,7 +156,7 @@ Content-Type: text/html"""
 
 from unittest import mock
 import dns.resolver
-from secator.utils import canonicalize_target, split_targets, classify_target
+from secator.utils import canonicalize_target, split_targets, classify_target, _target_host
 
 
 class TestCanonicalizeTarget(unittest.TestCase):
@@ -170,7 +170,11 @@ class TestCanonicalizeTarget(unittest.TestCase):
 			('127.1', '127.0.0.1', IP),           # short form
 			('0x7f.0.0.1', '127.0.0.1', IP),      # hex
 			('täst.de', 'xn--tst-qla.de', HOST),  # IDN host -> punycode
-			('[2001:db8::1]', '2001:db8::1', IP),  # bracketed IPv6
+			('[2001:db8::1]', '2001:db8::1', IP),  # bracketed IPv6, no port -> unwrapped
+			# Bracketed IPv6 WITH a port: brackets kept as the host:port delimiter (RFC 3986). They
+			# must NOT be dropped -- '2001:db8::1:443' is a DIFFERENT valid IPv6 (443 as a hextet).
+			('[2001:db8::1]:443', '[2001:db8::1]:443', HOST_PORT),
+			('[::1]:80', '[::1]:80', HOST_PORT),
 		]
 		for raw, canon, ttype in cases:
 			with self.subTest(raw=raw):
@@ -267,8 +271,9 @@ class TestClassifyTarget(unittest.TestCase):
 			for token in [
 				'8.8.8.8:443',
 				'192.168.1.1:22',
-				'[2001:db8::1]:443',   # canonicalizes to a valid IPv6 literal
-				'2001:db8::1:443',     # bare 8-group IPv6 literal
+				'[2001:db8::1]:443',   # bracketed IPv6 + port -> host:port over an IPv6 literal
+				'[::1]:80',            # loopback IPv6 + port
+				'2001:db8::1:443',     # bare 8-group IPv6 literal (distinct from the bracketed form)
 				'http://8.8.8.8:443/',  # URL whose host is an IPv4 literal
 				'https://[2001:db8::1]/',  # URL whose host is a bracketed IPv6 literal
 			]:
@@ -276,6 +281,22 @@ class TestClassifyTarget(unittest.TestCase):
 					info = classify_target(token, resolve=True)
 					self.assertTrue(info.is_network and info.reachable,
 						f'{token} was NOT classified network by construction')
+
+	def test_bracketed_ipv6_with_port_keeps_host_and_port_distinct(self):
+		# The port must NOT be absorbed into the address: [2001:db8::1]:443 must extract host
+		# 2001:db8::1, NOT the different valid IPv6 2001:db8::1:443 (443 smuggled in as a hextet).
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=AssertionError('DNS called')):
+			for token, real_host, absorbed in [
+				('[2001:db8::1]:443', '2001:db8::1', '2001:db8::1:443'),
+				('[::1]:80', '::1', '::1:80'),
+			]:
+				with self.subTest(token=token):
+					info = classify_target(token, resolve=True)
+					self.assertEqual(info.type, HOST_PORT)
+					self.assertTrue(info.is_network and info.reachable)  # IP literal -> no DNS
+					host = _target_host(canonicalize_target(token), info.type)
+					self.assertEqual(host, real_host)
+					self.assertNotEqual(host, absorbed)
 
 
 from secator.utils import remove_duplicates


### PR DESCRIPTION
Fast-follow to #1345. `canonicalize_target('[2001:db8::1]:443')` stripped brackets to `2001:db8::1:443` — a *different* valid IPv6 (443 became a hextet), mangling the host. Now the brackets are preserved as the RFC-3986 host:port delimiter (unwrapped only when there's no trailing port), a shared `_split_host_port` splits `]:` for the bracketed form (used by both `is_host_port` and `_target_host`), so `[2001:db8::1]:443` → `host:port`, network by construction (no DNS), host = the real `2001:db8::1`. Bare IPv6 / IPv4:port / hostname:port / `https://[IPv6]/` unchanged. Reviewed + re-verified live; 25 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)