### PR TITLE
test(core): prove scope inheritance to discovered targets + close producer gap

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -422,6 +422,13 @@ def mark_runner_started(results, runner, enable_hooks=True):
 		target_extractor_opts = {
 			k: v for k, v in runner.dynamic_opts.items() if k.rstrip('_') == 'targets'
 		}
+		# Inherit the run's scope so this dynamic-spawn producer emits only in-scope scope-tagged
+		# Targets (subdomain_recon -> host_recon fan-out). Consumers re-filter via the same
+		# host_in_scope choke point in run_extractors, but filtering here keeps out-of-scope
+		# discovered targets out of the store entirely. See secator/runners/_helpers.py.
+		for k in ('in_scope', 'out_of_scope'):
+			if runner.run_opts.get(k):
+				target_extractor_opts[k] = runner.run_opts[k]
 		# Start from the runner's full store-resolution context (preserves run-scoping keys like
 		# parent_scope, workspace_id, drivers, {type}_id) so the local/json driver scopes correctly,
 		# then overlay only the extractor-specific values.

--- a/secator/celery.py
+++ b/secator/celery.py
@@ -422,10 +422,7 @@ def mark_runner_started(results, runner, enable_hooks=True):
 		target_extractor_opts = {
 			k: v for k, v in runner.dynamic_opts.items() if k.rstrip('_') == 'targets'
 		}
-		# Inherit the run's scope so this dynamic-spawn producer emits only in-scope scope-tagged
-		# Targets (subdomain_recon -> host_recon fan-out). Consumers re-filter via the same
-		# host_in_scope choke point in run_extractors, but filtering here keeps out-of-scope
-		# discovered targets out of the store entirely. See secator/runners/_helpers.py.
+		# Inherit scope so discovered targets are filtered before they're stored.
 		for k in ('in_scope', 'out_of_scope'):
 			if runner.run_opts.get(k):
 				target_extractor_opts[k] = runner.run_opts[k]

--- a/secator/scope.py
+++ b/secator/scope.py
@@ -1,40 +1,14 @@
-"""Generic target-scope allow/deny filtering.
+"""Match a target against ``in_scope`` / ``out_of_scope`` allow/deny lists.
 
-secator core has NO concept of mandates, bug-bounty programs, or any platform
-authorization model -- and it must not. This module is a neutral host/target
-scope matcher: given a target string and plain scope entries (a host, a
-``*.wildcard``, a CIDR, or an anchored regex), decide whether the target is in
-scope.
+Pure, no network I/O (parsing via ``classify_target(resolve=False)``). Only
+network targets (ip/cidr/host/host:port/url) are checked; non-network items
+(email, username, path, ...) are always kept. Deny wins; empty ``in_scope`` =
+allow-all (subject to deny).
 
