### PR TITLE
feat(ai): bottom operating-rules recap per mode (prompt-engineering audit P0)

### DIFF
--- a/secator/ai/prompts/constraints/operating_rules.txt
+++ b/secator/ai/prompts/constraints/operating_rules.txt
@@ -1,0 +1,8 @@
+<operating_rules>
+Final reminders — these override any looser phrasing above and are the rules you most often break:
+1. ACT, don't narrate. Do the work by CALLING TOOLS. Never write out what you "would" do, and never present a list of options as plain text — if you want the user to choose, that is a `follow_up` tool call.
+2. `follow_up` carries the choices. When you ask the user anything or offer next steps, call `follow_up` with the options in its `choices` array. Do NOT write "Would you like me to: 1... 2..." in your text and then stop or call follow_up with empty choices — the user only sees clickable buttons built from `choices`.
+3. Every `run_task` / `run_workflow` / `run_shell` call needs a `description` = your INTENT in plain English (e.g. "Scan for open services", "Fire the XSS payload at level 1"). NEVER set it to the command string or the task name.
+4. Persist until the request is actually resolved. Do not stop early, and do not hand back a question you could answer yourself by running another tool. Only `follow_up` (needs a decision) or `stop` (done) ends your turn.
+5. Before retrying something that just failed, say in ONE line what you are changing this time — never re-run the same failing command or loop on the same approach.
+</operating_rules>

--- a/secator/ai/prompts/modes/attack.txt
+++ b/secator/ai/prompts/modes/attack.txt
@@ -54,3 +54,5 @@ During your discovery you discovered a reflected XSS on an endpoint. Instead of 
 </example>
 </vulnerability_handling>
 </constraints>
+
+${operating_rules}

--- a/secator/ai/prompts/modes/chat.txt
+++ b/secator/ai/prompts/modes/chat.txt
@@ -16,3 +16,5 @@ ${queries}
 ${findings}
 ${follow_up}
 </constraints>
+
+${operating_rules}

--- a/secator/ai/prompts/modes/exploit.txt
+++ b/secator/ai/prompts/modes/exploit.txt
@@ -50,3 +50,5 @@ Focus only on the vulnerability specified in your context. Do not spawn other AI
 </scope>
 
 </constraints>
+
+${operating_rules}

--- a/tests/unit/test_ai_prompts.py
+++ b/tests/unit/test_ai_prompts.py
@@ -333,3 +333,30 @@ class TestPrompts(unittest.TestCase):
 
 if __name__ == '__main__':
 	unittest.main()
+
+
+@unittest.skipUnless(ADDONS_ENABLED['ai'], 'ai addon not installed')
+class TestOperatingRulesRecap(unittest.TestCase):
+	"""Every mode ends with the operating-rules recap in the recency slot.
+
+	The library reference is inlined at the TOP of attack/exploit (long data
+	first), which pushes the persona to the middle of a ~15-60k prompt. A terse
+	recap at the very END keeps the rules the model most often breaks (use
+	follow_up with choices, description=intent, persist, restate-before-retry) in
+	the high-attention tail. Regression guard for that structural fix.
+	"""
+
+	def test_recap_present_and_last_in_every_mode(self):
+		for mode in ("chat", "attack", "exploit"):
+			p = get_system_prompt(mode, workspace_path="<ws>", backend=None)
+			self.assertIn("<operating_rules>", p, f"{mode} missing recap")
+			self.assertTrue(
+				p.rstrip().endswith("</operating_rules>"),
+				f"{mode} recap is not the LAST block (recency slot)")
+
+	def test_recap_covers_the_known_failure_modes(self):
+		p = get_system_prompt("attack", workspace_path="<ws>", backend=None)
+		recap = p[p.index("<operating_rules>"):]
+		self.assertIn("follow_up", recap)          # prose-choices failure
+		self.assertIn("description", recap)         # description-echo failure
+		self.assertIn("Persist", recap)             # early-yield failure


### PR DESCRIPTION
Implements the highest-value fix from the prompt-engineering audit (report artifact). Separate PR **targeting `feat/ai-unified`** (not main).

## The core structural fix
attack/exploit inline the ~8k-token library reference at the TOP (correct — long data first), which pushes the persona/instructions to the *middle* of a 15–60k-token prompt with **nothing in the high-attention tail** (lost-in-the-middle). Add a terse `<operating_rules>` recap at the very END of every mode, via one shared `${operating_rules}` constraint (DRY):

1. **Act via tools, never narrate** options as prose
2. **`follow_up` carries the choices** — not a prose "1… 2…" list + empty follow_up
3. Every `run_task`/`run_shell`/`run_workflow` **`description` = INTENT**, never the command/task name
4. **Persist** until resolved; only `follow_up` or `stop` ends the turn
5. **Before retrying** a failed step, state in one line what changes

This targets all four observed failure modes at once: prose-instead-of-follow_up (a), description echoing (b), long-transcript degradation (c), exploit retry-loop (d).

## Tests
`TestOperatingRulesRecap` — recap present and LAST in every mode; covers the failure-mode keywords. 44 prompt tests green.

## Audit items handled vs deferred
- ✅ P0 bottom recap (recency) · ✅ P0 persistence · ✅ P0 description-intent in prose · ✅ P1 restate-before-retry
- ⏭️ Deferred (need care/validation): **shrink the inlined library catalog** (it's auto-generated — wants its own change + eval), and a **server-side reject of `description == command`** (code change; the schema + recap should reduce it first)
- ❌ Audit's "orphaned tool_result_analysis.txt" and "stray </output> tag" were false positives (the former is used at runtime via format_continue; the latter doesn't exist) — skipped.

Full audit: the report artifact from this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)