### PR TITLE
feat(core): promote target scope-gate to main (classifier + scope matcher + discovered-target enforcement)

### DIFF
--- a/secator/celery.py
+++ b/secator/celery.py
@@ -422,6 +422,10 @@ def mark_runner_started(results, runner, enable_hooks=True):
 		target_extractor_opts = {
 			k: v for k, v in runner.dynamic_opts.items() if k.rstrip('_') == 'targets'
 		}
+		# Inherit scope so discovered targets are filtered before they're stored.
+		for k in ('in_scope', 'out_of_scope'):
+			if runner.run_opts.get(k):
+				target_extractor_opts[k] = runner.run_opts[k]
 		# Start from the runner's full store-resolution context (preserves run-scoping keys like
 		# parent_scope, workspace_id, drivers, {type}_id) so the local/json driver scopes correctly,
 		# then overlay only the extractor-specific values.

--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -796,9 +796,9 @@ class Runner:
 			'workflow_id': self.context.get('workflow_id'),
 			'task_id': self.context.get('task_id'),
 		}
-		inputs, run_opts, errors = run_extractors([], self.run_opts, self.inputs, ctx=ctx, dry_run=self.dry_run)
-		for error in errors:
-			self.add_result(error)
+		inputs, run_opts, messages = run_extractors([], self.run_opts, self.inputs, ctx=ctx, dry_run=self.dry_run)
+		for message in messages:
+			self.add_result(message)
 		self.inputs = sorted(list(set(inputs)))
 		self.debug(f'extracted {len(self.inputs)} inputs', sub='init')
 		self.run_opts = run_opts

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -2,7 +2,7 @@ import os
 import re
 
 from secator.config import CONFIG
-from secator.output_types import Error
+from secator.output_types import Error, Warning
 from secator.query.ast import substitute_ctx_constants
 from secator.scope import as_scope_list, host_in_scope
 from secator.utils import deduplicate, debug
@@ -68,7 +68,7 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		dry_run (bool): Dry run.
 
 	Returns:
-		tuple: inputs, options, errors.
+		tuple: inputs, options, messages (Error/Warning items to surface).
 	"""
 	if inputs is None:
 		inputs = []
@@ -95,7 +95,7 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		opts.update(dry_opts)
 		return inputs, opts, []
 
-	errors = []
+	messages = []
 	computed_inputs = []
 	input_extractors = False
 	computed_opts = {}
@@ -104,7 +104,7 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		key = key.rstrip('_')
 		ctx['key'] = key
 		values, err = extract_from_results(results, val, ctx=ctx)
-		errors.extend(err)
+		messages.extend(err)
 		if key == 'targets':
 			input_extractors = True
 			targets = deduplicate(values)
@@ -138,10 +138,12 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		dropped = [t for t in inputs if t not in kept]
 		if dropped:
 			debug(f'dropped {len(dropped)} out-of-scope target(s): {dropped}', sub='scope')
+			shown = ', '.join(dropped[:10]) + (f' (+{len(dropped) - 10} more)' if len(dropped) > 10 else '')
+			messages.append(Warning(message=f'Dropped {len(dropped)} out-of-scope target(s): {shown}'))
 		inputs = kept
 	if computed_opts:
 		debug('computed_opts', obj=computed_opts, sub='extractors')
-	return inputs, opts, errors
+	return inputs, opts, messages
 
 
 def fmt_extractor(extractor):

--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -4,6 +4,7 @@ import re
 from secator.config import CONFIG
 from secator.output_types import Error
 from secator.query.ast import substitute_ctx_constants
+from secator.scope import as_scope_list, host_in_scope
 from secator.utils import deduplicate, debug
 
 
@@ -124,6 +125,20 @@ def run_extractors(results, opts, inputs=None, ctx=None, dry_run=False):
 		if combined:
 			debug('using scope-tagged targets as inputs', obj=combined, sub='extractors')
 			inputs = combined
+	# Enforce a generic target-scope allow/deny list on the resolved inputs. This is the
+	# single fan-in choke point every runner's inputs flow through (user-supplied AND
+	# dynamically discovered, e.g. subdomain_recon -> host_recon), so filtering here drops
+	# out-of-scope discovered targets before any downstream task acts on them. The API derives
+	# in_scope/out_of_scope from the run's authorized scope (mandate) and passes them as plain
+	# run-options; core stays authorization-agnostic. See secator/scope.py.
+	in_scope = as_scope_list(opts.get('in_scope'))
+	out_of_scope = as_scope_list(opts.get('out_of_scope'))
+	if inputs and (in_scope or out_of_scope):
+		kept = [t for t in inputs if host_in_scope(t, in_scope, out_of_scope)]
+		dropped = [t for t in inputs if t not in kept]
+		if dropped:
+			debug(f'dropped {len(dropped)} out-of-scope target(s): {dropped}', sub='scope')
+		inputs = kept
 	if computed_opts:
 		debug('computed_opts', obj=computed_opts, sub='extractors')
 	return inputs, opts, errors

--- a/secator/scope.py
+++ b/secator/scope.py
@@ -1,116 +1,192 @@
 """Generic target-scope allow/deny filtering.
 
 secator core has NO concept of mandates, bug-bounty programs, or any platform
-authorization model — and it must not. This module is a neutral host/target
+authorization model -- and it must not. This module is a neutral host/target
 scope matcher: given a target string and plain scope entries (a host, a
-``*.wildcard``, a CIDR, or a regex), decide whether the target is in scope.
+``*.wildcard``, a CIDR, or an anchored regex), decide whether the target is in
+scope.
 
 The platform (secator-api) derives the effective authorized scope from whatever
 authorization model it uses and passes it in as generic ``in_scope`` /
 ``out_of_scope`` run-options. Core then enforces that allow-list on EVERY target
-it acts on — including subdomains discovered mid-scan (subdomain_recon output
-fed into host_recon) — closing the scope-escape where dynamically-discovered
+it acts on -- including subdomains discovered mid-scan (subdomain_recon output
+fed into host_recon) -- closing the scope-escape where dynamically-discovered
 targets were never checked against the run's authorized scope.
 
 The matching rules here intentionally mirror the platform's own scope matcher so
 a target that the ingress gate would reject is dropped identically mid-scan. The
-two copies share no code (separate repos, and core stays authorization-agnostic
-by design); keep the semantics in sync — see ``test_scope.py`` for the shared
-vectors.
+API imports THIS module rather than forking it, so the matcher stays pure and
+dependency-light: it does NO network I/O (target parsing runs through the shared
+``classify_target(..., resolve=False)`` classifier -- see ``secator/utils.py``).
+
+Semantics (see ``host_in_scope``):
+- Only NETWORK targets (ip / cidr / host / host:port / url) are scope-checked.
+A non-network discovered item (email, username, path, uuid, ...) is never
+subject to scope and is always kept -- this matcher gates scan INPUTS, not
+finding emission.
+- deny wins: any ``out_of_scope`` match drops the target regardless of allow.
+- empty ``in_scope`` means allow-all (subject to deny).
+
+Scope entry kinds:
+- IP / CIDR: ``ipaddress`` containment (v4 AND v6). An IP target inside a CIDR
+entry; a CIDR target that is ``subnet_of`` the entry.
+- exact host: canonical-host equality (``app.acme.com``).
+- wildcard: ``*.acme.com`` matches sub-domains only; the apex ``acme.com`` is
+NOT covered (add it as its own entry).
+- regex: ``re.fullmatch``-ANCHORED (both ends). ``acme\\.com`` does NOT match
+``evil-acme.com.attacker.net``. Author regex are scope entries, never targets.
 """
 
 import ipaddress
+import logging
 import re
-from urllib.parse import urlparse
+
+from secator.definitions import CIDR_RANGE, IP
+from secator.utils import (
+	NETWORK_TYPES,
+	_is_ip_literal,
+	_target_host,
+	canonicalize_target,
+	classify_target,
+)
+
+logger = logging.getLogger(__name__)
+
+# Regex scope entries are AUTHOR-controlled (platform mandate config), but the
+# TARGET they match is attacker-controlled (a discovered subdomain), so a
+# vulnerable author pattern + crafted target is a ReDoS vector. Python's `re`
+# has no match timeout, so we mitigate at COMPILE time: reject patterns with
+# nested quantifiers (the classic catastrophic-backtracking shape) and cap the
+# length of the string we ever feed to a regex. Both are best-effort.
+_MAX_REGEX_INPUT = 2048
+# Heuristic: a quantified group whose body also contains a quantifier -> (a+)+,
+# (a*)*, (a+)*b, ... Best-effort (single-level groups); flagged in the report.
+_NESTED_QUANTIFIER = re.compile(r'\([^()]*[+*?][^()]*\)[+*]')
+
+# Regex metacharacters that mark an entry as a regex rather than a structural
+# host/wildcard/CIDR. `.` and `*` are excluded: they are the ordinary furniture
+# of hostnames (`app.acme.com`) and wildcards (`*.acme.com`).
+_REGEX_META = set('[](){}|+?^$\\')
+
+# Compiled-regex cache. Value is a compiled pattern, or None for an entry that
+# failed to compile / was rejected as catastrophic (-> treated as non-matching).
+_regex_cache = {}
 
 
-def _looks_like_regex(entry: str) -> bool:
-	"""Heuristic: does this scope entry use regex metacharacters?
+def _compile_entry(entry):
+	"""Compile a regex scope entry once, fail-safe. Returns a compiled pattern or None.
 
-	A plain host/wildcard/CIDR entry (``app.acme.com``, ``*.acme.com``,
-	``1.2.3.0/24``) is matched with the structural host/network logic below. An
-	entry containing regex metacharacters other than the ``*``/``.`` used by
-	wildcards/hostnames is treated as a regex and matched against the raw target.
+	None means the entry never matches. On a bad/catastrophic pattern we log a
+	warning: a broken ALLOW entry silently narrows scope; a broken DENY entry
+	silently stops excluding -- see the fail-safe note in the module docstring
+	and the PR report. We deliberately do NOT fail a broken deny closed (deny
+	everything), because a single mistyped exclusion would otherwise DoS the
+	whole scan; the (non-empty) allow-list remains the primary boundary.
 	"""
