### PR TITLE
fix(hooks): carry task description into PENDING doc at on_build time

### DIFF
--- a/secator/hooks/mongodb.py
+++ b/secator/hooks/mongodb.py
@@ -119,7 +119,16 @@ def build_pending_doc(parent, task_spec, child_type):
 		'name': task_spec.get('name'),
 		'status': 'PENDING',
 		'done': False,
-		'config': {'type': child_type, 'name': task_spec.get('name')},
+		# Carry the build-time description (workflow-node override, e.g.
+		# "Find open ports (light)") so the UI shows it while PENDING, not only
+		# once the child runs. The UI reads config.description (falling back to
+		# config.name), and update_runner overwrites this with the full config
+		# on first run — which resolves to the same description.
+		'config': {
+			'type': child_type,
+			'name': task_spec.get('name'),
+			'description': task_spec.get('description', ''),
+		},
 		'context': dict(task_spec.get('context', {})),
 		'has_parent': True,
 		'chunk': task_spec.get('chunk'),

--- a/secator/hooks/sqlite.py
+++ b/secator/hooks/sqlite.py
@@ -172,7 +172,16 @@ def build_pending_doc(parent, task_spec, child_type):
 		'name': task_spec.get('name'),
 		'status': 'PENDING',
 		'done': False,
-		'config': {'type': child_type, 'name': task_spec.get('name')},
+		# Carry the build-time description (workflow-node override, e.g.
+		# "Find open ports (light)") so the UI shows it while PENDING, not only
+		# once the child runs. The UI reads config.description (falling back to
+		# config.name), and update_runner overwrites this with the full config
+		# on first run — which resolves to the same description.
+		'config': {
+			'type': child_type,
+			'name': task_spec.get('name'),
+			'description': task_spec.get('description', ''),
+		},
 		'context': dict(task_spec.get('context', {})),
 		'has_parent': True,
 		'chunk': task_spec.get('chunk'),

--- a/tests/unit/test_on_build.py
+++ b/tests/unit/test_on_build.py
@@ -310,6 +310,29 @@ class TestOnBuildChunkWiring(unittest.TestCase):
             f'Chunk ids are not all distinct: {chunk_ids}'
 
 
+class TestPendingDocDescription:
+    """build_pending_doc must carry the build-time description into config so the
+    UI shows it while a child task is PENDING (not only once it runs). The UI
+    reads config.description (falling back to config.name); before this the
+    pending doc had no description and every not-yet-run task showed its bare
+    name, then the description popped in on RUNNING."""
+
+    def test_pending_doc_carries_description_into_config(self):
+        from secator.hooks.sqlite import build_pending_doc
+        spec = {'name': 'nmap', 'description': 'Find open ports (light)',
+                'context': {'workspace_id': 'ws1'}}
+        doc = build_pending_doc(_FakeParent('workflow'), spec, 'task')
+        assert doc['config']['description'] == 'Find open ports (light)'
+        assert doc['config']['name'] == 'nmap'
+        assert doc['status'] == 'PENDING'
+
+    def test_pending_doc_description_defaults_to_empty(self):
+        from secator.hooks.sqlite import build_pending_doc
+        spec = {'name': 'nmap', 'context': {}}
+        doc = build_pending_doc(_FakeParent('workflow'), spec, 'task')
+        assert doc['config']['description'] == ''
+
+
 class TestOnBuildSqlite:
     def test_sqlite_on_build_stamps_task_id(self, tmp_path, monkeypatch):
         import secator.hooks.sqlite as sql


### PR DESCRIPTION
## Bug
When a workflow is dispatched, its child tasks appear in the UI **without a description** while PENDING — only the task name shows (e.g. `nmap/light`). The description pops in only once the task switches to RUNNING.

## Root cause
The store drivers mint a placeholder doc for each child at build time via `build_pending_doc` (in `on_build`). That doc set `config: {type, name}` — **no `description`**. The UI reads `config.description` (falling back to `config.name`), so a PENDING task shows its bare name. When the task runs, `update_runner` overwrites the doc with the full `self.toDict()` (whose `config.description` is populated), so the description appears only then.

Confirmed in mongo — a finished `nmap/light` doc has `config.description: 'Find open ports (light)'`, while a PENDING doc has no `config.description` at all.

## Fix
The build-time `task_spec` already carries the resolved description (the workflow-node override) — `workflow.yielder` already uses `task_spec.get('description')` for the progress panel. Add it to the pending doc's `config.description`, in both store drivers (`mongodb` + `sqlite` `build_pending_doc`). On first run `update_runner` overwrites with the full config, which resolves to the same value — so no flip.

## Verification
Real `host_recon` build now mints PENDING docs with descriptions:
```
nmap/light    -> 'Find open ports (light)'
nmap          -> 'Detect services and versions'
sshaudit      -> 'Audit SSH port'
httpx         -> 'Probe HTTP services on open ports'
search_vulns  -> 'Search for related vulns and exploits'
```
matching what the RUNNING docs show. Tests: `tests/unit/test_on_build.py::TestPendingDocDescription` (+ full file 12 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pending task entries now display their configured descriptions while execution is still pending.
  * Entries without a description use a blank value instead of omitting the field.

* **Tests**
  * Added coverage to verify description display and fallback behavior for pending tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->