### PR TITLE
feat(ai): migrate AI target authorization to in_scope/out_of_scope scope-gate

### DIFF
--- a/secator/ai/actions.py
+++ b/secator/ai/actions.py
@@ -34,6 +34,8 @@ class ActionContext:
 	verbose: bool = False
 	context: Dict = field(default_factory=dict)
 	scope: str = "workspace"
+	in_scope: Any = None  # mandate allow-list (run-opt); routed to every spawned child
+	out_of_scope: Any = None  # mandate deny-list (run-opt)
 	results: Optional[List[Dict]] = None
 	max_workers: int = 3
 	in_batch: bool = False  # H4: set on the per-batch ctx so the per-turn fan-out cap applies
@@ -648,6 +650,10 @@ def _run_runner(action: Dict, ctx: ActionContext, runner_type: str) -> Generator
 		"sync": ctx.sync,
 		"tty": not ctx.subagent and ctx.sync,
 		**opts,
+		# Force the run's mandate scope AFTER **opts so the LLM can't widen it; the
+		# child filters its inputs (LLM-generated + discovered) via host_in_scope.
+		"in_scope": ctx.in_scope,
+		"out_of_scope": ctx.out_of_scope,
 	}
 	if runner_type == "workflow":
 		run_opts["print_start"] = not ctx.silent and not ctx.subagent
@@ -813,6 +819,8 @@ def _handle_shell(action: Dict, ctx: ActionContext) -> Generator:
 			"sync": ctx.sync,
 			"dangerous": False,
 			"env": _sanitized_env(),
+			"in_scope": ctx.in_scope,
+			"out_of_scope": ctx.out_of_scope,
 		}
 
 		# Instantiate the concrete `command` task directly (NOT the generic Task

--- a/secator/ai/guardrails.py
+++ b/secator/ai/guardrails.py
@@ -967,27 +967,29 @@ class PermissionEngine:
 				values_to_check.append(f"{parsed.hostname}:{parsed.port}")
 
 		# Mandate scope boundary (in_scope/out_of_scope, derived by the API from the
-		# run's covering mandates and injected as run-opts). Deny-wins and fail-closed;
-		# a non-empty in_scope authorizes in-scope targets without prompting. An
-		# out-of-in_scope target falls through to the config/runtime rules + the
-		# interactive `ask` below, so the CLI approve path is preserved. Empty scope
-		# (CLI default) skips this entirely. Matched via the same host_in_scope every
-		# other runner uses.
-		if rule_type == "target" and (self.in_scope or self.out_of_scope):
-			if self.out_of_scope:
-				for v in values_to_check:
-					if not host_in_scope(v, [], self.out_of_scope):
-						return PermissionResult(decision="deny", reason=f"Out of scope: target({v})")
-			if self.in_scope:
-				for v in values_to_check:
-					if host_in_scope(v, self.in_scope, self.out_of_scope):
-						return PermissionResult(decision="allow", reason=f"In scope: target({v})")
+		# run's covering mandates and injected as run-opts). Deny-wins / fail-closed.
+		# BOTH out_of_scope AND the config safety-denies (metadata/localhost/127.0.0.1)
+		# are checked BEFORE the in_scope allow, so a broad mandate can never authorize
+		# a hard-denied target. A non-empty in_scope then authorizes in-scope targets
+		# without prompting; an out-of-in_scope target falls through to the config/
+		# runtime rules + the interactive `ask` below, so the CLI approve path is
+		# preserved. Empty scope (CLI default) skips the mandate checks. Same
+		# host_in_scope every other runner uses.
+		if rule_type == "target" and self.out_of_scope:
+			for v in values_to_check:
+				if not host_in_scope(v, [], self.out_of_scope):
+					return PermissionResult(decision="deny", reason=f"Out of scope: target({v})")
 
 		for rt, patterns in self.rules["deny"]:
 			if rt == rule_type:
 				for v in values_to_check:
 					if match_rule(v, patterns):
 						return PermissionResult(decision="deny", reason=f"Denied by rule: {rule_type}({v})")