-	regex_meta = set("[](){}|+?^$\\")
-	return any(c in regex_meta for c in entry)
+	if entry in _regex_cache:
+		return _regex_cache[entry]
+	compiled = None
+	if _NESTED_QUANTIFIER.search(entry):
+		logger.warning('scope: skipping regex entry with catastrophic (ReDoS) pattern: %r', entry)
+	else:
+		try:
+			compiled = re.compile(entry)
+		except re.error as e:
+			logger.warning('scope: skipping un-compilable regex entry %r: %s', entry, e)
+	_regex_cache[entry] = compiled
+	return compiled
 
 
-def _entry_matches_regex(target: str, entry: str) -> bool:
-	"""True if `entry` is a regex that matches the raw target string."""
+class _Shape:
+	"""Parsed target: exactly one of net / ip / host is set. `canonical` is the
+	full canonical target string (what regex entries fullmatch against)."""
+	__slots__ = ('net', 'ip', 'host', 'canonical')
+
+	def __init__(self, net=None, ip=None, host=None, canonical=''):
+		self.net = net
+		self.ip = ip
+		self.host = host
+		self.canonical = canonical
+
+
+def _target_shape(target):
+	"""Parse a target into a `_Shape`, or return None if it is not a NETWORK target.
+
+	Reuses PR1's single-source classifier for type detection and canonicalization
+	(alternate IPv4 encodings, IDNA, bracketed IPv6, ...) -- NO IP/host parsing is
+	re-implemented here. `resolve=False` keeps this pure (no DNS).
+	"""
+	info = classify_target(target, resolve=False)
+	if info.type not in NETWORK_TYPES:
+		return None
+	canonical = canonicalize_target(target)
+	if info.type == CIDR_RANGE:
+		return _Shape(net=ipaddress.ip_network(canonical, strict=False), canonical=canonical)
+	if info.type == IP and _is_ip_literal(canonical):
+		return _Shape(ip=ipaddress.ip_address(canonical), canonical=canonical)
+	# URL / HOST / HOST_PORT (and `localhost`, typed IP but not a real IP literal):
+	# pull the host out (strips scheme / port / path).
+	host = _target_host(canonical, info.type)
+	if _is_ip_literal(host):
+		# IP literal hiding in a url / host:port (8.8.8.8:443, http://8.8.8.8/) --
+		# match it by network containment, never as a hostname string.
+		return _Shape(ip=ipaddress.ip_address(host), canonical=canonical)
+	return _Shape(host=host.lower().rstrip('.'), canonical=canonical)
+
+
+def _entry_net(entry):
+	"""Parse a scope entry as an IP or CIDR network, or None. A bare IP -> /32 or /128."""
 	try:
-		return re.search(entry, target) is not None
-	except re.error:
-		return False
-
-
-def _host_of(target: str) -> str:
-	"""Extract a comparable host from a target string (url/host/domain)."""
-	t = target.strip()
-	if "://" in t:
-		return urlparse(t).hostname or ""
-	return t.split("/")[0].split(":")[0]
-
-
-def _as_network(value: str):
-	try:
-		return ipaddress.ip_network(value, strict=False)
+		return ipaddress.ip_network(entry, strict=False)
 	except ValueError:
 		return None
 
 
-def target_in_scope(target: str, scope: list) -> bool:
-	"""True if target string is covered by any scope entry.
+def _shape_matches_entry(shape, entry):
+	"""True if the parsed target `shape` is covered by a single scope `entry`."""
+	entry = entry.strip()
+	if not entry:
+		return False
 
-	Each entry is treated as a single-or-regex value: a plain host/wildcard/CIDR
-	is matched structurally (exact host, ``*.wildcard`` subdomain, IP-in-CIDR,
-	CIDR-subnet-of), while an entry containing regex metacharacters is matched as
-	a regex against the raw target string.
+	# Wildcard: *.acme.com covers sub-domains, NOT the apex.
+	if entry.startswith('*.'):
+		if shape.host is None:
+			return False
+		base = entry[2:].lower().rstrip('.')
+		return bool(base) and shape.host.endswith('.' + base)
+
+	# IP / CIDR entry: pure network containment (v4 and v6).
+	entry_net = _entry_net(entry)
+	if entry_net is not None:
+		if shape.net is not None:
+			return shape.net.version == entry_net.version and shape.net.subnet_of(entry_net)
+		if shape.ip is not None:
+			return shape.ip.version == entry_net.version and shape.ip in entry_net
+		return False  # hostname target can't be inside an IP network
+
+	# Regex entry: FULLMATCH-anchored (both ends), ReDoS-guarded.
+	if any(c in _REGEX_META for c in entry):
+		compiled = _compile_entry(entry)
+		if compiled is None or len(shape.canonical) > _MAX_REGEX_INPUT:
+			return False
+		return compiled.fullmatch(shape.canonical) is not None
+
+	# Exact host entry: canonical-host equality.
+	if shape.host is None:
+		return False
+	return shape.host == entry.lower().rstrip('.')
+
+
+def target_in_scope(target, scope):
+	"""True if a NETWORK target string is covered by any entry in `scope`.
+
+	Non-network targets return False here (the keep decision for them lives in
+	``host_in_scope``, which never routes them through this predicate).
 	"""
-	target = target.strip()
-	# Regex entries: match against the raw target first.
-	for entry in scope:
-		entry = entry.strip()
-		if _looks_like_regex(entry) and _entry_matches_regex(target, entry):
-			return True
-	target_net = _as_network(target) if ("/" in target or target.replace(".", "").isdigit()) else None
-	# IP/CIDR matching
-	for entry in scope:
-		entry = entry.strip()
-		if _looks_like_regex(entry):
-			continue
-		entry_net = _as_network(entry)
-		if entry_net is not None:
-			if target_net is not None:
-				if target_net.subnet_of(entry_net):
-					return True
-			else:
-				host = _host_of(target)
-				try:
-					if ipaddress.ip_address(host) in entry_net:
-						return True
-				except ValueError:
-					pass
-	# A pure IP/CIDR target only matches via network containment (handled above);
-	# never fall through to hostname matching, otherwise "1.2.3.0/24" and
-	# "1.2.3.0/25" would match as equal hostnames ("1.2.3.0").
-	if target_net is not None:
+	shape = _target_shape(target)
+	if shape is None:
 		return False
-	# hostname matching
-	host = _host_of(target).lower().rstrip(".")
-	if not host:
-		return False
-	for entry in scope:
-		if _looks_like_regex(entry):
-			continue
-		e = _host_of(entry).lower().rstrip(".")
-		if e.startswith("*."):
-			base = e[2:]
-			if host.endswith("." + base):
-				return True
-		elif host == e:
-			return True
-	return False
+	return any(_shape_matches_entry(shape, e) for e in scope)
 
 
 def as_scope_list(val):
@@ -121,21 +197,27 @@ def as_scope_list(val):
 	if not val:
 		return []
 	if isinstance(val, str):
-		return [v.strip() for v in val.split(",") if v.strip()]
+		return [v.strip() for v in val.split(',') if v.strip()]
 	return [str(v).strip() for v in val if str(v).strip()]
 
 
-def host_in_scope(target: str, in_scope=None, out_of_scope=None) -> bool:
-	"""Allow/deny decision for a single target. Deny wins.
+def host_in_scope(target, in_scope=None, out_of_scope=None):
+	"""Allow/deny scope decision for a single target. Deny wins.
 
-	- ``out_of_scope`` match  -> out (deny wins over allow).
-	- non-empty ``in_scope``  -> target must match an allow entry.
-	- empty ``in_scope``      -> allow-all (subject to deny).
+	- Non-network target (email / username / path / ...) -> True (never scoped).
+	- ``out_of_scope`` match                             -> False (deny wins over allow).
+	- non-empty ``in_scope``                             -> target must match an allow entry.
+	- empty ``in_scope``                                 -> allow-all (subject to deny).
 	"""
 	in_scope = as_scope_list(in_scope)
 	out_of_scope = as_scope_list(out_of_scope)
