### PR TITLE
feat(workflows): wire retirejs into code_scan, url_crawl and a new url_js_scan

### DIFF
--- a/secator/configs/workflows/code_scan.yaml
+++ b/secator/configs/workflows/code_scan.yaml
@@ -25,5 +25,8 @@ tasks:
     gitleaks:
       description: Scan codebase for leaks
       if: not opts.mode or opts.mode in ['filesystem', 'git']
+    retirejs:
+      description: Find vulnerable JavaScript libraries
+      if: not opts.mode or opts.mode in ['filesystem', 'git']
     trufflehog:
       description: Scan codebase for secrets

--- a/secator/configs/workflows/url_crawl.yaml
+++ b/secator/configs/workflows/url_crawl.yaml
@@ -36,6 +36,12 @@ options:
     default: False
     short: hs
 
+  scan_js:
+    is_flag: True
+    help: Scan HTTP responses for vulnerable JS libraries (retirejs)
+    default: False
+    short: sjs
+
 default_options:
   match_codes: 200,204,301,302,307,401,403,405,500
 
@@ -96,3 +102,13 @@ tasks:
           field: value
           condition: item.name == 'email_address'
       if: opts.hunt_secrets and not opts.passive
+    retirejs:
+      description: Find vulnerable JS libraries in HTTP responses
+      # httpx stores responses as <sha1>.txt (headers + body), so retire.js needs to be told to
+      # look at .txt files: its default only matches .js.
+      ext: txt
+      targets_:
+        - type: url
+          field: stored_response_path
+          condition: item.stored_response_path != ''
+      if: opts.scan_js and not opts.passive

--- a/secator/configs/workflows/url_js_scan.yaml
+++ b/secator/configs/workflows/url_js_scan.yaml
@@ -1,0 +1,30 @@
+type: workflow
+name: url_js_scan
+alias: ujs
+description: URL JavaScript library vulnerability scan
+long_description: |
+  Probes URLs and looks for JavaScript libraries with known vulnerabilities in the HTTP responses.
+  Identifies outdated and end-of-life front-end libraries (jQuery, AngularJS, Bootstrap, ...) shipped
+  by a web application, along with the CVEs and advisories affecting them. Complements dependency
+  scanners like grype and trivy, which cover system and container packages but not the vendored
+  JavaScript actually served to browsers.
+tags: [http, vuln, js]
+input_types:
+- url
+
+tasks:
+  httpx:
+    description: Run HTTP probes on URLs
+    tech_detect: True
+
+  retirejs:
+    description: Find vulnerable JS libraries in HTTP responses
+    # httpx stores responses as <sha1>.txt (headers + body), so retire.js needs to be told to look
+    # at .txt files: its default only matches .js. The prepended headers rule out hash-based
+    # detection and the hashed file name rules out filename-based detection, leaving `filecontent`
+    # matching on the response body, which covers 93% of the retire.js library repo.
+    ext: txt
+    targets_:
+    - type: url
+      field: stored_response_path
+      condition: item.stored_response_path != ''

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -9,6 +9,15 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
 
+  # Static JS libraries with known vulnerabilities (retire.js / url_js_scan)
+  js_server:
+    image: "nginx:alpine"
+    restart: always
+    volumes:
+      - ./js:/usr/share/nginx/html:ro
+    ports:
+      - "127.0.0.1:8901:80"
+
   # Log4Shell
   cve_2021_44228:
     restart: always

