### PR TITLE
fix(runners): propagate worker SIGTERM so evicted tasks redeliver

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -12,7 +12,7 @@ from time import time
 from dotmap import DotMap
 import humanize
 
-from secator.definitions import ADDONS_ENABLED, STATE_COLORS
+from secator.definitions import ADDONS_ENABLED, IN_WORKER, STATE_COLORS
 from secator.celery_utils import CeleryData
 from secator.config import CONFIG
 from secator.output_types import (
@@ -137,6 +137,7 @@ class Runner:
 		self.celery_result = None
 		self.celery_ids_map = {}
 		self.revoked = False
+		self._worker_terminated = False
 		self.skipped = False
 		self.results_buffer = []
 		self._hooks = hooks
@@ -730,7 +731,7 @@ class Runner:
 
 		except BaseException as e:
 			self.debug(f'encountered exception {type(e).__name__}. Stopping remote tasks.', sub='run')
-			error = Error.from_exception(e)
+			error = self._handle_worker_termination(e)  # re-raises on a worker SystemExit
 			self.add_result(error)
 			self.revoked = True
 			if not self.sync:  # yield latest results from Celery
@@ -744,10 +745,32 @@ class Runner:
 			self.results_buffer = []
 			self._finalize()
 
+	def _handle_worker_termination(self, exc):
+		"""Decide what a caught exception means for a running task.
+
+		On a worker, a ``SystemExit`` means the worker process is being torn down — a SIGTERM from a
+		node/Job eviction or deadline (external) or from ``app.control.revoke(..., terminate=True)``
+		(intentional). Re-raise it instead of turning it into a returned result: letting it
+		propagate out of the Celery task is what lets Celery apply the right policy — a *revoked*
+		task is acknowledged and never retried, while a task whose worker was *lost* is requeued via
+		``task_reject_on_worker_lost`` (both confirmed with a prefork worker). Swallowing it into a
+		returned Error acks the task and defeats both. Off the worker (CLI run), keep the previous
+		behavior and surface the failure as an Error.
+		"""
+		if IN_WORKER and isinstance(exc, SystemExit):
+			self._worker_terminated = True
+			raise exc
+		return Error.from_exception(exc)
+
 	def _finalize(self):
 		"""Finalize the runner."""
 		self.join_threads()
 		gc.collect()
+		if self._worker_terminated:
+			# Worker torn down mid-task (SIGTERM eviction/deadline, or revoke). Celery will
+			# redeliver or ack-as-revoked; don't record a terminal status or reports for this
+			# aborted attempt — it is wrong and about to be superseded.
+			return
 		if self.sync:
 			self.mark_completed()
 		elif self.celery_result and not self.done:

--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -594,7 +594,10 @@ class Command(Runner):
 		except BaseException as e:
 			self.debug(f'{self.unique_name}: {type(e).__name__}.', sub='end')
 			self.stop_process()
-			yield Error.from_exception(e)
+			# On a worker, a SystemExit (SIGTERM: eviction/deadline or revoke terminate=True)
+			# re-raises here so it propagates out of the Celery task and Celery can redeliver
+			# (worker lost) or ack-as-revoked (revoked). Off the worker it surfaces as an Error.
+			yield self._handle_worker_termination(e)
 
 		finally:
 			yield from self._wait_for_end()

--- a/tests/unit/test_worker_termination.py
+++ b/tests/unit/test_worker_termination.py
@@ -1,0 +1,86 @@
+"""Worker-termination handling (SIGTERM vs revoke).
+
+A worker torn down by SIGTERM raises ``SystemExit`` inside the running task (billiard's
+shutdown, ``SystemExit(-(256-signum))``). This happens for BOTH a node/Job eviction and a
+``revoke(terminate=True)``. The runner must *propagate* it on the worker rather than swallow it
+into a returned result, because that's what lets Celery apply the correct policy — the split
+between the two SIGTERM sources is Celery's job, not ours:
+
+eviction (worker lost, not revoked) is requeued via ``task_reject_on_worker_lost``;
+``revoke(terminate=True)`` (revoked) is acknowledged and never retried.
+
+Both confirmed with a real prefork worker; the revoked-set gating lives in Celery. These tests
+cover the secator half: propagate ``SystemExit`` on the worker, surface an ``Error`` off it, and
+never mark a torn-down task completed.
+"""
+import unittest
+from unittest import mock
+
+from secator.output_types import Error
+from secator.runners._base import Runner
+
+
+def _bare_runner():
+	r = Runner.__new__(Runner)          # bypass heavy __init__
+	r._worker_terminated = False
+	return r
+
+
+class TestWorkerTermination(unittest.TestCase):
+
+	def test_worker_systemexit_propagates_and_flags(self):
+		r = _bare_runner()
+		with mock.patch('secator.runners._base.IN_WORKER', True):
+			with self.assertRaises(SystemExit):
+				r._handle_worker_termination(SystemExit(-241))
+		self.assertTrue(r._worker_terminated)
+
+	def test_client_systemexit_becomes_error(self):
+		# Off the worker (CLI), keep the old behavior: don't crash, surface an Error.
+		r = _bare_runner()
+		with mock.patch('secator.runners._base.IN_WORKER', False):
+			out = r._handle_worker_termination(SystemExit(-241))
+		self.assertIsInstance(out, Error)
+		self.assertFalse(r._worker_terminated)
+
+	def test_worker_regular_exception_becomes_error(self):
+		# A genuine task error is NOT a worker teardown -> Error, no propagate, no flag.
+		r = _bare_runner()
+		with mock.patch('secator.runners._base.IN_WORKER', True):
+			out = r._handle_worker_termination(ValueError('boom'))
+		self.assertIsInstance(out, Error)
+		self.assertFalse(r._worker_terminated)
+
+	def test_keyboardinterrupt_on_worker_is_not_propagated(self):
+		# Only SystemExit is the worker-teardown signal. A Ctrl+C stays an Error (unchanged).
+		r = _bare_runner()
+		with mock.patch('secator.runners._base.IN_WORKER', True):
+			out = r._handle_worker_termination(KeyboardInterrupt())
+		self.assertIsInstance(out, Error)
+		self.assertFalse(r._worker_terminated)
+
+	def test_finalize_skips_mark_completed_when_terminated(self):
+		# A torn-down task must not record a terminal status or reports for the aborted attempt.
+		r = _bare_runner()
+		r._worker_terminated = True
+		r.sync = True
+		r.join_threads = mock.Mock()
+		r.mark_completed = mock.Mock()
+		r.export_reports = mock.Mock()
+		r._finalize()
+		r.mark_completed.assert_not_called()
+		r.export_reports.assert_not_called()
+
+	def test_finalize_marks_completed_normally(self):
+		# Sanity: without termination, sync runs still mark completed.
+		r = _bare_runner()
+		r.sync = True
+		r.enable_reports = False
+		r.join_threads = mock.Mock()
+		r.mark_completed = mock.Mock()
+		r._finalize()
+		r.mark_completed.assert_called_once()
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Problem

A worker torn down by **SIGTERM** (a node/Job eviction, or a Job `activeDeadlineSeconds`) raises `SystemExit` inside the running task (billiard's shutdown handler — `SystemExit(-(256-signum))`, i.e. `-241` for SIGTERM). The runner's broad `except BaseException` caught it and returned an `Error` result.

Under `task_acks_late=True`, returning a result **acks** the task — so `task_reject_on_worker_lost` never fires and the task is **silently dropped** instead of redelivered. An OOMKill/SIGKILL already redelivered (the child dies abruptly → `WorkerLostError`); only the *graceful* SIGTERM path was affected, because the runner cooperated with the shutdown and returned.

Observed in prod: a `dalfox` task ended `FAILURE` with no retry after its worker got SIGTERM mid-run.

## Fix

On a worker, **re-raise** `SystemExit` instead of swallowing it, via a single `_handle_worker_termination` helper used by both runner exception handlers (`command.py`, `_base.py`). Letting it propagate out of the Celery task lets **Celery** apply the correct policy — which is the key point, because the same SIGTERM has two sources that must go opposite ways:

| SIGTERM source | Outcome |
|---|---|
| eviction / deadline (worker lost, **not** revoked) | requeued via `task_reject_on_worker_lost` |
| `revoke(terminate=True)` (revoked) | acknowledged, **never** retried |

Celery's revoked-set already distinguishes these — secator just needs to stop swallowing the signal. `_finalize` also skips `mark_completed` for a torn-down attempt (its status is wrong and about to be superseded). Off the worker (CLI), behavior is unchanged.

## Validation

Confirmed with a **prefork worker** (`acks_late` + `reject_on_worker_lost`), three scenarios:

- **catch + external SIGTERM** → 1 delivery, **no** redelivery (the bug)
- **propagate + external SIGTERM** → **redelivered** on a new child (`reject_on_worker_lost`)
- **propagate + `revoke(terminate=True)`** → **NOT** redelivered (Celery's revoked-set gates it)

Plus unit tests (`tests/unit/test_worker_termination.py`) for the propagate-on-worker / Error-off-worker / skip-mark-completed logic, and the existing runner/task/celery suites pass.

**Note:** the prefork repro used a redis broker; the `reject_on_worker_lost` + revoked-set *decision* is Celery-level (broker-agnostic), but a final confirmation on RabbitMQ (prod's broker) is worth doing before/at rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of worker termination so terminated tasks stop cleanly without being reported as ordinary errors.
  * Prevented completion statuses and report exports from being generated after worker termination.
  * Preserved standard error handling for client-side exits, interruptions, and other exceptions.

* **Tests**
  * Added coverage for worker termination, exception handling, and finalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->