-The platform (secator-api) derives the effective authorized scope from whatever
-authorization model it uses and passes it in as generic ``in_scope`` /
-``out_of_scope`` run-options. Core then enforces that allow-list on EVERY target
-it acts on -- including subdomains discovered mid-scan (subdomain_recon output
-fed into host_recon) -- closing the scope-escape where dynamically-discovered
-targets were never checked against the run's authorized scope.
-
-The matching rules here intentionally mirror the platform's own scope matcher so
-a target that the ingress gate would reject is dropped identically mid-scan. The
-API imports THIS module rather than forking it, so the matcher stays pure and
-dependency-light: it does NO network I/O (target parsing runs through the shared
-``classify_target(..., resolve=False)`` classifier -- see ``secator/utils.py``).
-
-Semantics (see ``host_in_scope``):
-- Only NETWORK targets (ip / cidr / host / host:port / url) are scope-checked.
-A non-network discovered item (email, username, path, uuid, ...) is never
-subject to scope and is always kept -- this matcher gates scan INPUTS, not
-finding emission.
-- deny wins: any ``out_of_scope`` match drops the target regardless of allow.
-- empty ``in_scope`` means allow-all (subject to deny).
-
-Scope entry kinds:
-- IP / CIDR: ``ipaddress`` containment (v4 AND v6). An IP target inside a CIDR
-entry; a CIDR target that is ``subnet_of`` the entry.
-- exact host: canonical-host equality (``app.acme.com``).
-- wildcard: ``*.acme.com`` matches sub-domains only; the apex ``acme.com`` is
-NOT covered (add it as its own entry).
-- regex: ``re.fullmatch``-ANCHORED (both ends). ``acme\\.com`` does NOT match
-``evil-acme.com.attacker.net``. Author regex are scope entries, never targets.
+Entry kinds: IP/CIDR (``ipaddress`` containment, v4+v6, ``subnet_of``); exact
+host; ``*.acme.com`` wildcard (sub-domains only, not the apex); ``re.fullmatch``-
+anchored regex (``acme\\.com`` never matches ``evil-acme.com.x``). Regexes are
+scope entries, never targets.
 """
 
 import ipaddress

--- a/tests/unit/test_scope_inheritance.py
+++ b/tests/unit/test_scope_inheritance.py
@@ -1,0 +1,123 @@
+"""Linchpin test for PR3 of the target-scoping rework.
+
+Run-scope (`in_scope`/`out_of_scope`) set on a ROOT runner's run_opts must reach EVERY descendant
+runner (scan -> workflow -> task, including the dynamically-spawned fan-out where one task
+discovers targets another task then scans, e.g. subdomain_recon -> host_recon) and DROP the
+out-of-scope discovered targets before they are actively scanned -- while an unset scope leaves CLI
+behaviour unchanged (allow-all).
+
+This exercises the real celery build+execute path in sync mode (same harness as
+test_target_filter_scope / #1328): `discovertask` stands in for a recon step that DISCOVERS targets,
+`consumetask` stands in for the downstream active task that resolves those discovered Targets as its
+own scan inputs. The filter is applied in `run_extractors` (secator/runners/_helpers.py), the single
+scan-input choke point; finding emission (the Targets a task yields) is NOT gated.
+"""
+import unittest
+from unittest.mock import patch
+
+from secator.decorators import task
+from secator.output_types import Target
+from secator.runners import Scan
+from secator.runners.command import Command
+from secator.template import TemplateLoader
+
+
+# What each downstream (active) task resolved its scan inputs to, after scope filtering.
+RESOLVED = {}
+
+# A recon step "discovers" these: one in-scope subdomain + one out-of-scope host it found (e.g. in
+# JS/HTML/a cert). Reporting it as a finding is fine; feeding it as an active-scan input is not.
+DISCOVERED = ['api.acme.test', 'evil.attacker.test']
+
+
+@task()
+class discovertask(Command):
+	"""Recon stand-in: emits discovered Targets regardless of its own inputs."""
+	cmd = 'true'
+	input_types = []  # accept any input
+	output_types = [Target]
+
+	def yielder(self):
+		for name in DISCOVERED:
+			yield Target(name=name)
+
+
+@task()
+class consumetask(Command):
+	"""Active-task stand-in: resolves upstream discovered Targets as its scan inputs (scope filter is
+	applied in _run_extractors) and records exactly what it would actively scan."""
+	cmd = 'true'
+	input_types = []
+	output_types = [Target]
+
+	def _run_extractors(self):
+		super()._run_extractors()
+		RESOLVED[self.unique_name] = sorted(self.inputs)
+
+	def yielder(self):
+		for name in self.inputs:
+			yield Target(name=name)
+
+
+def _wf(name, task_name, task_node, task_targets_=None):
+	opts = {'targets_': task_targets_} if task_targets_ is not None else {}
+	return TemplateLoader(input={
+		'type': 'workflow', 'name': name,
+		'tasks': {f'{task_name}/{task_node}': opts},
+	})
+
+
+class TestScopeInheritance(unittest.TestCase):
+
+	ROOT = ['acme.test']  # a network root that is itself in scope (exact host)
+
+	def setUp(self):
+		"""Register the mock tasks and serve inline workflow templates by name."""
+		RESOLVED.clear()
+		import secator.runners.task as task_mod
+		import secator.loader as loader_mod
+		self._orig_discover = task_mod.discover_tasks
+		task_mod.discover_tasks = lambda: list(self._orig_discover()) + [discovertask, consumetask]
+		# wf1 discovers targets; wf2 (scan-level targets_) consumes them via parent_scope, which is
+		# the dynamically-spawned fan-out the scope must reach.
+		self._templates = [
+			_wf('wf1', 'discovertask', 'recon'),
+			_wf('wf2', 'consumetask', 'active', {'type': 'target', 'field': 'name'}),
+		]
+		self._patch_ft = patch.object(loader_mod, 'find_templates', side_effect=lambda: self._templates)
+		self._patch_ft.start()
+
+	def tearDown(self):
+		import secator.runners.task as task_mod
+		task_mod.discover_tasks = self._orig_discover
+		self._patch_ft.stop()
+
+	def _run(self, run_opts):
+		scan_cfg = TemplateLoader(input={
+			'type': 'scan', 'name': 'myscan',
+			'workflows': {'wf1': {}, 'wf2': {'targets_': {'type': 'target', 'field': 'name'}}},
+		})
+		scan = Scan(scan_cfg, self.ROOT, run_opts={'sync': True, **run_opts}, context={})
+		list(scan)
+		return [inp for uname, inp in RESOLVED.items() if uname.startswith('consumetask_active')]
+
+	def test_out_of_scope_discovered_target_is_dropped(self):
+		"""in_scope inherited from the scan reaches the downstream active task and drops the
+		out-of-scope discovered target before it is scanned (the linchpin)."""
+		results = self._run({'in_scope': ['acme.test', '*.acme.test']})
+		self.assertTrue(results, 'downstream active task never executed')
+		for inputs in results:
+			self.assertIn('api.acme.test', inputs)        # in-scope discovered target kept
+			self.assertNotIn('evil.attacker.test', inputs)  # out-of-scope discovered target dropped
+
+	def test_no_scope_allows_all(self):
+		"""No scope set -> allow-all: CLI behaviour unchanged, out-of-scope discovered target scanned."""
+		results = self._run({})
+		self.assertTrue(results, 'downstream active task never executed')
+		for inputs in results:
+			self.assertIn('api.acme.test', inputs)
+			self.assertIn('evil.attacker.test', inputs)  # nothing dropped without a scope
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
**PR 3/6** — the linchpin the audit flagged as a *blocker* ("authorized_scope inheritance not yet wired"). Turns out it largely **was** wired; this PR proves it end-to-end and closes the one real gap.

## Findings
- **`run_extractors` scan-input filter already exists** (`_helpers.py:128-141`, from #1343, on `host_in_scope` hardened by #1346) — no second matcher to consolidate, no change needed. Confirmed it gates scan **inputs**, not finding emission (findings go `yielder()`→`add_result()`, a separate path), so a crawler still *reports* an out-of-scope host it found; only chaining it as an active-scan input is dropped.
- **Inheritance already propagates** via run_opts: scan→workflow (`run_opts.copy()`+`merge_opts`), workflow→task (same), and `merge_opts` never drops known keys — so `in_scope`/`out_of_scope` reach every descendant and each re-applies the filter.

## The one gap fixed (7 lines, `celery.py:425-431`)
The dynamic-spawn **producer** (`mark_runner_started`'s scope_producer for subdomain_recon→host_recon) built its extractor opts from only `targets_` keys, so it emitted scope-tagged Targets **without** the scope filter. Now it inherits `in_scope`/`out_of_scope` so out-of-scope discovered targets never even hit the store. Defense-in-depth — consumers still re-filter at the same choke point.

## The linchpin test (`tests/unit/test_scope_inheritance.py`, 2 tests)
Real sync scan→workflow→task chain: a discover-task emits `api.acme.test` (in-scope) + `evil.attacker.test` (out-of-scope); a downstream task resolves those as its own inputs.
- `test_out_of_scope_discovered_target_is_dropped`: inherited `in_scope=['acme.test','*.acme.test']` → child keeps `api.acme.test`, **drops** `evil.attacker.test`. ✅
- `test_no_scope_allows_all`: no scope → both kept. ✅
Full scope/runner regression: 110 passed, 4 skipped (pre-existing AI-scope skips).

## Note for PR4
`*.acme.test` does not cover apex `acme.test` (documented PR2 semantics) — the API's scope derivation must include the apex when a mandate covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)