### PR TITLE
test(integration): stop pinning the drifting free.fr testssl cert fingerprint

### DIFF
--- a/tests/integration/outputs.py
+++ b/tests/integration/outputs.py
@@ -18,7 +18,19 @@ OUTPUTS_CHECKS = {
 				},
 			],
 			'runner': '^(?!urlfinder|xurlfind3r|gau|urlparser$).*',
-		}
+		},
+		Certificate: {
+			'checks': [
+				{
+					# Don't pin the fingerprint/expiry: the target host renews its cert,
+					# so assert testssl parsed a real certificate instead.
+					'info': 'should have a valid sha256 fingerprint and a host',
+					'error': 'testssl did not produce a certificate with a real sha256 fingerprint',
+					'function': lambda item: len(item.fingerprint_sha256) == 64 and bool(item.host),
+				},
+			],
+			'runner': 'testssl',
+		},
 	},
 	# 'runner': {
 	#     Command: {
@@ -160,9 +172,8 @@ OUTPUTS_TASKS = {
 	'search_vulns': [
 		Exploit(name='Apache exploit', provider='apache', id='CVE-2019-10081-exploit', matched_at='apache 2.4.39', confidence='high'),
 	],
-	'testssl': [
-		Certificate(host='free.fr', fingerprint_sha256='B425AF159E0B51051EEFAC692595C7CFDFA71690406FEE6428A47C9524D1187E', _source='testssl'),
-	],
+	# Cert is verified via OUTPUTS_CHECKS (fingerprint/expiry drift as the host renews).
+	'testssl': [],
 	'wpscan': [
 		Tag(name='wordpress_theme', category='info', value='twentytwentyfive:1.5', match='http://localhost:8000/', _source='wpscan'),
 		Vulnerability(matched_at='http://localhost:8000/', ip='127.0.0.1', name='Headers', confidence='high', severity='info', cvss_score=0, _source='wpscan'),


### PR DESCRIPTION
`test_tasks` hard-coded a Certificate fingerprint for the live host **free.fr** (`outputs.py:164`, `B425AF159E…`). free.fr renewed its cert (now `0F098362CA…`, valid to 2026-11-01), so the fixture stopped matching and the `integration` gate went red — the same red check that got bypassed during the 0.43.0 promotion.

Fix (mirrors #1325's drift handling): drop the exact-match fixture and verify the cert via `OUTPUTS_CHECKS` — assert testssl produced a Certificate with a real 64-char sha256 fingerprint and a host, without pinning the value that renews. `empty_results_allowed=False` still ensures testssl produces output.

Test-only change; verified the check passes a real cert and fails an empty one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)