### PR TITLE
fix(ai): accurate + resilient empty-response handling

### DIFF
--- a/secator/ai/utils.py
+++ b/secator/ai/utils.py
@@ -752,8 +752,12 @@ def call_llm(
 
 	# Get tool calls
 	tool_calls = getattr(message, 'tool_calls', None) or []
+	# finish_reason distinguishes a genuinely-empty turn from a truncated one
+	# (finish_reason == "length") — the caller uses it to report the real cause
+	# of an empty response instead of blaming tool-calling support.
+	finish_reason = getattr(response.choices[0], 'finish_reason', None)
 
-	return {"content": content, "usage": usage, "tool_calls": tool_calls}
+	return {"content": content, "usage": usage, "tool_calls": tool_calls, "finish_reason": finish_reason}
 
 
 MODEL_COLORS = [

--- a/secator/tasks/ai.py
+++ b/secator/tasks/ai.py
@@ -1,6 +1,7 @@
 # secator/tasks/ai.py
 """AI-powered penetration testing task."""
 import json
+import time
 import uuid
 from pathlib import Path
 from typing import Generator
@@ -597,6 +598,7 @@ class ai(PythonRunner):
 				content = result["content"]
 				tool_calls = result.get("tool_calls", [])
 				usage = result.get("usage", {})
+				finish_reason = result.get("finish_reason")
 
 				# Accumulate billed tokens for this run (read by the billing chore
 				# as context.ai_tokens). Done here, before any empty-response
@@ -605,14 +607,27 @@ class ai(PythonRunner):
 
 				self.debug(f'content: {content[:200] if content else "(empty)"}', sub='llm')
 
-				# Empty response
+				# Empty response — neither content nor a tool call. This is almost
+				# never "the model can't call tools" (most models can, and a wrong
+				# model name 400s rather than returning empty); the usual causes are
+				# a transient provider hiccup (empty upstream response) or a truncated
+				# turn (finish_reason == "length"). Report the real reason, back off
+				# to let a transient blip recover, and retry a few times before giving up.
 				if not content and not tool_calls:
 					empty_streak += 1
-					yield Warning(message="LLM returned empty response")
+					if finish_reason == "length":
+						reason = "response truncated (finish_reason=length) — the model hit its output-token cap"
+					else:
+						reason = f"empty response from the provider (finish_reason={finish_reason or 'unknown'})"
+					yield Warning(message=f"LLM returned an {reason}")
 					if empty_streak >= 3:
-						yield Error(message="3 consecutive empty responses - the model may not support tool calling. Stopping.")
+						yield Error(message=(
+							f"3 consecutive empty responses — {reason}. This is usually a transient "
+							"provider issue or an output-token cap, not a lack of tool-calling support — "
+							"retry, or try a different model."))
 						self._save_history()
 						return
+					time.sleep(min(2 ** empty_streak, 8))  # brief backoff for a transient provider blip
 					continue
 
 				empty_streak = 0

--- a/tests/unit/test_ai_resilience.py
+++ b/tests/unit/test_ai_resilience.py
@@ -49,11 +49,12 @@ def _tc(name, args, call_id="tc1"):
 	return types.SimpleNamespace(id=call_id, function=types.SimpleNamespace(name=name, arguments=arguments))
 
 
-def _resp(content=None, tool_calls=None, usage="default"):
+def _resp(content=None, tool_calls=None, usage="default", finish_reason=None):
 	"""A call_llm() return dict."""
 	if usage == "default":
 		usage = {"tokens": 100, "cost": 0.001}
-	return {"content": content, "tool_calls": tool_calls or [], "usage": usage}
+	return {"content": content, "tool_calls": tool_calls or [], "usage": usage,
+			"finish_reason": finish_reason}
 
 
 def _make_loop_task():
@@ -126,6 +127,8 @@ def _driven(task, weird_responses):
 
 	with contextlib.ExitStack() as stack:
 		stack.enter_context(patch('secator.tasks.ai.call_llm', side_effect=_next))
+		# empty-response retries back off with time.sleep — make it instant in tests
+		stack.enter_context(patch('secator.tasks.ai.time.sleep'))
 		stack.enter_context(patch('secator.tasks.ai.get_context_window', return_value=8000))
 		stack.enter_context(patch('secator.ai.history.get_context_window', return_value=8000))
 		stack.enter_context(patch('secator.tasks.ai.save_history'))
@@ -234,6 +237,25 @@ class TestWeirdContentResponses(unittest.TestCase):
 		items, n, aborted = _run(task, [_resp(content=None, tool_calls=[]) for _ in range(3)])
 		self.assertIsNone(aborted)  # a deliberate Error(485), not the catch-all
 		self.assertTrue(any(getattr(i, '_type', '') == 'error' for i in items))
+
+	def test_empty_error_does_not_blame_tool_calling(self):
+		"""The empty-response error must not (mis)claim the model can't call tools —
+		most models can; empties are transient-provider / truncation conditions."""
+		task = _make_loop_task()
+		items, n, aborted = _run(task, [_resp(content=None, tool_calls=[]) for _ in range(3)])
+		err = next((i for i in items if getattr(i, '_type', '') == 'error'), None)
+		self.assertIsNotNone(err)
+		self.assertNotIn('support tool calling', getattr(err, 'message', ''))
+
+	def test_length_finish_reason_reports_truncation(self):
+		"""An empty turn with finish_reason=length is reported as a truncation/output-cap
+		issue, not a generic empty response."""
+		task = _make_loop_task()
+		items, n, aborted = _run(task, [_resp(content=None, tool_calls=[], finish_reason="length")])
+		self.assertIsNone(aborted)
+		self.assertGreaterEqual(n, 2)  # recovered and asked again
+		warns = [getattr(i, 'message', '') for i in items if getattr(i, '_type', '') == 'warning']
+		self.assertTrue(any('truncated' in w or 'length' in w for w in warns), warns)
 
 	def test_missing_usage_does_not_crash(self):
 		"""usage=None must not crash accounting."""


### PR DESCRIPTION
## Report (canary)
Using `openrouter/anthropic/claude-opus-4.8` with the AI task failed with:
> 3 consecutive empty responses - the model may not support tool calling. Stopping.

## Investigation
Pulled the failing runner from canary mongo → model was `openrouter/anthropic/claude-opus-4.8`. Reproduced the raw `litellm.completion` call from inside the canary pod:
- **Trivial tool:** `finish_reason: tool_calls`, content **and** a tool call returned ✅
- **Real chat-mode tool set (5 tools) + full 14KB system prompt:** `finish_reason: tool_calls`, content + tool call ✅

So the model **does** support tool calling, and `call_llm` parses it correctly. The failure was empty responses from the provider (not reproducible now → a transient/upstream condition), which the loop **misdiagnosed**.

## Root cause
The agent loop treats *any* turn with no content and no tool_calls as "the model may not support tool calling" and stops after **3 immediate** retries. But an empty turn is almost always:
- a **transient provider hiccup** (empty upstream response), or
- a **truncated** turn (`finish_reason == "length"`, hit the output-token cap).

A wrong model name 400s rather than returning empty, so "doesn't support tools" is essentially never the real cause.

## Fix
- `call_llm` returns `finish_reason`.
- The empty-response path reports the **real** cause (truncation vs empty-from-provider, including `finish_reason`) instead of the misleading tool-calling claim.
- Empty-retry now **backs off** (2^n, capped 8s) so a transient blip can recover, instead of 3 immediate re-calls into the same blip.

## Tests
`tests/unit/test_ai_resilience.py`: error no longer blames tool calling; `finish_reason=length` reports truncation; `time.sleep` patched instant. 30 passed (103 across the AI suite).

Base is `canary` because the AI stack lives there (far ahead of main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)