### PR TITLE
fix(command): resolve tools exposed as shell aliases before auto-installing

### DIFF
--- a/secator/runners/command.py
+++ b/secator/runners/command.py
@@ -523,13 +523,19 @@ class Command(Runner):
 					yield Error(message=error)
 					return
 
-			# Prepare cmds
-			command = self.cmd if self.shell else shlex.split(self.cmd)
-
-			# Check command is installed and auto-install
+			# Resolve the command before exec: prefer a PATH binary; if none, try a
+			# shell alias. Some environments (Exegol/RVM) expose tools ONLY as shell
+			# aliases, which live in the shell runtime — not on PATH — so which /
+			# shutil.which miss them. When a tool resolves only via an alias, splice the
+			# expansion into the cmd so the subprocess can run it, and skip installing a
+			# conflicting copy. Auto-install only when the tool is nowhere to be found.
 			if not self.no_process and not self.is_installed():
-				self.debug('command is not installed, auto-installing', sub='start')
-				if CONFIG.security.auto_install_commands:
+				alias = self._resolve_shell_alias(self.cmd_name)
+				if alias:
+					self._splice_resolved_command(alias)
+					self.debug(f'{self.cmd_name} not on PATH; using shell alias -> {alias}', sub='start')
+				elif CONFIG.security.auto_install_commands:
+					self.debug('command is not installed, auto-installing', sub='start')
 					from secator.installer import ToolInstaller
 
 					yield Info(message=f'Command {self.name} is missing but auto-installing since security.autoinstall_commands is set')  # noqa: E501
@@ -537,6 +543,9 @@ class Command(Runner):
 					if not status.is_ok():
 						yield Error(message=f'Failed installing {self.cmd_name}')
 						return
+
+			# Prepare cmds (after any alias substitution)
+			command = self.cmd if self.shell else shlex.split(self.cmd)
 
 			# Output and results
 			self.return_code = 0
@@ -600,18 +609,59 @@ class Command(Runner):
 			yield from self._wait_for_end()
 
 	def is_installed(self):
-		"""Check if a command is installed by using `which`.
+		"""Whether the command binary is on PATH.
 
