### PR TITLE
fix(wpprobe): restore -f multi-target scanning

### DIFF
--- a/secator/tasks/wpprobe.py
+++ b/secator/tasks/wpprobe.py
@@ -18,10 +18,9 @@ class wpprobe(Command):
 	"""Fast wordpress plugin enumeration tool."""
 	cmd = 'wpprobe'
 	input_types = [URL]
-	input_chunk_size = 1
 	output_types = [Vulnerability, Tag]
 	tags = ['vuln', 'scan', 'wordpress']
-	# file_flag = '-f'
+	file_flag = '-f'
 	input_flag = '-u'
 	opt_prefix = '-'
 	opts = {
@@ -34,7 +33,7 @@ class wpprobe(Command):
 	opt_key_map = {
 		THREADS: 't'
 	}
-	install_version = 'v0.11.1'
+	install_version = 'v0.12.11'
 	install_cmd = 'go install github.com/Chocapikk/wpprobe@[install_version]'
 	github_handle = 'Chocapikk/wpprobe'
 	install_post = {
@@ -71,17 +70,28 @@ class wpprobe(Command):
 		yield Info(message=f'JSON results saved to {self.output_path}')
 		with open(self.output_path, 'r') as f:
 			results = json.load(f)
-			if not results or 'url' not in results:
-				yield Warning(message='No results found !')
-				return
-			url = results['url']
+
+		# wpprobe >= v0.12.11 always emits a JSON array, one object per target
+		# (https://github.com/Chocapikk/wpprobe/issues/33). Older versions emitted
+		# a single object, so accept both shapes.
+		if isinstance(results, dict):
+			results = [results]
+
+		if not results:
+			yield Warning(message='No results found !')
+			return
+
+		for result in results:
+			if 'url' not in result:
+				continue
+			url = result['url']
 
 			# Parse plugins
-			for item in wpprobe._parse_software(results.get('plugins', {}), url, 'plugin'):
+			for item in wpprobe._parse_software(result.get('plugins', {}), url, 'plugin'):
 				yield item
 
 			# Parse themes (v0.11.0+, absent in older versions)
-			for item in wpprobe._parse_software(results.get('themes', {}), url, 'theme'):
+			for item in wpprobe._parse_software(result.get('themes', {}), url, 'theme'):
 				yield item
 
 	@staticmethod


### PR DESCRIPTION
Follow-up to #1355 by @bpce-it-dis-soc-sof, which worked around Chocapikk/wpprobe#33 by scanning one URL at a time (`input_chunk_size = 1`, `-f` disabled), because wpprobe emitted concatenated JSON objects (JSONL) that `json.load` could not parse for multiple targets.

That's now fixed upstream in **wpprobe v0.12.11**, which always emits a proper JSON array, one object per target (Chocapikk/wpprobe#33). So `-f` can be restored and targets scanned in a single wpprobe call again.

### Changes
- Re-enable `file_flag = '-f'` and drop `input_chunk_size = 1` (from #1355)
- Bump `install_version` to `v0.12.11`
- Parse the JSON array (one object per target), still accepting the old single-object shape for backward compatibility

### Testing
Ran against a live WordPress lab (Elementor 3.5.0 installed) with two targets:

```
printf 'http://localhost:8099\nhttp://127.0.0.1:8099\n' | secator x wpprobe -json
# -> 4 tags, 64 vulnerabilities, split across both URLs, correct CVEs
```

Single-target runs are unchanged (2 tags / 32 vulns), and `flake8` is clean.

Refs:
- freelabz/secator#1355
- Chocapikk/wpprobe#33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated WordPress scanning to support the latest wpprobe output format.
  * Improved processing of multiple targets, including their URLs, plugins, and themes.
  * Maintained compatibility with legacy wpprobe result formats.
  * Updated the bundled wpprobe version for improved scanning reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->