### PR TITLE
feat(runner): warn when a target is dropped as out-of-scope

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -796,9 +796,9 @@ class Runner:
 			'workflow_id': self.context.get('workflow_id'),
 			'task_id': self.context.get('task_id'),
 		}
-		inputs, run_opts, errors = run_extractors([], self.run_opts, self.inputs, ctx=ctx, dry_run=self.dry_run)
-		for error in errors:
-			self.add_result(error)
+		inputs, run_opts, messages = run_extractors([], self.run_opts, self.inputs, ctx=ctx, dry_run=self.dry_run)
+		for message in messages:
+			self.add_result(message)
 		self.inputs = sorted(list(set(inputs)))
 		self.debug(f'extracted {len(self.inputs)} inputs', sub='init')
 		self.run_opts = run_opts

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -2,7 +2,7 @@ import os
 import re
 
 from secator.config import CONFIG
-from secator.output_types import Error
+from secator.output_types import Error, Warning
 from secator.query.ast import substitute_ctx_constants
 from secator.scope import as_scope_list, host_in_scope
 from secator.utils import deduplicate, debug
@@ -68,7 +68,7 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		dry_run (bool): Dry run.
 
 	Returns:
-		tuple: inputs, options, errors.
+		tuple: inputs, options, messages (Error/Warning items to surface).
 	"""
 	if inputs is None:
 		inputs = []
@@ -95,7 +95,7 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		opts.update(dry_opts)
 		return inputs, opts, []
 
-	errors = []
+	messages = []
 	computed_inputs = []
 	input_extractors = False
 	computed_opts = {}
@@ -104,7 +104,7 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		key = key.rstrip('_')
 		ctx['key'] = key
 		values, err = extract_from_results(results, val, ctx=ctx)
-		errors.extend(err)
+		messages.extend(err)
 		if key == 'targets':
 			input_extractors = True
 			targets = deduplicate(values)
@@ -138,10 +138,12 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		dropped = [t for t in inputs if t not in kept]
 		if dropped:
 			debug(f'dropped {len(dropped)} out-of-scope target(s): {dropped}', sub='scope')
+			shown = ', '.join(dropped[:10]) + (f' (+{len(dropped) - 10} more)' if len(dropped) > 10 else '')
+			messages.append(Warning(message=f'Dropped {len(dropped)} out-of-scope target(s): {shown}'))
 		inputs = kept
 	if computed_opts:
 		debug('computed_opts', obj=computed_opts, sub='extractors')
-	return inputs, opts, errors
+	return inputs, opts, messages
 
 
 def fmt_extractor(extractor):

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -339,6 +339,21 @@ class TestExtractorFunctions(unittest.TestCase):
         self.assertEqual(updated_opts['other'], ['<DYNAMIC(url.url)>'])
         self.assertEqual(errors, [])
 
+    def test_run_extractors_out_of_scope_emits_warning(self):
+        """An out-of-scope target is dropped AND surfaces a Warning naming it."""
+        from secator.output_types import Warning
+        opts = {'in_scope': ['acme.test', '*.acme.test']}
+        inputs = ['app.acme.test', 'evil.attacker.test']
+        kept, _opts, messages = run_extractors([], opts, inputs=inputs)
+        self.assertEqual(kept, ['app.acme.test'])
+        warnings = [m for m in messages if isinstance(m, Warning)]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('evil.attacker.test', warnings[0].message)
+        # No scope opts -> allow-all -> no warning.
+        kept, _opts, messages = run_extractors([], {}, inputs=inputs)
+        self.assertEqual(sorted(kept), sorted(inputs))
+        self.assertEqual([m for m in messages if isinstance(m, Warning)], [])
+
     def test_run_extractors_with_group_by(self):
         """Full pipeline: Technology items → grouped search_vulns inputs via group_by extractor."""
         tech1 = Technology(match='10.0.0.1:80', product='apache httpd', version='2.4.50')

--- a/tests/unit/test_scope.py
+++ b/tests/unit/test_scope.py
@@ -131,12 +131,16 @@ class TestRunExtractorsScopeFilter(unittest.TestCase):
 	def test_discovered_subdomain_filtered_against_allowlist(self):
 		# Simulates subdomain_recon feeding host_recon: claris.com in scope (apex only),
 		# www.claris.com discovered -> must be dropped before host_recon scans it.
+		from secator.output_types import Warning
 		discovered = ['claris.com', 'www.claris.com', 'api.claris.com']
-		inputs, _opts, errors = run_extractors(
+		inputs, _opts, messages = run_extractors(
 			[], {'in_scope': ['claris.com']}, inputs=discovered
 		)
-		self.assertEqual(errors, [])
 		self.assertEqual(inputs, ['claris.com'])
+		warnings = [m for m in messages if isinstance(m, Warning)]
+		self.assertEqual(len(warnings), 1)
+		self.assertIn('www.claris.com', warnings[0].message)
+		self.assertIn('api.claris.com', warnings[0].message)
 
 	def test_wildcard_scope_keeps_subdomains(self):
 		discovered = ['claris.com', 'www.claris.com', 'evil.com']


### PR DESCRIPTION
## What
When `run_extractors` drops a target because it fails the `in_scope`/`out_of_scope` allow/deny check (the fan-in choke point every runner's inputs flow through — user-supplied **and** dynamically discovered), it now emits a **`Warning`** naming the dropped target(s). Previously this was a `debug()`-only line, invisible in normal output — a subdomain silently vanishing mid-scan with no trace.

```
[WRN] Dropped 2 out-of-scope target(s): www.claris.com, api.claris.com
```

The `debug()` line stays (full uncapped list under `SECATOR_DEBUG`); the Warning caps its listing at 10 names + `(+N more)`.

## Naming
Renamed `run_extractors`' third return value `errors` → `messages`: it now carries `Warning`s as well as `Error`s. Both are `OutputType`s surfaced identically via `add_result` in `_base.py::_run_extractors`. The old name was misleading once Warnings joined the channel.

## Tests
- `test_run_extractors_out_of_scope_emits_warning` — drop emits exactly one Warning naming the target; empty scope (allow-all) emits none.
- Updated `test_scope.py::test_discovered_subdomain_filtered_against_allowlist` to assert the Warning (was asserting an empty channel).
- Full scope + helper suite: **65 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)