### PR TITLE
fix(wpscan): install into a fixed gem dir + set GEM_HOME (fixes exegol crash #1366)

### DIFF
--- a/secator/tasks/wpscan.py
+++ b/secator/tasks/wpscan.py
@@ -74,22 +74,32 @@ class wpscan(VulnHttp):
 			PROVIDER: 'wpscan',
 		},
 	}
+	# Dedicated ruby gem home for wpscan. We install with --install-dir (not
+	# --user-install) and point GEM_HOME here when running (see extra_env), so the
+	# generated `wpscan` wrapper resolves the gem no matter how the host manages
+	# ruby. On RVM (e.g. exegol) a --user-install gem is NOT on the wrapper's
+	# Gem.path, so `wpscan` died with `Gem::GemNotFoundException: can't find gem
+	# wpscan` while the pre-installed system wpscan (in an RVM gemset) worked (#1366).
+	install_gem_dir = str(CONFIG.dirs.share / 'ruby')
 	install_version = 'v3.8.28'
 	install_pre_cmd = {
 		'apt': ['make', 'kali:libcurl4t64', 'libffi-dev'],
 		'pacman': ['make', 'ruby-erb'],
 		'*': ['make']
 	}
-	install_cmd = f'gem install wpscan -v [install_version_strip] --user-install -n {CONFIG.dirs.bin}'
+	install_cmd = f'gem install wpscan -v [install_version_strip] --install-dir {install_gem_dir} -n {CONFIG.dirs.bin}'
 	install_post = {
 		'kali': (
-			f'gem uninstall nokogiri --user-install -n {CONFIG.dirs.bin} --force --executables && '
-			f'gem install nokogiri --user-install -n {CONFIG.dirs.bin} --platform=ruby'
+			f'gem uninstall nokogiri --install-dir {install_gem_dir} --force --executables && '
+			f'gem install nokogiri --install-dir {install_gem_dir} --platform=ruby'
 		)
 	}
 	install_github_bin = False
 	github_handle = 'wpscanteam/wpscan'
 	proxychains = False
+	# GEM_HOME makes the wpscan wrapper find the gem in install_gem_dir at runtime,
+	# independent of the host's Gem.path (RVM excludes it otherwise) — see #1366.
+	extra_env = {'GEM_HOME': install_gem_dir}
 	proxy_http = True
 	proxy_socks5 = False
 	profile = 'small'

--- a/tests/unit/test_wpscan_install.py
+++ b/tests/unit/test_wpscan_install.py
@@ -1,0 +1,32 @@
+"""wpscan must install into a fixed gem dir and export GEM_HOME so its generated
+`wpscan` wrapper resolves the gem regardless of the host ruby manager.
+
+Regression for #1366: a `--user-install` gem is NOT on RVM's Gem.path (exegol),
+so the wrapper crashed with `Gem::GemNotFoundException: can't find gem wpscan`
+while the pre-installed system wpscan (an RVM gemset) worked. Installing with
+`--install-dir <dir>` and pointing GEM_HOME at <dir> at run time fixes it.
+"""
+import unittest
+
+from secator.tasks.wpscan import wpscan
+
+
+class TestWpscanInstall(unittest.TestCase):
+
+	def test_installs_into_fixed_gem_dir_not_user_install(self):
+		self.assertIn(f'--install-dir {wpscan.install_gem_dir}', wpscan.install_cmd)
+		self.assertNotIn('--user-install', wpscan.install_cmd)
+
+	def test_gem_home_env_points_at_install_dir(self):
+		# GEM_HOME is always on Gem.path, so the wrapper finds the gem at run time
+		# even when the inherited Gem.path (e.g. RVM on exegol) excludes install_gem_dir.
+		self.assertEqual(wpscan.extra_env.get('GEM_HOME'), wpscan.install_gem_dir)
+
+	def test_nokogiri_post_uses_install_dir(self):
+		post = wpscan.install_post['kali']
+		self.assertIn(f'--install-dir {wpscan.install_gem_dir}', post)
+		self.assertNotIn('--user-install', post)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Closes #1366.

## Bug
On exegol, `secator x wpscan <url> --sync` crashes:
```
/usr/local/rvm/rubies/ruby-3.2.2/.../rubygems.rb: can't find gem wpscan (>= 0.a) with executable wpscan (Gem::GemNotFoundException)
    from /root/.local/bin/wpscan:25
[ERR] wpscan Could not find JSON results ... Command failed with return code 1
```
…while exegol's own `wpscan` (an RVM gemset, reachable via an interactive alias) works.

## Root cause
The task installed wpscan with `gem install wpscan --user-install -n ~/.local/bin`. That puts the **gem** in `~/.gem/ruby/<abi>` and the **executable wrapper** in `~/.local/bin/wpscan`. On RVM (exegol) the ruby `Gem.path` does **not** include the `--user-install` dir, so the wrapper can't resolve the gem at run time. And `~/.local/bin` is early in `PATH`, so this broken wrapper **shadows** exegol's working RVM wpscan (which secator's non-interactive subprocess can't reach via the alias anyway).

## Fix
Install into a fixed, secator-owned gem dir with `--install-dir`, and point **`GEM_HOME`** at it via the task's `extra_env`. `GEM_HOME` is always on `Gem.path`, so the wrapper resolves the gem no matter how the host manages ruby.

```python
install_gem_dir = str(CONFIG.dirs.share / 'ruby')
install_cmd = f'gem install wpscan -v [...] --install-dir {install_gem_dir} -n {CONFIG.dirs.bin}'
extra_env = {'GEM_HOME': install_gem_dir}
```
(the kali `nokogiri` post-step switches to `--install-dir` too.)

## Validation
Reproduced the **exact** `Gem::GemNotFoundException` with a stand-in gem installed the same way, and confirmed `GEM_HOME=<install-dir>` fixes it:
| run | result |
|---|---|
| wrapper, our dir NOT on Gem.path (simulates RVM) | `can't find gem` ❌ (same as #1366) |
| wrapper, `GEM_HOME=<install-dir>` | works ✓ |

**Backward-compatible:** existing `--user-install` gems stay findable via `user_dir` even with `GEM_HOME` overridden (verified), so upgrading doesn't break non-RVM installs.

Test: `tests/unit/test_wpscan_install.py` (loader suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WPScan installation reliability by using a dedicated Ruby gem directory.
  * Ensured WPScan consistently locates its installed dependencies regardless of the host Ruby environment.
  * Updated Nokogiri setup to use the dedicated installation directory.

* **Tests**
  * Added regression coverage for WPScan installation paths, runtime environment configuration, and dependency setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->