-	if out_of_scope and target_in_scope(target, out_of_scope):
+	if not in_scope and not out_of_scope:
+		return True
+	shape = _target_shape(target)
+	if shape is None:
+		return True  # non-network item: scope is network-only, always kept
+	if out_of_scope and any(_shape_matches_entry(shape, e) for e in out_of_scope):
 		return False
 	if in_scope:
-		return target_in_scope(target, in_scope)
+		return any(_shape_matches_entry(shape, e) for e in in_scope)
 	return True

--- a/secator/scope.py
+++ b/secator/scope.py
@@ -1,0 +1,141 @@
+"""Generic target-scope allow/deny filtering.
+
+secator core has NO concept of mandates, bug-bounty programs, or any platform
+authorization model — and it must not. This module is a neutral host/target
+scope matcher: given a target string and plain scope entries (a host, a
+``*.wildcard``, a CIDR, or a regex), decide whether the target is in scope.
+
+The platform (secator-api) derives the effective authorized scope from whatever
+authorization model it uses and passes it in as generic ``in_scope`` /
+``out_of_scope`` run-options. Core then enforces that allow-list on EVERY target
+it acts on — including subdomains discovered mid-scan (subdomain_recon output
+fed into host_recon) — closing the scope-escape where dynamically-discovered
+targets were never checked against the run's authorized scope.
+
+The matching rules here intentionally mirror the platform's own scope matcher so
+a target that the ingress gate would reject is dropped identically mid-scan. The
+two copies share no code (separate repos, and core stays authorization-agnostic
+by design); keep the semantics in sync — see ``test_scope.py`` for the shared
+vectors.
+"""
+
+import ipaddress
+import re
+from urllib.parse import urlparse
+
+
+def _looks_like_regex(entry: str) -> bool:
+	"""Heuristic: does this scope entry use regex metacharacters?
+
+	A plain host/wildcard/CIDR entry (``app.acme.com``, ``*.acme.com``,
+	``1.2.3.0/24``) is matched with the structural host/network logic below. An
+	entry containing regex metacharacters other than the ``*``/``.`` used by
+	wildcards/hostnames is treated as a regex and matched against the raw target.
+	"""
+	regex_meta = set("[](){}|+?^$\\")
+	return any(c in regex_meta for c in entry)
+
+
+def _entry_matches_regex(target: str, entry: str) -> bool:
+	"""True if `entry` is a regex that matches the raw target string."""
+	try:
+		return re.search(entry, target) is not None
+	except re.error:
+		return False
+
+
+def _host_of(target: str) -> str:
+	"""Extract a comparable host from a target string (url/host/domain)."""
+	t = target.strip()
+	if "://" in t:
+		return urlparse(t).hostname or ""
+	return t.split("/")[0].split(":")[0]
+
+
+def _as_network(value: str):
+	try:
+		return ipaddress.ip_network(value, strict=False)
+	except ValueError:
+		return None
+
+
+def target_in_scope(target: str, scope: list) -> bool:
+	"""True if target string is covered by any scope entry.
+
+	Each entry is treated as a single-or-regex value: a plain host/wildcard/CIDR
+	is matched structurally (exact host, ``*.wildcard`` subdomain, IP-in-CIDR,
+	CIDR-subnet-of), while an entry containing regex metacharacters is matched as
+	a regex against the raw target string.
+	"""
+	target = target.strip()
+	# Regex entries: match against the raw target first.
+	for entry in scope:
+		entry = entry.strip()
+		if _looks_like_regex(entry) and _entry_matches_regex(target, entry):
+			return True
+	target_net = _as_network(target) if ("/" in target or target.replace(".", "").isdigit()) else None
+	# IP/CIDR matching
+	for entry in scope:
+		entry = entry.strip()
+		if _looks_like_regex(entry):
+			continue
+		entry_net = _as_network(entry)
+		if entry_net is not None:
+			if target_net is not None:
+				if target_net.subnet_of(entry_net):
+					return True
+			else:
+				host = _host_of(target)
+				try:
+					if ipaddress.ip_address(host) in entry_net:
+						return True
+				except ValueError:
+					pass
+	# A pure IP/CIDR target only matches via network containment (handled above);
+	# never fall through to hostname matching, otherwise "1.2.3.0/24" and
+	# "1.2.3.0/25" would match as equal hostnames ("1.2.3.0").
+	if target_net is not None:
+		return False
+	# hostname matching
+	host = _host_of(target).lower().rstrip(".")
+	if not host:
+		return False
+	for entry in scope:
+		if _looks_like_regex(entry):
+			continue
+		e = _host_of(entry).lower().rstrip(".")
+		if e.startswith("*."):
+			base = e[2:]
+			if host.endswith("." + base):
+				return True
+		elif host == e:
+			return True
+	return False
+
+
+def as_scope_list(val):
+	"""Coerce a scope run-option into a list of entries.
+
+	Accepts ``None`` (-> ``[]``), a comma-separated string (CLI form), or a list.
+	"""
+	if not val:
+		return []
+	if isinstance(val, str):
+		return [v.strip() for v in val.split(",") if v.strip()]
+	return [str(v).strip() for v in val if str(v).strip()]
+
+
+def host_in_scope(target: str, in_scope=None, out_of_scope=None) -> bool:
+	"""Allow/deny decision for a single target. Deny wins.
+
+	- ``out_of_scope`` match  -> out (deny wins over allow).
+	- non-empty ``in_scope``  -> target must match an allow entry.
+	- empty ``in_scope``      -> allow-all (subject to deny).
+	"""
+	in_scope = as_scope_list(in_scope)
+	out_of_scope = as_scope_list(out_of_scope)
+	if out_of_scope and target_in_scope(target, out_of_scope):
+		return False
+	if in_scope:
+		return target_in_scope(target, in_scope)
+	return True

--- a/secator/scope.py
+++ b/secator/scope.py
@@ -1,40 +1,14 @@
-"""Generic target-scope allow/deny filtering.
+"""Match a target against ``in_scope`` / ``out_of_scope`` allow/deny lists.
 
-secator core has NO concept of mandates, bug-bounty programs, or any platform
-authorization model -- and it must not. This module is a neutral host/target
-scope matcher: given a target string and plain scope entries (a host, a
-``*.wildcard``, a CIDR, or an anchored regex), decide whether the target is in
-scope.
+Pure, no network I/O (parsing via ``classify_target(resolve=False)``). Only
+network targets (ip/cidr/host/host:port/url) are checked; non-network items
+(email, username, path, ...) are always kept. Deny wins; empty ``in_scope`` =
+allow-all (subject to deny).
 