-		Args:
-			command (str): The command to check.
+		Uses shutil.which (pure-Python, cross-platform) — no subprocess, and it works
+		on Windows too. NOTE: this is PATH-only; tools exposed solely as a shell alias
+		(e.g. Exegol/RVM) are not on PATH and are resolved separately at exec time via
+		`_resolve_shell_alias` (aliases aren't files, so no PATH lookup can find them).
 
 		Returns:
-			bool: True if the command is installed, False otherwise.
+			bool: True if the command is on PATH, False otherwise.
 		"""
-		cmd = ['which', self.cmd_name]
-		result = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-		result.communicate()
-		return result.returncode == 0
+		return shutil.which(self.cmd_name) is not None
+
+	@staticmethod
+	def _resolve_shell_alias(name):
+		"""Resolve a command that is not on PATH but exists as a shell alias.
+
+		Aliases live in the shell runtime, not the filesystem, so shutil.which / the
+		`which` binary can't see them — only an interactive login shell that sourced
+		its rc can. We query the `alias` builtin (bash + zsh) because it prints the
+		alias in its literal, locale-independent form (`[alias ]name='<expansion>'`),
+		unlike `type`, whose prose is translated by the shell locale (e.g. a French
+		bash prints "est un alias vers", which no English regex would match).
+
+		Args:
+			name (str): Command name to resolve.
+
+		Returns:
+			str | None: The resolved invocation (e.g. '/rvm/wrappers/ruby /rvm/bin/wpscan'),
+				or None if it isn't a shell alias / can't be resolved.
+		"""
+		shell = os.environ.get('SHELL') or ''
+		if not shell:
+			return None
+		try:
+			result = subprocess.run(
+				[shell, '-ic', f'alias {shlex.quote(name)}'],
+				capture_output=True, text=True, timeout=10, stdin=subprocess.DEVNULL,
+				env={**os.environ, 'LC_ALL': 'C'},
+			)
+		except Exception:
+			return None
+		# bash: "alias name='<expansion>'"   zsh: "name='<expansion>'"
+		match = re.search(rf"^(?:alias\s+)?{re.escape(name)}='(.*)'\s*$", (result.stdout or '').strip())
+		return match.group(1) if match else None
+
+	def _splice_resolved_command(self, resolved):
+		"""Replace the cmd_name token in self.cmd with a resolved alias expansion.
+
+		Only the first whole-word occurrence is replaced, so any `sudo`/`proxychains`
+		prefix already prepended to self.cmd is preserved.
+		"""
+		self.cmd = re.sub(
+			rf'(?<!\S){re.escape(self.cmd_name)}(?!\S)', lambda _: resolved, self.cmd, count=1)
 
 	def process_line(self, line):
 		"""Process a single line of output emitted on stdout / stderr and yield results."""

--- a/secator/utils_test.py
+++ b/secator/utils_test.py
@@ -239,7 +239,11 @@ def mock_command(cls, inputs=[], opts={}, fixture=None, method=''):
 	else:
 		mocks.append(fixture)
 
-	with mock_subprocess_popen(mocks):
+	# Mocked commands never actually run or install, so treat them as installed —
+	# otherwise the runner's presence check (shutil.which on the fake `cmd`) fails
+	# and triggers auto-install during the test.
+	with mock_subprocess_popen(mocks), \
+			unittest.mock.patch.object(cls, 'is_installed', return_value=True):
 		command = cls(inputs, **opts)
 		if method == 'run':
 			yield cls(inputs, **opts).run()

--- a/secator/utils_test.py
+++ b/secator/utils_test.py
@@ -242,8 +242,9 @@ def mock_command(cls, inputs=[], opts={}, fixture=None, method=''):
 	# Mocked commands never actually run or install, so treat them as installed —
 	# otherwise the runner's presence check (shutil.which on the fake `cmd`) fails
 	# and triggers auto-install during the test.
-	with mock_subprocess_popen(mocks), \
-			unittest.mock.patch.object(cls, 'is_installed', return_value=True):
+	with contextlib.ExitStack() as stack:
+		stack.enter_context(mock_subprocess_popen(mocks))
+		stack.enter_context(unittest.mock.patch.object(cls, 'is_installed', return_value=True))
 		command = cls(inputs, **opts)
 		if method == 'run':
 			yield cls(inputs, **opts).run()

--- a/tests/unit/test_shell_alias_resolution.py
+++ b/tests/unit/test_shell_alias_resolution.py
@@ -1,0 +1,75 @@
+"""Command resolves tools that exist only as a shell alias (e.g. Exegol/RVM),
+which PATH lookups (which / shutil.which) can't see, and runs them instead of
+installing a conflicting copy.
+
+Regression context: Exegol exposes wpscan as an RVM-gemset alias, not a PATH
+binary — `which wpscan` failed in secator's non-interactive subprocess, so
+secator auto-installed its own (broken) copy that shadowed the working one.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from secator.runners.command import Command
+
+
+def _type_output(stdout):
+	return MagicMock(stdout=stdout, returncode=0)
+
+
+class TestShellAliasResolution(unittest.TestCase):
+
+	def test_resolve_bash_alias_format(self):
+		# bash `alias`: "alias name='<expansion>'"
+		with patch.dict('os.environ', {'SHELL': '/bin/bash'}), \
+			 patch('secator.runners.command.subprocess.run',
+				   return_value=_type_output("alias wpscan='/rvm/wrappers/ruby /rvm/bin/wpscan'")):
+			self.assertEqual(
+				Command._resolve_shell_alias('wpscan'),
+				'/rvm/wrappers/ruby /rvm/bin/wpscan')
+
+	def test_resolve_zsh_alias_format(self):
+		# zsh `alias`: "name='<expansion>'" (no leading 'alias ')
+		with patch.dict('os.environ', {'SHELL': '/usr/bin/zsh'}), \
+			 patch('secator.runners.command.subprocess.run',
+				   return_value=_type_output("wpscan='/rvm/bin/wpscan'")):
+			self.assertEqual(Command._resolve_shell_alias('wpscan'), '/rvm/bin/wpscan')
+
+	def test_not_an_alias_returns_none(self):
+		# genuinely-missing / non-alias -> `alias` prints nothing -> None
+		with patch.dict('os.environ', {'SHELL': '/bin/bash'}), \
+			 patch('secator.runners.command.subprocess.run', return_value=_type_output("")):
+			self.assertIsNone(Command._resolve_shell_alias('wpscan'))
+
+	def test_no_shell_returns_none_without_spawning(self):
+		with patch.dict('os.environ', {'SHELL': ''}), \
+			 patch('secator.runners.command.subprocess.run', side_effect=AssertionError('should not run')):
+			self.assertIsNone(Command._resolve_shell_alias('wpscan'))
+
+	def test_shell_error_returns_none(self):
+		with patch.dict('os.environ', {'SHELL': '/bin/bash'}), \
+			 patch('secator.runners.command.subprocess.run', side_effect=OSError('boom')):
+			self.assertIsNone(Command._resolve_shell_alias('wpscan'))
+
+	def test_splice_preserves_sudo_prefix(self):
+		c = Command.__new__(Command)
+		c.cmd_name = 'wpscan'
+		c.cmd = 'sudo wpscan --force --url http://x'
+		c._splice_resolved_command('/rvm/ruby /rvm/bin/wpscan')
+		self.assertEqual(c.cmd, 'sudo /rvm/ruby /rvm/bin/wpscan --force --url http://x')
+
+	def test_splice_first_token_only_and_word_boundary(self):
+		c = Command.__new__(Command)
+		c.cmd_name = 'nmap'
+		# 'nmap' is also a substring of a path arg — only the standalone token is replaced
+		c.cmd = 'nmap -oX /tmp/nmap_scan.xml target'
+		c._splice_resolved_command('/opt/nmap')
+		self.assertEqual(c.cmd, '/opt/nmap -oX /tmp/nmap_scan.xml target')
+
+	def test_is_installed_is_path_only(self):
+		c = Command.__new__(Command)
+		c.cmd_name = 'definitely-not-a-real-binary-xyz-123'
+		self.assertFalse(c.is_installed())
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Motivation
Groundwork for the Exegol integration (and a general robustness fix). Some environments expose a tool **only as a shell alias**, not a real PATH binary — e.g. Exegol's `wpscan` is an RVM-gemset alias. secator's presence check runs in a **non-interactive subprocess** where aliases aren't loaded, so it saw the tool as *missing* and auto-installed its own copy, which shadowed the working one (the root of the #1366 class of problems, and unnecessary duplication of tools the host already ships).

## Change
- **`is_installed()` → `shutil.which`**: pure-Python, cross-platform (works on Windows), no subprocess.
- **Alias fallback before auto-install**: when a tool isn't on PATH, resolve it via the login shell's `alias` builtin (`$SHELL -ic 'alias <name>'`). If it's an alias, splice the expansion into the command (preserving any `sudo`/`proxychains` prefix) so the subprocess runs the **host's** tool, and skip the install. Only auto-install when the tool is genuinely absent.

### Why `alias`, not `type`
`type`'s output is **locale-translated** — a French-locale bash prints `mytool est un alias vers « … »`, which no English regex matches. The `alias` builtin prints the literal, locale-independent `[alias ]name='<expansion>'` in both bash and zsh (and we force `LC_ALL=C` for good measure). Verified against real bash/zsh output.

## Behavior matrix
| tool state | before | after |
|---|---|---|
| on PATH | used | used (via `shutil.which`) |
| alias only (Exegol/RVM) | **auto-installed a shadow copy** | **resolved + host tool used**, no install |
| genuinely missing | auto-installed | auto-installed (unchanged) |

## Tests
- `tests/unit/test_shell_alias_resolution.py` — bash/zsh alias formats, non-alias, no-shell, shell-error, splice preserves sudo prefix + word-boundary, is_installed is PATH-only.
- `mock_command` updated to mark mocked commands installed (they never run/install; is_installed no longer routes through the mocked `subprocess.Popen`).
- Ran all mock_command-based unit suites (runners/tasks/celery/on_build): **100 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Commands configured as shell aliases can now be resolved and executed when they are not available on the system PATH.
  - Alias resolution supports Bash and Zsh formats, including commands prefixed with `sudo`.
  - Improved command availability checks prevent unnecessary installation attempts when tools are already accessible through PATH.
  - Command execution now handles missing shell configuration and shell errors more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->