+
+		if rule_type == "target" and self.in_scope:
+			for v in values_to_check:
+				if host_in_scope(v, self.in_scope, self.out_of_scope):
+					return PermissionResult(decision="allow", reason=f"In scope: target({v})")
 
 		for rt, patterns in self.rules["allow"]:
 			if rt == rule_type:

--- a/secator/ai/guardrails.py
+++ b/secator/ai/guardrails.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from typing import Dict, List, Optional, Tuple, Union
 
 from secator.ai.encryption import PII_PATTERNS
+from secator.scope import host_in_scope, as_scope_list
 
 # URL pattern for target detection
 URL_PATTERN = re.compile(r'https?://[^\s\'"]+')
@@ -235,23 +236,18 @@ def _is_network_target(value: str) -> bool:
 
 	Filters out descriptive strings that aren't actual targets.
 	"""
+	# Reuse the shipped classifier (same detection the in_scope/out_of_scope options
+	# use) instead of a parallel regex set. resolve=False keeps it pure (no DNS).
+	from secator.utils import classify_target, NETWORK_TYPES
 	if ' ' in value.strip():
 		return False
-	if value.startswith(('http://', 'https://')):
-		return True
-	if PII_PATTERNS["ipv4"].fullmatch(value):
-		return True
-	# CIDR notation (e.g. 10.0.0.0/24)
-	if '/' in value and PII_PATTERNS["ipv4"].match(value.split('/')[0]):
-		return True
-	if PII_PATTERNS["host"].fullmatch(value):
-		return True
-	# host:port
-	if ':' in value:
-		host_part = value.rsplit(':', 1)[0]
-		if PII_PATTERNS["ipv4"].fullmatch(host_part) or PII_PATTERNS["host"].fullmatch(host_part):
-			return True
-	return False
+	# For extracting targets from a shell command, require a structural marker
+	# ('.', ':', '/') — otherwise a bare token like a timeout arg '60' (a decimal-
+	# encoded IP to the classifier) or a command name ('curl', a single-label host)
+	# would be mistaken for a target. IP/CIDR/URL/host:port/FQDN all carry a marker.
+	if not any(ch in value for ch in './:'):
+		return False
+	return classify_target(value, resolve=False).type in NETWORK_TYPES
 
 
 @lru_cache(maxsize=256)
@@ -773,9 +769,14 @@ class PermissionEngine:
 	Two-step validation: (1) action type check, (2) target/path check.
 	"""
 
-	def __init__(self, config: Dict, targets: List[str] = None, workspace: str = ""):
+	def __init__(self, config: Dict, targets: List[str] = None, workspace: str = "",
+				in_scope=None, out_of_scope=None):
 		self.targets = targets or []
 		self.workspace = str(workspace)
+		# Mandate-derived allow/deny target lists (run-opts). Empty = no mandate
+		# boundary (CLI): fall through to the config/runtime rules + interactive ask.
+		self.in_scope = as_scope_list(in_scope)
+		self.out_of_scope = as_scope_list(out_of_scope)
 		self.rules = {"allow": [], "deny": [], "ask": []}
 		self.runtime_allow: List[Tuple[str, List[str]]] = []
 
@@ -964,6 +965,23 @@ class PermissionEngine:
 				values_to_check.append(parsed.hostname)
 			if parsed.port:
 				values_to_check.append(f"{parsed.hostname}:{parsed.port}")
+
+		# Mandate scope boundary (in_scope/out_of_scope, derived by the API from the
+		# run's covering mandates and injected as run-opts). Deny-wins and fail-closed;
+		# a non-empty in_scope authorizes in-scope targets without prompting. An
+		# out-of-in_scope target falls through to the config/runtime rules + the
+		# interactive `ask` below, so the CLI approve path is preserved. Empty scope
+		# (CLI default) skips this entirely. Matched via the same host_in_scope every
+		# other runner uses.
+		if rule_type == "target" and (self.in_scope or self.out_of_scope):
+			if self.out_of_scope:
+				for v in values_to_check:
+					if not host_in_scope(v, [], self.out_of_scope):
+						return PermissionResult(decision="deny", reason=f"Out of scope: target({v})")
+			if self.in_scope:
+				for v in values_to_check:
+					if host_in_scope(v, self.in_scope, self.out_of_scope):
+						return PermissionResult(decision="allow", reason=f"In scope: target({v})")
 
 		for rt, patterns in self.rules["deny"]:
 			if rt == rule_type:

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -447,6 +447,8 @@ class ai(PythonRunner):
 			verbose=self.verbose,
 			context=self.context or {},
 			scope=self.scope,