-The platform (secator-api) derives the effective authorized scope from whatever
-authorization model it uses and passes it in as generic ``in_scope`` /
-``out_of_scope`` run-options. Core then enforces that allow-list on EVERY target
-it acts on -- including subdomains discovered mid-scan (subdomain_recon output
-fed into host_recon) -- closing the scope-escape where dynamically-discovered
-targets were never checked against the run's authorized scope.
-
-The matching rules here intentionally mirror the platform's own scope matcher so
-a target that the ingress gate would reject is dropped identically mid-scan. The
-API imports THIS module rather than forking it, so the matcher stays pure and
-dependency-light: it does NO network I/O (target parsing runs through the shared
-``classify_target(..., resolve=False)`` classifier -- see ``secator/utils.py``).
-
-Semantics (see ``host_in_scope``):
-- Only NETWORK targets (ip / cidr / host / host:port / url) are scope-checked.
-A non-network discovered item (email, username, path, uuid, ...) is never
-subject to scope and is always kept -- this matcher gates scan INPUTS, not
-finding emission.
-- deny wins: any ``out_of_scope`` match drops the target regardless of allow.
-- empty ``in_scope`` means allow-all (subject to deny).
-
-Scope entry kinds:
-- IP / CIDR: ``ipaddress`` containment (v4 AND v6). An IP target inside a CIDR
-entry; a CIDR target that is ``subnet_of`` the entry.
-- exact host: canonical-host equality (``app.acme.com``).
-- wildcard: ``*.acme.com`` matches sub-domains only; the apex ``acme.com`` is
-NOT covered (add it as its own entry).
-- regex: ``re.fullmatch``-ANCHORED (both ends). ``acme\\.com`` does NOT match
-``evil-acme.com.attacker.net``. Author regex are scope entries, never targets.
+Entry kinds: IP/CIDR (``ipaddress`` containment, v4+v6, ``subnet_of``); exact
+host; ``*.acme.com`` wildcard (sub-domains only, not the apex); ``re.fullmatch``-
+anchored regex (``acme\\.com`` never matches ``evil-acme.com.x``). Regexes are
+scope entries, never targets.
 """
 
 import ipaddress

--- a/secator/utils.py
+++ b/secator/utils.py
@@ -10,6 +10,7 @@ import os
 import re
 import select
 import signal
+import socket
 import sys
 import tempfile
 import threading
@@ -18,7 +19,12 @@ import traceback
 import validators
 import warnings
 
+import dns.exception
+import dns.resolver
+import idna
+
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from functools import reduce
 from pathlib import Path
@@ -1061,6 +1067,190 @@ def validate_cidr_range(target):
 		return True
 	except ValueError:
 		return False
+
+
+# Network types that name a routable target (as opposed to slug / email / iban / ...).
+# HOST covers both bare hostnames and registrable domains (autodetect_type returns HOST for both).
+NETWORK_TYPES = (IP, CIDR_RANGE, HOST, HOST_PORT, URL)
+
+
+@dataclass
+class TargetInfo:
+	"""Result of classify_target(). Single source of truth the API imports (never reimplement)."""
+	type: str          # autodetect_type() taxonomy: ip / cidr_range / host / url / slug / email / ...
+	is_network: bool    # ip|cidr: valid by construction (no DNS). host|url: DNS resolved. else False.
+	root: str           # url -> hostname ; cidr -> network address ; else the (canonical) token
+	reachable: bool     # ip|cidr: validity. host|url: DNS success. else False.
+
+
+def canonicalize_target(raw):
+	"""Normalize a single raw target token to the form a scanner/resolver would actually hit.
+
+	This closes classification-smuggling gaps: alternate IPv4 encodings (decimal 2130706433,
+	octal 0177.0.0.1, short 127.1, hex 0x7f.0.0.1 -- all via inet_aton semantics), IDNA/Unicode
+	hostnames, bracketed IPv6, and surrounding whitespace all collapse to their canonical string
+	BEFORE type detection runs. Pure function, no network I/O.
+
+	Args:
+		raw (str): A single target token (not a list -- use split_targets first).
+
+	Returns:
+		str: Canonical target string.
+	"""
+	if raw is None:
+		return ''
+	token = str(raw).strip()
+	if not token:
+		return ''
+
+	# Strip IPv6 brackets, keeping any :port, but ONLY when the bracketed content is a real IP
+	# literal (what brackets are for): [2001:db8::1] -> 2001:db8::1 , [2001:db8::1]:443 ->
+	# 2001:db8::1:443. A non-IP like [a-z].example.com keeps its brackets -> caught as a scope entry.
+	if token.startswith('['):
+		end = token.find(']')
+		if end != -1 and _is_ip_literal(token[1:end]):
+			token = token[1:end] + token[end + 1:]
+
+	# Alternate IPv4 encodings -> dotted-quad, using inet_aton (same parser nmap/ping/libc use).
+	# Only numeric-ish tokens reach a match; hostnames and out-of-range ints raise and fall through.
+	try:
+		token = socket.inet_ntoa(socket.inet_aton(token))
+		return token
+	except OSError:
+		pass
+
+	# IDNA-encode Unicode hostnames (bare host or URL netloc) to punycode.
+	if not token.isascii():
+		token = _idna_encode(token)
+
+	return token
+
+
+def _idna_encode(token):
+	"""Best-effort IDNA (punycode) encoding of a Unicode host or URL netloc. Pure, no I/O."""
+	scheme = rest = ''
+	host = token
+	if '://' in token:
+		scheme, _, after = token.partition('://')
+		scheme += '://'
+		# split host from path/query/port
+		slash = after.find('/')
+		host, rest = (after, '') if slash == -1 else (after[:slash], after[slash:])
+	try:
+		encoded = idna.encode(host, uts46=True).decode('ascii')
+	except (idna.IDNAError, UnicodeError):
+		return token  # not a valid IDN host -> leave as-is (will classify non-network)
+	return f'{scheme}{encoded}{rest}'
+
+
+def split_targets(raw):
+	"""Split a raw multi-target input into individual tokens on comma AND newline.
+
+	Consolidates the two split styles core already used ad hoc (CLI split(',') and stdin/file
+	splitlines()) into one reusable, whitespace-trimming, empty-dropping helper.
+
+	Args:
+		raw (str | list): Raw input, possibly containing commas and/or newlines, or a list thereof.
+
+	Returns:
+		list[str]: Non-empty, stripped tokens.
+	"""
+	if raw is None:
+		return []
+	if isinstance(raw, (list, tuple)):
+		out = []
+		for item in raw:
+			out.extend(split_targets(item))
+		return out
+	# Char-class split, no backtracking -> ReDoS-safe.
+	return [t.strip() for t in re.split(r'[,\n]', str(raw)) if t.strip()]
+
+
+def _resolve_host(host, timeout):
+	"""DNS-resolve a hostname (A then AAAA) with a short timeout. Network I/O.
+
+	Returns:
+		bool: True if it resolves, False on NXDOMAIN / no answer / timeout / any DNS error.
+	"""
+	if not host:
+		return False
+	resolver = dns.resolver.Resolver()
+	resolver.timeout = timeout
+	resolver.lifetime = timeout
+	for rdtype in ('A', 'AAAA'):
+		try:
+			resolver.resolve(host, rdtype)
+			return True
+		except dns.resolver.NoAnswer:
+			continue  # no A record, try AAAA
+		except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers, dns.exception.DNSException):
+			return False
+	return False
+
+
+def _is_ip_literal(host):
+	"""True if host is a v4 or v6 IP literal. Pure -- ipaddress does no DNS."""
+	try:
+		ipaddress.ip_address(host)
+		return True
+	except ValueError:
+		return False
+
+
+def _target_host(canonical, ttype):
+	"""Extract the DNS-resolvable host from a canonical url / host / host:port token. Pure."""
+	if ttype == URL:
+		return (urlparse(canonical).hostname or '')
+	if ttype == HOST_PORT:
+		return canonical.rsplit(':', 1)[0]
+	return canonical
+
+
+def classify_target(token, *, resolve=True, timeout=2.0):
+	"""Classify a single target token. THE single-source classifier -- callers must not reimplement.
+
+	Type detection reuses the pure regex `autodetect_type`; all network I/O lives here behind
+	`resolve=True`. With `resolve=False` this is a pure no-I/O path (host/url reachability is left
+	False/unknown; ip/cidr are still resolved by construction).
+
+	Args:
+		token (str): A single target token (use split_targets first for multi-target input).
+		resolve (bool): If True, DNS-resolve host/url targets. If False, no network I/O at all.
+		timeout (float): Per-query DNS timeout in seconds (short; server-side safe).
+
+	Returns:
+		TargetInfo: {type, is_network, root, reachable}.
+	"""
+	canonical = canonicalize_target(token)
+	ttype = autodetect_type(canonical)
+	info = TargetInfo(type=ttype, is_network=False, root=canonical, reachable=False)
+
+	# Non-network types keep the False defaults. This also fails scope entries closed: wildcard /
+	# regex forms (*.example.com, .*\.corp$, [a-z].example.com) are rejected by autodetect_type's
+	# strict validators to STRING, so they are never in NETWORK_TYPES.
+	if ttype not in NETWORK_TYPES:
+		return info
+
+	if ttype == IP:
+		# Validity already proven by autodetect_type (validators/ipaddress) -- no DNS needed.
+		info.is_network = info.reachable = True
+	elif ttype == CIDR_RANGE:
+		info.root = str(ipaddress.ip_network(canonical, strict=False).network_address)
+		info.is_network = info.reachable = True
+	elif ttype in (URL, HOST, HOST_PORT):
+		host = _target_host(canonical, ttype)
+		if ttype == URL:
+			info.root = host
+		if _is_ip_literal(host):
+			# An IP literal hiding in url/host:port (8.8.8.8:443, http://8.8.8.8/) is network
+			# BY CONSTRUCTION -- never gate its network-ness on DNS (it won't resolve as a name).
+			info.is_network = info.reachable = True
+		elif resolve:
+			ok = _resolve_host(host, timeout)
+			info.is_network = info.reachable = ok
+		# genuine hostname + resolve=False -> pure path: leave is_network/reachable False (unverified).
+
+	return info
 
 
 def get_versions_from_string(string):

--- a/secator/utils.py
+++ b/secator/utils.py
@@ -1010,16 +1010,34 @@ def is_host_port(target):
 	Returns:
 		bool: True if the target is a host:port, False otherwise.
 	"""