--- a/tests/integration/inputs.py
+++ b/tests/integration/inputs.py
@@ -46,6 +46,12 @@ INPUTS_WORKFLOWS = {
 	'subdomain_recon': 'api.github.com',
 	'url_crawl': 'localhost:3000',
 	'url_fuzz': 'http://localhost:3000',
+	# Served by the js_server container (docker-compose.yml), which exposes tests/integration/js.
+	# No expected outputs: retire.js matches inside httpx's stored response, whose path carries a
+	# per-run report folder and a hashed file name, so `matched_at` -- a compared field on
+	# Vulnerability -- is never stable across runs. Same reason url_crawl asserts no trufflehog
+	# finding. The retirejs parsing itself is covered by OUTPUTS_TASKS['retirejs'].
+	'url_js_scan': 'http://localhost:8901/jquery-1.8.3.min.js',
 	'url_nuclei': [
 		'http://localhost:3000',
 		'http://localhost:8080',


### PR DESCRIPTION
Makes the `retirejs` task reachable from workflows.

> [!IMPORTANT]
> **Base branch is `feat/add-retirejs`, not `main`.** These configs reference the `retirejs` task, which does not exist on `main` yet. Merge #1363 first.

### The constraint

`retirejs` only accepts a `path`, and no task in secator emits one. Scanning the JavaScript actually served by a website therefore goes through httpx's stored responses — the exact chaining `trufflehog` already uses in `url_crawl` and `url_secrets_hunt`:

```yaml
targets_:
  - type: url
    field: stored_response_path
    condition: item.stored_response_path != ''
```

`CONFIG.http.store_responses` already defaults to `True`, so no new plumbing was needed.

### Changes

- **`code_scan`** — adds `retirejs` next to grype / trivy / gitleaks, behind the same `filesystem`/`git` mode gate. Native use case, `path` in. Fills a real gap: grype and trivy cover system and container dependencies, nothing covered the vendored front-end JS shipped to browsers.

- **`url_js_scan`** (new, alias `ujs`) — `httpx` → `retirejs` on `stored_response_path`, mirroring `url_secrets_hunt` (`httpx` → `trufflehog`).

- **`url_crawl`** — same chaining behind an opt-in `--scan-js` / `-sjs` flag, exactly like `--hunt-secrets` for trufflehog. This is what carries retirejs into the `url` and `host` scans, which embed `url_crawl`.

### Why `ext: txt`

httpx stores responses as `<sha1>.txt` (request headers + response headers + body), and retire.js only looks at `.js` by default — without `ext: txt` it reports **zero** findings on those files.

The prepended headers rule out `hash` detection and the hashed file name rules out `filename` detection, leaving `filecontent` matching on the response body. Measured against the retire.js library repo (76 entries):

| Extractor | Libraries | Share |
|---|---|---|
| `filecontent` | 71 | 93% |
| `filename` | 42 | 55% |
| `hashes` | 4 | 5% |
| **`filename`/`hash` only** (lost here) | **2** | **2%** |

So ~98% of detection coverage is retained. Confidence is reported as `high` on this path, which is correct — `filecontent` matches the actual bytes.

### Testing

- `secator test template` — 5 passed, all 15 workflows validate
- `secator test lint` — passing
- `TEST_WORKFLOWS=url_js_scan test_workflows::test_default_workflows` — 1 passed
- `url_crawl` with and without `-sjs`: retirejs runs only when the flag is set (7 jQuery findings with, 0 task invocations without)

Integration target is a new nginx `js_server` container serving `tests/integration/js` on `127.0.0.1:8901`, so `url_js_scan` runs against a fixture we control rather than a drifting third-party frontend.

### Notes for reviewers

**No `expected_results` for `url_js_scan`.** retire.js matches inside the stored response, whose path carries a per-run report folder and a hashed file name, so `matched_at` — a compared field on `Vulnerability` — is never stable across runs. `url_crawl` asserts no trufflehog finding for the same reason, and `url_secrets_hunt` has no expectations at all. The parsing itself stays covered by `OUTPUTS_TASKS['retirejs']`.

**Pre-existing, not addressed here:** in sync mode `Workflow.run()` surfaces only the `Target` — the backfill in `Runner.__iter__` is gated on `if not self.sync`. Reproduced on an untouched inline `httpx`-only workflow: `run()` returns `['Target']` while `findings` has 2. That means no workflow's `expected_results` can pass locally. It goes unnoticed because CI runs only `test_celery,test_worker,test_tasks` — `test_workflows` is not in the pipeline. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bz13P4HFeXqpmKJAr1f9yb