+			in_scope=self.run_opts.get('in_scope'),
+			out_of_scope=self.run_opts.get('out_of_scope'),
 			# AI accumulates its own action results here; queries the store on demand (avoids OOM on the full subtree)
 			results=[],
 			max_workers=self.max_workers,
@@ -699,7 +701,9 @@ class ai(PythonRunner):
 		self.permission_engine = PermissionEngine(
 			CONFIG.addons.ai.permissions,
 			targets=self.inputs,
-			workspace=self.reports_folder or ""
+			workspace=self.reports_folder or "",
+			in_scope=self.run_opts.get('in_scope'),
+			out_of_scope=self.run_opts.get('out_of_scope'),
 		)
 
 		# Per-run billed-token accounting. The platform billing chore reads
@@ -746,9 +750,6 @@ class ai(PythonRunner):
 		if self.context is not None:
 			self.context["session_id"] = self.session_id
 		self.backend = create_backend(self.interactive, timeout=CONFIG.addons.ai.user_response_timeout)
-
-		# Auto-approve workspace targets
-		self._auto_approve_workspace_targets()
 
 		# Suppress noisy output for subagents
 		if self.is_subagent:
@@ -829,25 +830,6 @@ class ai(PythonRunner):
 	# -------------------------------------------------------------------------
 	# Workspace helpers
 	# -------------------------------------------------------------------------
-
-	def _auto_approve_workspace_targets(self):
-		"""Auto-approve all targets found in the workspace."""
-		workspace_id = self.context.get("workspace_id", "")
-		if not workspace_id:
-			return
-		try:
-			from secator.query import QueryEngine
-			engine = QueryEngine(workspace_id, context=dict(self.context))
-			results = engine.search({"_type": "target"}, limit=1000)
-			target_names = {r.get("name") or r.get("_name", "") for r in results if r}
-			target_names.discard("")
-			self.debug(f'[workspace] found {len(results)} target(s): {list(target_names)[:20]}', sub='guardrail')
-			if target_names:
-				rule = f"target({','.join(target_names)})"
-				self.debug(f'[workspace] auto-approve: {rule}', sub='guardrail')
-				self.permission_engine.add_runtime_allow([rule])
-		except Exception as e:
-			self.debug(f'[workspace] failed to query targets: {e}', sub='guardrail')
 
 	# -------------------------------------------------------------------------
 	# Summarization / compaction

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -170,6 +170,15 @@ class TestScopeGate(unittest.TestCase):
 		self.assertEqual(e.out_of_scope, [])
 		self.assertEqual(e._check_values("target", ["x.com"]).decision, "ask")
 
+	def test_config_safety_deny_beats_broad_in_scope(self):
+		# A hard config deny (metadata/localhost) must win even when a broad mandate
+		# in_scope (e.g. a wide CIDR) would otherwise cover the target. Config deny is
+		# checked BEFORE the in_scope allow.
+		cfg = dict(allow=[], deny=['target(127.0.0.1)', 'target(169.254.169.254)'], ask=[])
+		e = PermissionEngine(cfg, in_scope=["127.0.0.0/8", "169.254.0.0/16"])
+		self.assertEqual(e._check_value("target", "127.0.0.1").decision, "deny")
+		self.assertEqual(e._check_value("target", "169.254.169.254").decision, "deny")
+
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
 class TestDetection(unittest.TestCase):

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -137,6 +137,41 @@ class TestEncodedIPDeny(unittest.TestCase):
 
 
 @unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestScopeGate(unittest.TestCase):