-	split = target.split(':')
-	if not (validators.domain(split[0]) or validators.ipv4(split[0]) or validators.ipv6(split[0]) or split[0] == 'localhost'):  # noqa: E501
+	host, port = _split_host_port(target)
+	if not port:
+		return False
+	if not (validators.domain(host) or validators.ipv4(host) or validators.ipv6(host) or host == 'localhost'):
 		return False
 	try:
-		port = int(split[1])
+		port = int(port)
 		if port < 1 or port > 65535:
 			return False
 	except ValueError:
 		return False
 	return True
+
+
+def _split_host_port(target):
+	"""Split a host:port token into (host, port_str), unwrapping a bracketed IPv6 host.
+
+	[2001:db8::1]:443 -> ('2001:db8::1', '443') -- the brackets, not the last colon, delimit the
+	host, since an IPv6 literal contains colons of its own. A bare hostname/IP with no port yields
+	(host, ''). Pure, no I/O.
+	"""
+	if target.startswith('[') and ']:' in target:
+		host, _, port = target[1:].partition(']:')
+		return host, port
+	host, sep, port = target.rpartition(':')
+	if not sep:
+		return port, ''  # no colon -> rpartition puts the whole token in the last field
+	return host, port
 
 
 def autodetect_type(target):
@@ -1103,13 +1121,16 @@ def canonicalize_target(raw):
 	if not token:
 		return ''
 
-	# Strip IPv6 brackets, keeping any :port, but ONLY when the bracketed content is a real IP
-	# literal (what brackets are for): [2001:db8::1] -> 2001:db8::1 , [2001:db8::1]:443 ->
-	# 2001:db8::1:443. A non-IP like [a-z].example.com keeps its brackets -> caught as a scope entry.
+	# Bracketed IPv6, but ONLY when the bracketed content is a real IP literal (what brackets are for).
+	# Bare [2001:db8::1] -> 2001:db8::1 (brackets unwrapped). With a trailing :port the brackets are
+	# the canonical RFC 3986 host:port separator and MUST be kept -- unwrapping [2001:db8::1]:443 to
+	# 2001:db8::1:443 re-parses as a DIFFERENT valid IPv6 (443 becomes a hextet), absorbing the port.
+	# So keep the bracketed form and let is_host_port / _target_host split host from port.
+	# A non-IP like [a-z].example.com keeps its brackets -> caught as a scope entry.
 	if token.startswith('['):
 		end = token.find(']')
-		if end != -1 and _is_ip_literal(token[1:end]):
-			token = token[1:end] + token[end + 1:]
+		if end != -1 and _is_ip_literal(token[1:end]) and token[end + 1:] == '':
+			token = token[1:end]
 
 	# Alternate IPv4 encodings -> dotted-quad, using inet_aton (same parser nmap/ping/libc use).
 	# Only numeric-ish tokens reach a match; hostnames and out-of-range ints raise and fall through.
@@ -1202,7 +1223,7 @@ def _target_host(canonical, ttype):
 	if ttype == URL:
 		return (urlparse(canonical).hostname or '')
 	if ttype == HOST_PORT:
-		return canonical.rsplit(':', 1)[0]
+		return _split_host_port(canonical)[0]
 	return canonical
 
 

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -339,6 +339,21 @@ class TestExtractorFunctions(unittest.TestCase):
         self.assertEqual(updated_opts['other'], ['<DYNAMIC(url.url)>'])
         self.assertEqual(errors, [])
 
+    def test_run_extractors_out_of_scope_emits_warning(self):
+        """An out-of-scope target is dropped AND surfaces a Warning naming it."""
+        from secator.output_types import Warning
+        opts = {'in_scope': ['acme.test', '*.acme.test']}
+        inputs = ['app.acme.test', 'evil.attacker.test']
+        kept, _opts, messages = run_extractors([], opts, inputs=inputs)
+        self.assertEqual(kept, ['app.acme.test'])
+        warnings = [m for m in messages if isinstance(m, Warning)]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('evil.attacker.test', warnings[0].message)
+        # No scope opts -> allow-all -> no warning.
+        kept, _opts, messages = run_extractors([], {}, inputs=inputs)
+        self.assertEqual(sorted(kept), sorted(inputs))
+        self.assertEqual([m for m in messages if isinstance(m, Warning)], [])
+
     def test_run_extractors_with_group_by(self):
         """Full pipeline: Technology items → grouped search_vulns inputs via group_by extractor."""
         tech1 = Technology(match='10.0.0.1:80', product='apache httpd', version='2.4.50')

--- a/tests/unit/test_scope.py
+++ b/tests/unit/test_scope.py
@@ -1,0 +1,67 @@
+import unittest
+
+from secator.runners._helpers import run_extractors
+from secator.scope import as_scope_list, host_in_scope, target_in_scope
+
+
+class TestScopeMatcher(unittest.TestCase):
+	"""Semantics must mirror the platform (secator-api) mandate scope matcher."""
+
+	def test_apex_does_not_cover_subdomain(self):
+		# The bug: a scope of `claris.com` (apex only) must NOT cover discovered subdomains.
+		self.assertTrue(target_in_scope('claris.com', ['claris.com']))
+		self.assertFalse(target_in_scope('www.claris.com', ['claris.com']))
+
+	def test_wildcard_covers_subdomain(self):
+		self.assertTrue(target_in_scope('www.claris.com', ['*.claris.com']))
+		self.assertFalse(target_in_scope('claris.com', ['*.claris.com']))
+
+	def test_cidr_and_regex(self):
+		self.assertTrue(target_in_scope('10.0.0.5', ['10.0.0.0/24']))
+		self.assertFalse(target_in_scope('10.0.1.5', ['10.0.0.0/24']))
+		self.assertTrue(target_in_scope('https://api.acme.com/v1/', [r'^https?://api\.acme\.com/']))
+
+	def test_host_extracted_from_url(self):
+		self.assertTrue(target_in_scope('https://www.claris.com/login', ['*.claris.com']))
+
+	def test_deny_wins(self):
+		self.assertFalse(host_in_scope('secret.claris.com', ['*.claris.com'], ['secret.claris.com']))
+		self.assertTrue(host_in_scope('www.claris.com', ['*.claris.com'], ['secret.claris.com']))
+
+	def test_empty_in_scope_allows_all(self):
+		self.assertTrue(host_in_scope('anything.example', [], []))
+
+	def test_as_scope_list_coercion(self):
+		self.assertEqual(as_scope_list('a.com, b.com'), ['a.com', 'b.com'])
+		self.assertEqual(as_scope_list(['a.com', ' b.com ']), ['a.com', 'b.com'])
+		self.assertEqual(as_scope_list(None), [])
+
+
+class TestRunExtractorsScopeFilter(unittest.TestCase):
+	"""The fan-in choke point must drop out-of-scope discovered targets."""
+
+	def test_discovered_subdomain_filtered_against_allowlist(self):
+		# Simulates subdomain_recon feeding host_recon: claris.com in scope (apex only),
+		# www.claris.com discovered -> must be dropped before host_recon scans it.
+		discovered = ['claris.com', 'www.claris.com', 'api.claris.com']
+		inputs, _opts, errors = run_extractors(
+			[], {'in_scope': ['claris.com']}, inputs=discovered
+		)
+		self.assertEqual(errors, [])
+		self.assertEqual(inputs, ['claris.com'])
+
+	def test_wildcard_scope_keeps_subdomains(self):
+		discovered = ['claris.com', 'www.claris.com', 'evil.com']
+		inputs, _opts, _errors = run_extractors(
+			[], {'in_scope': ['*.claris.com', 'claris.com']}, inputs=discovered
+		)
+		self.assertEqual(sorted(inputs), ['claris.com', 'www.claris.com'])
+
+	def test_no_scope_option_is_noop(self):
+		discovered = ['claris.com', 'www.claris.com']
+		inputs, _opts, _errors = run_extractors([], {}, inputs=discovered)
+		self.assertEqual(sorted(inputs), ['claris.com', 'www.claris.com'])
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/unit/test_scope.py
+++ b/tests/unit/test_scope.py
@@ -131,12 +131,16 @@ class TestRunExtractorsScopeFilter(unittest.TestCase):
 	def test_discovered_subdomain_filtered_against_allowlist(self):
 		# Simulates subdomain_recon feeding host_recon: claris.com in scope (apex only),
 		# www.claris.com discovered -> must be dropped before host_recon scans it.
