### PR TITLE
fix(config): store `queries.*` values verbatim (--save with commas/brackets)

### DIFF
--- a/secator/config.py
+++ b/secator/config.py
@@ -557,10 +557,17 @@ class Config(DotMap):
 				updated.update(value)
 		else:
 			if subkey:
-				new_val = Config._parse_new_value(value)
-				# For workspaces.profiles, always coerce single strings to list
-				if parent_path == 'workspaces.profiles' and isinstance(new_val, str):
-					new_val = [new_val]
+				# `queries.*` values are raw query-expression strings (Dict[str, str]). A query
+				# like `severity in [high, critical]` must NOT be comma-split / bracket-parsed
+				# into a list by _parse_new_value, or it fails Dict[str, str] validation and the
+				# save is rejected (issue #1340). Store the expression verbatim.
+				if parent_path == 'queries' and isinstance(value, str):
+					new_val = value
+				else:
+					new_val = Config._parse_new_value(value)
+					# For workspaces.profiles, always coerce single strings to list
+					if parent_path == 'workspaces.profiles' and isinstance(new_val, str):
+						new_val = [new_val]
 				updated[subkey] = new_val
 			elif isinstance(value, dict):
 				updated.update(value)

--- a/tests/unit/test_query_save.py
+++ b/tests/unit/test_query_save.py
@@ -1,0 +1,30 @@
+"""`secator q ... --save <name>` stores the raw query expression string.
+
+Bug (#1340): a query containing list/`in` syntax (commas + brackets) was comma-split into a list
+by the config value coercion, then rejected because `queries` is ``Dict[str, str]`` -> the save
+failed with "Input should be a valid string". The expression must be stored verbatim.
+"""
+import unittest
+
+from secator.config import Config
+
+
+class TestQuerySaveRawString(unittest.TestCase):
+
+	def test_query_with_commas_and_brackets_round_trips_as_string(self):
+		config = Config.parse()
+		expr = "severity in [high, critical] && tags ~= (exploit|kev) && confidence == high"
+		config.set('queries.high_priority', expr)
+		self.assertIsInstance(config.queries['high_priority'], str)
+		self.assertEqual(config.queries['high_priority'], expr)
+		self.assertTrue(config.validate(print_errors=False))
+
+	def test_plain_query_still_saved(self):
+		config = Config.parse()
+		config.set('queries.ports', 'port')
+		self.assertEqual(config.queries['ports'], 'port')
+		self.assertTrue(config.validate(print_errors=False))
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Bug (#1340)

```
secator q "severity in [high, critical] && tags ~= (exploit|kev) && confidence == high" --save high_priority
# 1 validation error for SecatorConfig / queries.high_priority
#   Input should be a valid string [input_type=list]
```

## Cause

`--save` calls `CONFIG.set('queries.<name>', expr)` → `_set_dict_key` → `_parse_new_value`, which **comma-splits** the value into a list (`['severity in [high', 'critical] && ...']`). `queries` is `Dict[str, str]`, so the list fails validation and the save is rejected.

## Fix

`queries.*` values are raw query-expression strings — store them verbatim, skipping `_parse_new_value` (mirrors the existing `workspaces.profiles` special-case).

## Test

`tests/unit/test_query_save.py` — a query with commas + brackets round-trips as the exact string and validates. Verified it fails on `main` (splits into a list) and passes with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Query expressions containing brackets, commas, or operators are now saved and preserved as a single string.
  - Saving queries no longer incorrectly rejects valid expressions due to unintended value parsing.
  - Plain query saving continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->