+	"""in_scope/out_of_scope (mandate) boundary on target rules — the scope-gate
+	migration. Deny-wins; in_scope auto-allows; an out-of-in_scope target falls
+	through to the interactive `ask` (CLI approve preserved); empty scope (CLI
+	default) imposes no boundary. Matched via the shared host_in_scope."""
+	CFG = dict(allow=[], deny=[], ask=[])
+
+	def _eng(self, **kw):
+		return PermissionEngine(self.CFG, **kw)
+
+	def test_out_of_scope_denied(self):
+		e = self._eng(in_scope=["acme.test", "*.acme.test"], out_of_scope=["evil.test"])
+		self.assertEqual(e._check_value("target", "evil.test").decision, "deny")
+
+	def test_in_scope_allowed_without_prompting(self):
+		e = self._eng(in_scope=["acme.test", "*.acme.test"])
+		self.assertEqual(e._check_value("target", "app.acme.test").decision, "allow")
+		# URL host is matched too
+		self.assertEqual(e._check_value("target", "http://app.acme.test/x").decision, "allow")
+
+	def test_out_of_in_scope_reaches_ask(self):
+		# not in a non-empty in_scope and not denied -> no target rule -> the interactive
+		# `ask` path (CLI approve). _check_values turns the "No rule" default into ask.
+		e = self._eng(in_scope=["acme.test"])
+		self.assertEqual(e._check_values("target", ["other.test"]).decision, "ask")
+
+	def test_empty_scope_no_boundary(self):
+		# CLI default: empty in_scope/out_of_scope -> scope block skipped entirely
+		e = self._eng()
+		self.assertEqual(e.in_scope, [])
+		self.assertEqual(e.out_of_scope, [])
+		self.assertEqual(e._check_values("target", ["x.com"]).decision, "ask")
+
+
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
 class TestDetection(unittest.TestCase):
 
 	def test_extract_command_targets_ip(self):

--- a/tests/unit/test_ai_session.py
+++ b/tests/unit/test_ai_session.py
@@ -683,7 +683,6 @@ class TestSessionIdStampedOnContext(unittest.TestCase):
 			stack.enter_context(patch('secator.tasks.ai.PermissionEngine'))
 			stack.enter_context(patch('secator.tasks.ai.create_backend'))
 			stack.enter_context(patch('secator.tasks.ai.SensitiveDataEncryptor'))
-			stack.enter_context(patch.object(ai, '_auto_approve_workspace_targets'))
 			stack.enter_context(patch.object(type(task), 'reports_folder', property(lambda self: None)))
 			stack.enter_context(patch.object(type(task), 'id', 'runner-id-42', create=True))
 			task._init_options()
@@ -755,7 +754,6 @@ class TestLocalResumeAdoptsSessionId(unittest.TestCase):
 			patch('secator.tasks.ai.PermissionEngine'),
 			patch('secator.tasks.ai.create_backend'),
 			patch('secator.tasks.ai.SensitiveDataEncryptor'),
-			patch.object(ai, '_auto_approve_workspace_targets'),
 			patch('secator.tasks.ai.get_system_prompt', return_value='SYS'),
 			patch('secator.tasks.ai.build_tool_schemas', return_value=[]),
 		)

--- a/tests/unit/test_ai_tokens.py
+++ b/tests/unit/test_ai_tokens.py
@@ -198,7 +198,6 @@ class TestAiModelRecording(unittest.TestCase):
 			stack.enter_context(patch('secator.tasks.ai.PermissionEngine'))
 			stack.enter_context(patch('secator.tasks.ai.create_backend'))
 			stack.enter_context(patch('secator.tasks.ai.SensitiveDataEncryptor'))
-			stack.enter_context(patch.object(ai, '_auto_approve_workspace_targets'))
 			stack.enter_context(patch.object(type(task), 'reports_folder', property(lambda self: None)))
 			stack.enter_context(patch.object(type(task), 'id', 'task-id', create=True))
 			task._init_options()


### PR DESCRIPTION
Migrates the AI task's target authorization onto the shipped in_scope/out_of_scope + host_in_scope + classify_target (deletes the bespoke workspace allowlist `_auto_approve_workspace_targets` + regex target lists). Routes in_scope/out_of_scope to every spawned child (the enforcement lever — children filter via host_in_scope in run_extractors). Guardrail auto-allows in-scope targets, keeps the CLI interactive approve (runtime_allow) for out-of-scope, and config safety-denies (metadata/localhost) win over any broad mandate. Mandate-link (approve→create/edit mandate) is a platform UI/API affordance, not core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)