### PR TITLE
fix(cli): resolve bare `-f <field>` as a field when it matches the type name

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1346,19 +1346,31 @@ def _apply_format(results, fmt):
 					pass
 			new_results[_type] = formatted
 		else:
-			# No field specified — use each OutputType's __str__ for a clean primary-field repr.
-			# Items from report.data['results'] may be raw dicts; reconstruct via OutputType.load().
-			_otype_map = {cls.get_name(): cls for cls in FINDING_TYPES}
-			otype_cls = _otype_map.get(_type)
+			# No field template. `_type` is a bare token that matched a result type name (e.g.
+			# `-f port`). If that token is ALSO a field on the items, the user means the field
+			# column — emit its value (parity with `-f port.port`). Otherwise fall back to each
+			# OutputType's __str__ for a clean primary-field repr. Items from report.data['results']
+			# may be raw dicts; reconstruct via OutputType.load() for the __str__ path.
+			_first = items[0]
+			_first_d = _first if isinstance(_first, dict) else (_first.toDict() if hasattr(_first, 'toDict') else {})
 			formatted = []
-			for item in items:
-				if isinstance(item, dict) and otype_cls:
-					try:
-						formatted.append(str(otype_cls.load(item)))
-					except Exception:
-						formatted.append(json.dumps(item))
-				else:
-					formatted.append(str(item))
+			if _type in _first_d:
+				for item in items:
+					d = item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
+					val = d.get(_type)
+					if val is not None:
+						formatted.append(str(val))
+			else:
+				_otype_map = {cls.get_name(): cls for cls in FINDING_TYPES}
+				otype_cls = _otype_map.get(_type)
+				for item in items:
+					if isinstance(item, dict) and otype_cls:
+						try:
+							formatted.append(str(otype_cls.load(item)))
+						except Exception:
+							formatted.append(json.dumps(item))
+					else:
+						formatted.append(str(item))
 			new_results[_type] = formatted
 
 	return new_results

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1351,12 +1351,13 @@ def _apply_format(results, fmt):
 			# column — emit its value (parity with `-f port.port`). Otherwise fall back to each
 			# OutputType's __str__ for a clean primary-field repr. Items from report.data['results']
 			# may be raw dicts; reconstruct via OutputType.load() for the __str__ path.
-			_first = items[0]
-			_first_d = _first if isinstance(_first, dict) else (_first.toDict() if hasattr(_first, 'toDict') else {})
+			# Detect the field across the WHOLE result set (not just the first item), so a
+			# heterogeneous type whose first item lacks the field still resolves the field values.
+			_dicts = [item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
+					  for item in items]
 			formatted = []
-			if _type in _first_d:
-				for item in items:
-					d = item if isinstance(item, dict) else (item.toDict() if hasattr(item, 'toDict') else {})
+			if any(_type in d for d in _dicts):
+				for d in _dicts:
 					val = d.get(_type)
 					if val is not None:
 						formatted.append(str(val))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -57,12 +57,12 @@ class TestApplyFormat(unittest.TestCase):
 		out = _apply_format(results, 'url')
 		self.assertEqual(out, {'url': ['https://example.com']})
 
-	def test_type_only_spec_port_uses_str_repr(self):
-		"""--format port (no dot) should use Port.__str__ (returns host:port), not dict repr."""
+	def test_type_only_spec_port_resolves_as_field(self):
+		"""--format port (no dot) resolves the `port` field (parity with `-f port.port`), NOT the
+		Port.__str__ host:port repr — a bare token that is also a field is treated as the field."""
 		results = {'port': [self._make_port(ip='1.2.3.4', port=8080)]}
 		out = _apply_format(results, 'port')
-		# Port.__str__ returns 'host:port'
-		self.assertEqual(out, {'port': ['example.com:8080']})
+		self.assertEqual(out, {'port': ['8080']})
 
 	def test_brace_style_field_only_single_type(self):
 		"""Brace-style with direct field names works when only one type is present."""

--- a/tests/unit/test_query_format.py
+++ b/tests/unit/test_query_format.py
@@ -29,6 +29,13 @@ class TestApplyFormatBareField(unittest.TestCase):
 		out = _apply_format(dict(results), 'host')
 		self.assertEqual(out['port'], ['h1', 'h2'])
 
+	def test_bare_field_detected_when_first_item_lacks_it(self):
+		# Field presence is checked across ALL items: the first item has no `port`, a later one
+		# does -> still resolve as a field (parity with `-f port.port`), not the __str__ fallback.
+		results = {'port': [{'host': 'h1'}, {'host': 'h2', 'port': 80}]}
+		out = _apply_format(dict(results), 'port')
+		self.assertEqual(out['port'], ['80'])
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/tests/unit/test_query_format.py
+++ b/tests/unit/test_query_format.py
@@ -1,0 +1,34 @@
+"""`secator q -f <field>` formatting.
+
+Bug: a bare `-f port` was treated as the *type* `port` (which is in the results), so it fell to
+the OutputType's ``__str__`` (the ``host:port`` couple) instead of the ``port`` field. It must
+behave like ``-f port.port`` when a single type is present.
+"""
+import unittest
+
+from secator.cli import _apply_format
+
+
+class TestApplyFormatBareField(unittest.TestCase):
+
+	def test_bare_token_that_is_a_field_emits_the_field(self):
+		results = {'port': [{'host': '10.0.0.1', 'port': 443}, {'host': 'h2', 'port': 80}]}
+		out = _apply_format(dict(results), 'port')
+		self.assertEqual(out['port'], ['443', '80'])  # the port field, NOT '10.0.0.1:443'
+
+	def test_bare_token_matches_dotted_form(self):
+		results = {'port': [{'host': 'h', 'port': 443}, {'host': 'h', 'port': 8080}]}
+		self.assertEqual(
+			_apply_format(dict(results), 'port'),
+			_apply_format(dict(results), 'port.port'),
+		)
+
+	def test_bare_field_not_matching_type_name_still_works(self):
+		# Unchanged path: a bare field that isn't the type name resolves on the single type.
+		results = {'port': [{'host': 'h1', 'port': 443}, {'host': 'h2', 'port': 80}]}
+		out = _apply_format(dict(results), 'host')
+		self.assertEqual(out['port'], ['h1', 'h2'])
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Bug

`secator q port -f port` returned the `host:port` couple instead of just the port number, while `secator q port -f "port.port"` worked correctly.

## Cause

In `_apply_format`, a bare token (`port`) that matches a result **type** name is `_type in results` → skips the field-fallback and hits the `__str__` branch → the Port's default `host:port` repr. The dotted form (`port.port`) builds a `{port}` template and works.

## Fix

When a bare format token is also a **field** on the single result type, emit that field's value (parity with `-f port.port`). The `__str__` fallback is kept for tokens that are a type but not a field (e.g. `-f vulnerability`). This is the single-type case the compound `{port.port} || {vulnerability.matched_at}` syntax already handles for multiple types.

## Tests

`tests/unit/test_query_format.py`: bare token → field value; parity with the dotted form; and the existing bare-field-not-type path still resolves. Backend-agnostic (formatting is post-fetch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Query formatting now correctly outputs a matching field value when using a bare format option, such as `-f port`.
  - Bare field formats now behave consistently with their dotted equivalents, such as `-f port.port`.
  - Field names that differ from the result type name are also resolved correctly when formatting query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->