### PR TITLE
fix(bbot): add python dev headers to apt/dnf install prereqs

### DIFF
--- a/secator/tasks/bbot.py
+++ b/secator/tasks/bbot.py
@@ -270,14 +270,23 @@ class bbot(Command):
 			'extra_data': 'extra_data',
 		}
 	}
+	# bbot's deps (regex, yara-python) ship no prebuilt wheels for newer Pythons
+	# (e.g. 3.14), so pip builds them from source — which needs the Python dev
+	# headers (Python.h) plus a C toolchain. The apt/dnf paths lacked
+	# python3-dev/python3-devel, so `secator install bbot` failed on Ubuntu/Debian
+	# with `fatal error: Python.h: No such file or directory`.
 	install_pre = {
 		'apk': ['python3-dev', 'linux-headers', 'musl-dev', 'gcc', 'git', 'openssl', 'unzip', 'tar', 'chromium'],
+		'apt': ['python3-dev', 'gcc', 'git', 'openssl', 'unzip', 'tar', 'chromium'],
+		'dnf|yum|zypper': ['python3-devel', 'gcc', 'git', 'openssl', 'unzip', 'tar', 'chromium'],
 		'*': ['gcc', 'git', 'openssl', 'unzip', 'tar', 'chromium']
 	}
 	install_version = '2.7.2'
 	install_cmd = 'pipx install bbot==[install_version] --force'
 	install_post = {
-		'*': f'rm -fr {CONFIG.dirs.share}/pipx/venvs/bbot/lib/python3.12/site-packages/ansible_collections/*'
+		# Glob the python minor version so this cleanup isn't silently skipped when
+		# the pipx venv runs on a different Python than a hardcoded one (e.g. 3.14).
+		'*': f'rm -fr {CONFIG.dirs.share}/pipx/venvs/bbot/lib/python3.*/site-packages/ansible_collections/*'
 	}
 
 	@staticmethod

--- a/tests/unit/test_bbot_install.py
+++ b/tests/unit/test_bbot_install.py
@@ -1,0 +1,42 @@
+"""bbot's native deps (regex, yara-python) have no prebuilt wheels on newer
+Pythons (e.g. 3.14), so pip builds them from source and needs the Python dev
+headers. The apt/dnf install prereqs must therefore carry python3-dev /
+python3-devel — otherwise `secator install bbot` fails on Ubuntu/Debian with
+`fatal error: Python.h: No such file or directory`.
+"""
+import unittest
+
+from secator.tasks.bbot import bbot
+
+
+def _resolve(install_pre, pm_name):
+	"""Mirror PackageInstaller's first-match resolution (managers split on '|',
+	'*' is the catch-all)."""
+	for managers, packages in install_pre.items():
+		if pm_name in managers.split('|') or managers == '*':
+			return packages
+	return []
+
+
+class TestBbotInstall(unittest.TestCase):
+
+	def test_apt_prereqs_include_python_headers(self):
+		pkgs = _resolve(bbot.install_pre, 'apt')  # ubuntu / debian / kali
+		self.assertIn('python3-dev', pkgs)
+		self.assertIn('gcc', pkgs)
+
+	def test_dnf_yum_prereqs_include_python_headers(self):
+		for pm in ('dnf', 'yum', 'zypper'):
+			self.assertIn('python3-devel', _resolve(bbot.install_pre, pm), pm)
+
+	def test_apk_prereqs_still_have_headers(self):
+		self.assertIn('python3-dev', _resolve(bbot.install_pre, 'apk'))
+
+	def test_install_post_cleanup_is_python_version_agnostic(self):
+		post = bbot.install_post['*']
+		self.assertIn('python3.*', post)
+		self.assertNotIn('python3.12', post)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Bug
The `platform (ubuntu)` CI build fails installing bbot:
```
[INF] 🔧 Installing bbot ...
⚡ pipx install bbot==2.7.2 --force
    regex_3/_regex.c:50:10: fatal error: Python.h: No such file or directory
    yara-python.c:20:10:    fatal error: Python.h: No such file or directory
[ERR] Failed to install bbot: InstallerStatus.INSTALL_FAILED
```

## Root cause
bbot's native deps (`regex`, `yara-python`) have **no prebuilt wheels for Python 3.14** (the CI Docker image's Python), so pip builds them **from source** — which needs the **Python dev headers** (`Python.h`) plus a C toolchain.

`bbot.install_pre` only carried `python3-dev` under the **`apk`** (Alpine) key. On Ubuntu/Debian (`apt`) the resolver falls through to `*` — which had `gcc`, `git`, … but **no python3-dev** — so the source build failed. (On older Pythons this was masked because prebuilt wheels existed and no source build happened.)

## Fix
Add explicit prereq entries with the Python dev headers:
- `apt` → `python3-dev` (covers ubuntu/debian/kali)
- `dnf|yum|zypper` → `python3-devel` (fedora/centos/rhel/opensuse)

Also glob the python minor version in the `install_post` ansible-collections cleanup (`python3.12` → `python3.*`) so it isn't silently skipped on 3.14+.

## Verification
Unit test asserts the apt/dnf paths resolve to the headers (mirrors `PackageInstaller`'s first-match logic); loader suite green. Not transient — a genuine missing build dependency exposed by the Python 3.14 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BBOT installation compatibility on apt-, dnf-, yum-, and zypper-based systems by installing the required Python development dependencies.
  * Updated post-install cleanup to support ansible collections across Python 3 minor versions, rather than targeting only Python 3.12.

* **Tests**
  * Added coverage verifying package-manager-specific dependencies and version-agnostic cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->