+		from secator.output_types import Warning
 		discovered = ['claris.com', 'www.claris.com', 'api.claris.com']
-		inputs, _opts, errors = run_extractors(
+		inputs, _opts, messages = run_extractors(
 			[], {'in_scope': ['claris.com']}, inputs=discovered
 		)
-		self.assertEqual(errors, [])
 		self.assertEqual(inputs, ['claris.com'])
+		warnings = [m for m in messages if isinstance(m, Warning)]
+		self.assertEqual(len(warnings), 1)
+		self.assertIn('www.claris.com', warnings[0].message)
+		self.assertIn('api.claris.com', warnings[0].message)
 
 	def test_wildcard_scope_keeps_subdomains(self):
 		discovered = ['claris.com', 'www.claris.com', 'evil.com']

--- a/tests/unit/test_scope.py
+++ b/tests/unit/test_scope.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 
 from secator.runners._helpers import run_extractors
@@ -7,29 +8,116 @@ from secator.scope import as_scope_list, host_in_scope, target_in_scope
 class TestScopeMatcher(unittest.TestCase):
 	"""Semantics must mirror the platform (secator-api) mandate scope matcher."""
 
+	# --- host / wildcard --------------------------------------------------
+
 	def test_apex_does_not_cover_subdomain(self):
-		# The bug: a scope of `claris.com` (apex only) must NOT cover discovered subdomains.
+		# apex-only scope `claris.com` must NOT cover discovered subdomains.
 		self.assertTrue(target_in_scope('claris.com', ['claris.com']))
 		self.assertFalse(target_in_scope('www.claris.com', ['claris.com']))
 
-	def test_wildcard_covers_subdomain(self):
+	def test_wildcard_covers_subdomain_but_not_apex(self):
 		self.assertTrue(target_in_scope('www.claris.com', ['*.claris.com']))
+		self.assertTrue(target_in_scope('a.b.claris.com', ['*.claris.com']))
+		# apex is NOT covered by a wildcard (documented behaviour).
 		self.assertFalse(target_in_scope('claris.com', ['*.claris.com']))
+		# and a wildcard must not match a lookalike suffix.
+		self.assertFalse(target_in_scope('evilclaris.com', ['*.claris.com']))
+		self.assertFalse(target_in_scope('www.claris.com.evil.net', ['*.claris.com']))
 
-	def test_cidr_and_regex(self):
+	def test_host_extracted_from_url_and_port(self):
+		self.assertTrue(target_in_scope('https://www.claris.com/login', ['*.claris.com']))
+		self.assertTrue(target_in_scope('www.claris.com:8443', ['*.claris.com']))
+		self.assertTrue(target_in_scope('https://app.acme.com/x', ['app.acme.com']))
+
+	# --- CIDR containment (v4 + v6) --------------------------------------
+
+	def test_cidr_containment_v4(self):
 		self.assertTrue(target_in_scope('10.0.0.5', ['10.0.0.0/24']))
 		self.assertFalse(target_in_scope('10.0.1.5', ['10.0.0.0/24']))
-		self.assertTrue(target_in_scope('https://api.acme.com/v1/', [r'^https?://api\.acme\.com/']))
+		# CIDR target subnet_of a CIDR entry.
+		self.assertTrue(target_in_scope('10.0.0.0/25', ['10.0.0.0/24']))
+		self.assertFalse(target_in_scope('10.0.0.0/23', ['10.0.0.0/24']))
 
-	def test_host_extracted_from_url(self):
-		self.assertTrue(target_in_scope('https://www.claris.com/login', ['*.claris.com']))
+	def test_cidr_containment_v6(self):
+		self.assertTrue(target_in_scope('2001:db8::1', ['2001:db8::/32']))
+		self.assertTrue(target_in_scope('2001:db8:abcd::5', ['2001:db8::/32']))
+		self.assertTrue(target_in_scope('[2001:db8::1]', ['2001:db8::/32']))
+
+	def test_ipv6_escape_bug_is_fixed(self):
+		# The old _host_of split(':')[0] truncated '2001:db9::1' -> '2001' and
+		# wrongly matched. `2001:db8::/32` must NOT cover `2001:db9::1`.
+		self.assertFalse(target_in_scope('2001:db9::1', ['2001:db8::/32']))
+		self.assertFalse(host_in_scope('2001:db9::1', ['2001:db8::/32'], []))
+
+	def test_localhost_is_a_scoped_host_not_a_crash(self):
+		# `localhost` classifies as IP type but is not a parseable IP literal;
+		# it must be treated as a scoped network host, not raise.
+		self.assertTrue(target_in_scope('localhost', ['localhost']))
+		self.assertFalse(host_in_scope('localhost', ['*.acme.com'], []))
+
+	def test_version_mismatch_never_matches(self):
+		self.assertFalse(target_in_scope('10.0.0.5', ['2001:db8::/32']))
+		self.assertFalse(target_in_scope('2001:db8::1', ['10.0.0.0/8']))
+
+	# --- anchored regex ---------------------------------------------------
+
+	def test_regex_is_fullmatch_anchored(self):
+		# `acme\.com` must match ONLY the exact string, never a substring.
+		self.assertTrue(target_in_scope('acme.com', [r'acme\.com']))
+		self.assertFalse(target_in_scope('evil-acme.com.attacker.net', [r'acme\.com']))
+		self.assertFalse(target_in_scope('acme.com.evil.net', [r'acme\.com']))
+
+	def test_regex_unanchored_substring_does_not_match(self):
+		# Even an explicit ^...$ must be enforced at BOTH ends (fullmatch).
+		self.assertTrue(target_in_scope('api.acme.com', [r'^api\.acme\.com$']))
+		self.assertFalse(target_in_scope('api.acme.com.evil.net', [r'^api\.acme\.com$']))
+		self.assertFalse(target_in_scope('x.api.acme.com', [r'^api\.acme\.com$']))
+
+	def test_regex_matches_full_url(self):
+		self.assertTrue(target_in_scope('https://api.acme.com/v1/', [r'https?://api\.acme\.com/.*']))
+		# a prefix-only regex does NOT fullmatch a longer URL.
+		self.assertFalse(target_in_scope('https://api.acme.com/v1/', [r'https?://api\.acme\.com/']))
+
+	def test_pathological_regex_does_not_hang(self):
+		# Catastrophic (a+)+ pattern must be rejected, not executed. Call returns
+		# fast and simply does not match (fail-safe non-matching).
+		start = time.monotonic()
+		result = host_in_scope('aaaaaaaaaaaaaaaaaaaaaaaaaaaa.com', [r'(a+)+$'], [])
+		elapsed = time.monotonic() - start
+		self.assertFalse(result)  # bad allow entry -> nothing matches -> out of scope
+		self.assertLess(elapsed, 1.0)
+
+	def test_uncompilable_regex_is_skipped(self):
+		# An un-compilable entry contributes no match (does not raise).
+		self.assertFalse(target_in_scope('acme.com', [r'(unclosed']))
+		# ...and a broken DENY entry does not block (allow-list stays the boundary).
+		self.assertTrue(host_in_scope('acme.com', ['acme.com'], [r'(unclosed']))
+
+	# --- deny wins / empty scope -----------------------------------------
 
 	def test_deny_wins(self):
 		self.assertFalse(host_in_scope('secret.claris.com', ['*.claris.com'], ['secret.claris.com']))
 		self.assertTrue(host_in_scope('www.claris.com', ['*.claris.com'], ['secret.claris.com']))
 
+	def test_deny_cidr_inside_allow_cidr(self):
+		# deny CIDR nested inside an allow CIDR -> deny wins.
+		self.assertFalse(host_in_scope('10.0.0.5', ['10.0.0.0/8'], ['10.0.0.0/24']))
+		self.assertTrue(host_in_scope('10.1.0.5', ['10.0.0.0/8'], ['10.0.0.0/24']))
+
 	def test_empty_in_scope_allows_all(self):
 		self.assertTrue(host_in_scope('anything.example', [], []))
+		self.assertTrue(host_in_scope('10.9.9.9', [], []))
+		# ...but deny still applies with an empty allow-list.
+		self.assertFalse(host_in_scope('10.0.0.5', [], ['10.0.0.0/24']))
+
+	# --- non-network targets are never scoped ----------------------------
+
+	def test_non_network_target_is_kept(self):
+		# email / username-ish / path are not NETWORK targets -> always kept,
+		# even against a restrictive allow-list or a matching-looking deny.
+		self.assertTrue(host_in_scope('user@example.com', ['*.corp.internal'], []))
+		self.assertTrue(host_in_scope('user@example.com', [], ['.*@example.com']))
+		self.assertTrue(host_in_scope('550e8400-e29b-41d4-a716-446655440000', ['*.acme.com'], []))
 
 	def test_as_scope_list_coercion(self):
 		self.assertEqual(as_scope_list('a.com, b.com'), ['a.com', 'b.com'])

--- a/tests/unit/test_scope_inheritance.py
+++ b/tests/unit/test_scope_inheritance.py
@@ -1,0 +1,123 @@
+"""Linchpin test for PR3 of the target-scoping rework.
+
+Run-scope (`in_scope`/`out_of_scope`) set on a ROOT runner's run_opts must reach EVERY descendant
+runner (scan -> workflow -> task, including the dynamically-spawned fan-out where one task
+discovers targets another task then scans, e.g. subdomain_recon -> host_recon) and DROP the
+out-of-scope discovered targets before they are actively scanned -- while an unset scope leaves CLI
+behaviour unchanged (allow-all).
+
+This exercises the real celery build+execute path in sync mode (same harness as
+test_target_filter_scope / #1328): `discovertask` stands in for a recon step that DISCOVERS targets,
+`consumetask` stands in for the downstream active task that resolves those discovered Targets as its
+own scan inputs. The filter is applied in `run_extractors` (secator/runners/_helpers.py), the single
+scan-input choke point; finding emission (the Targets a task yields) is NOT gated.
+"""
+import unittest
+from unittest.mock import patch
+
+from secator.decorators import task
+from secator.output_types import Target
+from secator.runners import Scan
+from secator.runners.command import Command
+from secator.template import TemplateLoader
+
+
+# What each downstream (active) task resolved its scan inputs to, after scope filtering.
+RESOLVED = {}
+
+# A recon step "discovers" these: one in-scope subdomain + one out-of-scope host it found (e.g. in
+# JS/HTML/a cert). Reporting it as a finding is fine; feeding it as an active-scan input is not.
+DISCOVERED = ['api.acme.test', 'evil.attacker.test']
+
+
+@task()
+class discovertask(Command):
+	"""Recon stand-in: emits discovered Targets regardless of its own inputs."""
+	cmd = 'true'
+	input_types = []  # accept any input
+	output_types = [Target]
+
+	def yielder(self):
+		for name in DISCOVERED:
+			yield Target(name=name)
+
+
+@task()
+class consumetask(Command):
+	"""Active-task stand-in: resolves upstream discovered Targets as its scan inputs (scope filter is
+	applied in _run_extractors) and records exactly what it would actively scan."""
+	cmd = 'true'
+	input_types = []
+	output_types = [Target]
+
+	def _run_extractors(self):
+		super()._run_extractors()
+		RESOLVED[self.unique_name] = sorted(self.inputs)
+
+	def yielder(self):
+		for name in self.inputs:
+			yield Target(name=name)
+
+
+def _wf(name, task_name, task_node, task_targets_=None):
+	opts = {'targets_': task_targets_} if task_targets_ is not None else {}
+	return TemplateLoader(input={
+		'type': 'workflow', 'name': name,
+		'tasks': {f'{task_name}/{task_node}': opts},
+	})
+
+
+class TestScopeInheritance(unittest.TestCase):
+
+	ROOT = ['acme.test']  # a network root that is itself in scope (exact host)
+
+	def setUp(self):
+		"""Register the mock tasks and serve inline workflow templates by name."""
+		RESOLVED.clear()
+		import secator.runners.task as task_mod
+		import secator.loader as loader_mod
+		self._orig_discover = task_mod.discover_tasks
+		task_mod.discover_tasks = lambda: list(self._orig_discover()) + [discovertask, consumetask]
+		# wf1 discovers targets; wf2 (scan-level targets_) consumes them via parent_scope, which is
+		# the dynamically-spawned fan-out the scope must reach.
+		self._templates = [
+			_wf('wf1', 'discovertask', 'recon'),
+			_wf('wf2', 'consumetask', 'active', {'type': 'target', 'field': 'name'}),
+		]
+		self._patch_ft = patch.object(loader_mod, 'find_templates', side_effect=lambda: self._templates)
+		self._patch_ft.start()
+
+	def tearDown(self):
+		import secator.runners.task as task_mod
+		task_mod.discover_tasks = self._orig_discover
+		self._patch_ft.stop()
+
+	def _run(self, run_opts):
+		scan_cfg = TemplateLoader(input={
+			'type': 'scan', 'name': 'myscan',
+			'workflows': {'wf1': {}, 'wf2': {'targets_': {'type': 'target', 'field': 'name'}}},
+		})
+		scan = Scan(scan_cfg, self.ROOT, run_opts={'sync': True, **run_opts}, context={})
+		list(scan)
+		return [inp for uname, inp in RESOLVED.items() if uname.startswith('consumetask_active')]
+
+	def test_out_of_scope_discovered_target_is_dropped(self):
+		"""in_scope inherited from the scan reaches the downstream active task and drops the
+		out-of-scope discovered target before it is scanned (the linchpin)."""
+		results = self._run({'in_scope': ['acme.test', '*.acme.test']})
+		self.assertTrue(results, 'downstream active task never executed')
+		for inputs in results:
+			self.assertIn('api.acme.test', inputs)        # in-scope discovered target kept
+			self.assertNotIn('evil.attacker.test', inputs)  # out-of-scope discovered target dropped
+
+	def test_no_scope_allows_all(self):
+		"""No scope set -> allow-all: CLI behaviour unchanged, out-of-scope discovered target scanned."""
+		results = self._run({})
+		self.assertTrue(results, 'downstream active task never executed')
+		for inputs in results:
+			self.assertIn('api.acme.test', inputs)
+			self.assertIn('evil.attacker.test', inputs)  # nothing dropped without a scope
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -156,7 +156,7 @@ Content-Type: text/html"""
 
 from unittest import mock
 import dns.resolver
-from secator.utils import canonicalize_target, split_targets, classify_target
+from secator.utils import canonicalize_target, split_targets, classify_target, _target_host
 
 
 class TestCanonicalizeTarget(unittest.TestCase):
@@ -170,7 +170,11 @@ class TestCanonicalizeTarget(unittest.TestCase):
 			('127.1', '127.0.0.1', IP),           # short form
 			('0x7f.0.0.1', '127.0.0.1', IP),      # hex
 			('täst.de', 'xn--tst-qla.de', HOST),  # IDN host -> punycode
-			('[2001:db8::1]', '2001:db8::1', IP),  # bracketed IPv6
+			('[2001:db8::1]', '2001:db8::1', IP),  # bracketed IPv6, no port -> unwrapped
+			# Bracketed IPv6 WITH a port: brackets kept as the host:port delimiter (RFC 3986). They
+			# must NOT be dropped -- '2001:db8::1:443' is a DIFFERENT valid IPv6 (443 as a hextet).
+			('[2001:db8::1]:443', '[2001:db8::1]:443', HOST_PORT),
+			('[::1]:80', '[::1]:80', HOST_PORT),
 		]
 		for raw, canon, ttype in cases:
 			with self.subTest(raw=raw):
@@ -267,8 +271,9 @@ class TestClassifyTarget(unittest.TestCase):
 			for token in [
 				'8.8.8.8:443',
 				'192.168.1.1:22',
-				'[2001:db8::1]:443',   # canonicalizes to a valid IPv6 literal
-				'2001:db8::1:443',     # bare 8-group IPv6 literal
+				'[2001:db8::1]:443',   # bracketed IPv6 + port -> host:port over an IPv6 literal
+				'[::1]:80',            # loopback IPv6 + port
+				'2001:db8::1:443',     # bare 8-group IPv6 literal (distinct from the bracketed form)
 				'http://8.8.8.8:443/',  # URL whose host is an IPv4 literal
 				'https://[2001:db8::1]/',  # URL whose host is a bracketed IPv6 literal
 			]:
@@ -276,6 +281,22 @@ class TestClassifyTarget(unittest.TestCase):
 					info = classify_target(token, resolve=True)
 					self.assertTrue(info.is_network and info.reachable,
 						f'{token} was NOT classified network by construction')
+
+	def test_bracketed_ipv6_with_port_keeps_host_and_port_distinct(self):
+		# The port must NOT be absorbed into the address: [2001:db8::1]:443 must extract host
+		# 2001:db8::1, NOT the different valid IPv6 2001:db8::1:443 (443 smuggled in as a hextet).
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=AssertionError('DNS called')):
+			for token, real_host, absorbed in [
+				('[2001:db8::1]:443', '2001:db8::1', '2001:db8::1:443'),
+				('[::1]:80', '::1', '::1:80'),
+			]:
+				with self.subTest(token=token):
+					info = classify_target(token, resolve=True)
+					self.assertEqual(info.type, HOST_PORT)
+					self.assertTrue(info.is_network and info.reachable)  # IP literal -> no DNS
+					host = _target_host(canonicalize_target(token), info.type)
+					self.assertEqual(host, real_host)
+					self.assertNotEqual(host, absorbed)
 
 
 from secator.utils import remove_duplicates

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -154,6 +154,130 @@ Content-Type: text/html"""
 		self.assertEqual(result, {})
 
 
+from unittest import mock
+import dns.resolver
+from secator.utils import canonicalize_target, split_targets, classify_target
+
+
+class TestCanonicalizeTarget(unittest.TestCase):
+	def test_canonicalize_and_classify_network_forms(self):
+		# (raw, expected canonical, expected type) -- all must canonicalize to the real host
+		# and classify as a network type. Covers the smuggling vectors + IDN + bracketed IPv6.
+		cases = [
+			(' 1.2.3.4', '1.2.3.4', IP),          # whitespace
+			('2130706433', '127.0.0.1', IP),      # decimal inet_aton
+			('0177.0.0.1', '127.0.0.1', IP),      # octal
+			('127.1', '127.0.0.1', IP),           # short form
+			('0x7f.0.0.1', '127.0.0.1', IP),      # hex
+			('täst.de', 'xn--tst-qla.de', HOST),  # IDN host -> punycode
+			('[2001:db8::1]', '2001:db8::1', IP),  # bracketed IPv6
+		]
+		for raw, canon, ttype in cases:
+			with self.subTest(raw=raw):
+				self.assertEqual(canonicalize_target(raw), canon)
+				# resolve=False keeps it pure; type detection still sees the canonical (network) form.
+				self.assertEqual(classify_target(raw, resolve=False).type, ttype)
+
+	def test_canonicalize_empty(self):
+		self.assertEqual(canonicalize_target('  '), '')
+		self.assertEqual(canonicalize_target(None), '')
+
+
+class TestSplitTargets(unittest.TestCase):
+	def test_split_on_comma_and_newline(self):
+		self.assertEqual(
+			split_targets('a.com,b.com\n1.2.3.4 , \n c.com'),
+			['a.com', 'b.com', '1.2.3.4', 'c.com'],
+		)
+		self.assertEqual(split_targets(['a.com,b.com', 'c.com']), ['a.com', 'b.com', 'c.com'])
+		self.assertEqual(split_targets(''), [])
+
+
+class TestClassifyTarget(unittest.TestCase):
+	def test_type_detection(self):
+		# type mirrors autodetect_type across network + one non-network example
+		cases = [
+			('1.2.3.4', IP),
+			('192.168.1.0/24', CIDR_RANGE),
+			('example.com', HOST),               # registrable domain -> HOST
+			('sub.example.com', HOST),           # bare hostname -> HOST
+			('https://example.com/path', URL),
+			('test@example.com', EMAIL),         # non-network
+		]
+		for token, ttype in cases:
+			with self.subTest(token=token):
+				self.assertEqual(classify_target(token, resolve=False).type, ttype)
+
+	def test_ip_cidr_network_by_construction_no_dns(self):
+		# ip/cidr are network+reachable WITHOUT any DNS call, even with resolve=True.
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=AssertionError('DNS called')):
+			ip = classify_target('1.2.3.4', resolve=True)
+			self.assertTrue(ip.is_network and ip.reachable)
+			self.assertEqual(ip.root, '1.2.3.4')
+			cidr = classify_target('10.0.0.0/8', resolve=True)
+			self.assertTrue(cidr.is_network and cidr.reachable)
+			self.assertEqual(cidr.root, '10.0.0.0')  # cidr root = network address
+
+	def test_is_network_dns_resolves(self):
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', return_value=mock.MagicMock()) as m:
+			info = classify_target('example.com', resolve=True)
+			self.assertTrue(info.is_network and info.reachable)
+			m.assert_called()
+
+	def test_is_network_dns_nxdomain(self):
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=dns.resolver.NXDOMAIN):
+			info = classify_target('nope.invalid', resolve=True)
+			self.assertFalse(info.is_network)
+			self.assertFalse(info.reachable)
+
+	def test_url_root_is_hostname_and_resolves(self):
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', return_value=mock.MagicMock()):
+			info = classify_target('https://sub.example.com:8443/a?b=c', resolve=True)
+			self.assertEqual(info.root, 'sub.example.com')
+			self.assertTrue(info.is_network)
+
+	def test_resolve_false_is_pure_no_io(self):
+		# The pure path must NOT touch DNS: a resolver that raises if called proves it.
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=AssertionError('DNS called')):
+			host = classify_target('example.com', resolve=False)
+			self.assertEqual(host.type, HOST)
+			self.assertFalse(host.is_network)  # unverified without DNS
+			# autodetect_type itself is pure regex -> also must not call DNS
+			self.assertEqual(autodetect_type('example.com'), HOST)
+
+	def test_scope_and_near_miss_forms_never_network(self):
+		# Adversarial: wildcard/regex scope entries and near-miss junk must classify non-network,
+		# never smuggled in as a network target.
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', return_value=mock.MagicMock()):
+			for token in [
+				'*.example.com',      # wildcard scope
+				'.*\\.corp$',         # regex scope
+				'example.*',
+				'[a-z].example.com',  # char-class
+				'exa mple.com',       # space
+			]:
+				with self.subTest(token=token):
+					self.assertFalse(classify_target(token, resolve=True).is_network,
+						f'{token} slipped through as network')
+
+	def test_ip_literal_host_is_network_no_dns(self):
+		# Fail-open regression: an IP literal hiding in host:port / [IPv6]:port / URL host is a
+		# concrete target the scanner WILL hit -> must be network BY CONSTRUCTION, never via DNS.
+		with mock.patch.object(dns.resolver.Resolver, 'resolve', side_effect=AssertionError('DNS called')):
+			for token in [
+				'8.8.8.8:443',
+				'192.168.1.1:22',
+				'[2001:db8::1]:443',   # canonicalizes to a valid IPv6 literal
+				'2001:db8::1:443',     # bare 8-group IPv6 literal
+				'http://8.8.8.8:443/',  # URL whose host is an IPv4 literal
+				'https://[2001:db8::1]/',  # URL whose host is a bracketed IPv6 literal
+			]:
+				with self.subTest(token=token):
+					info = classify_target(token, resolve=True)
+					self.assertTrue(info.is_network and info.reachable,
+						f'{token} was NOT classified network by construction')
+
+
 from secator.utils import remove_duplicates
 from secator.output_types import Vulnerability
 


### PR DESCRIPTION
Promotes the validated canary scope-gate work to `main` for the prod release. Cherry-picks of #1343, #1345, #1346, #1347, #1348, #1349 (main had no `scope.py`).

- `classify_target` / `canonicalize_target` single-source classifier (alt-IPv4, IDNA, bracketed IPv6, network-reachability) — `secator/utils.py`
- `host_in_scope` secure scope matcher (anchored-fullmatch regex, ipaddress v4/v6 containment, deny-wins, empty=allow-all, non-network kept) — `secator/scope.py`
- discovered-target scope enforcement at the `run_extractors` fan-in choke point + producer scope inheritance
- `[WRN]` surfaced when a target is dropped as out-of-scope

43 scope/classifier/inheritance tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added allowlist and blocklist filtering for network targets, including hostnames, wildcards, IP addresses, CIDR ranges, and regular expressions.
  * Scope settings now apply consistently to discovered targets throughout workflows.
  * Added target normalization, classification, splitting, and DNS resolution support.
* **Bug Fixes**
  * Out-of-scope targets are excluded before scanning and generate warnings.
  * Improved handling of IPv6 addresses and malformed ports.
  * Extractor warnings and errors are now surfaced as runner results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->