### PR TITLE
feat(query): --sort / --count / --uniq for secator q & report show

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -5,6 +5,8 @@ import shutil
 import subprocess
 import sys
 
+from collections import Counter
+
 
 from pathlib import Path
 from stat import S_ISFIFO
@@ -1123,10 +1125,13 @@ def list_aliases(silent):
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api', 'sqlite']), default=None, help='Query backend driver')  # noqa: E501
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.option('-l', '--limit', type=int, default=0, help='Limit number of results (0 = no limit)')
+@click.option('--sort', 'sort', type=str, default=None, help='Sort results by a field (numeric-aware; prefix with - for descending), e.g. --sort port or --sort -severity_score')  # noqa: E501
+@click.option('--count', 'count', is_flag=True, default=False, help='Group identical --format values with an occurrence count (most frequent first; --sort orders by value instead)')  # noqa: E501
+@click.option('--uniq', 'uniq', is_flag=True, default=False, help='Drop duplicate --format values')
 @click.option('--group', is_flag=False, flag_value='', default=None, help='Group findings by field(s) (comma-separated) with auto-aggregation. Bare --group uses per-type defaults.')  # noqa: E501
 @click.option('--save', 'save', type=str, default=None, help='Save the query expression ARG under this name for later reuse (e.g. --save vuln_high)')  # noqa: E501
 @click.pass_context
-def query(ctx, arg, output, output_folder, time_delta, fmt, workspace, report_filter, driver, dedupe, limit, group, save):  # noqa: E501
+def query(ctx, arg, output, output_folder, time_delta, fmt, workspace, report_filter, driver, dedupe, limit, sort, count, uniq, group, save):  # noqa: E501
 	"""Query"""
 
 	# 0. Save the expression under a name, then exit (reuse later with `secator q <name>`).
@@ -1142,17 +1147,17 @@ def query(ctx, arg, output, output_folder, time_delta, fmt, workspace, report_fi
 	# Empty query: return all results (subject to the enforced base query),
 	# optionally scoped by --report-filter / --workspace.
 	if not arg:
-		run_report_show(report_filter, output, time_delta, None, fmt, workspace, driver, dedupe, limit, output_folder)
+		run_report_show(report_filter, output, time_delta, None, fmt, workspace, driver, dedupe, limit, output_folder, sort=sort, count=count, uniq=uniq, group=group)  # noqa: E501
 		return
 
 	# 1. Saved query name
 	if arg in CONFIG.queries:
-		run_report_show(report_filter, output, time_delta, CONFIG.queries[arg], fmt, workspace, driver, dedupe, limit, output_folder, group)  # noqa: E501
+		run_report_show(report_filter, output, time_delta, CONFIG.queries[arg], fmt, workspace, driver, dedupe, limit, output_folder, sort=sort, count=count, uniq=uniq, group=group)  # noqa: E501
 		return
 
 	# 2. Raw filter expression
 	if _looks_like_query_expr(arg):
-		run_report_show(report_filter, output, time_delta, arg, fmt, workspace, driver, dedupe, limit, output_folder, group)  # noqa: E501
+		run_report_show(report_filter, output, time_delta, arg, fmt, workspace, driver, dedupe, limit, output_folder, sort=sort, count=count, uniq=uniq, group=group)  # noqa: E501
 		return
 
 	# 3. Natural language -> AI chat
@@ -1378,7 +1383,61 @@ def _apply_format(results, fmt):
 	return new_results
 
 
-def run_report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe, limit, output_folder=None, group=None):  # noqa: E501
+def _sort_results_by_field(results, sort):
+	"""Sort each type's findings by a field, in place. Numeric-aware (ints/floats sort naturally);
+	a leading `-` sorts descending. Missing values sort last. Runs before --format, so `--sort port`
+	orders the rows even when --format shows a different field. Backend-agnostic (post-fetch)."""
+	field = sort.strip()
+	reverse = field.startswith('-')
+	if reverse:
+		field = field[1:].strip()
+
+	def _key(item):
+		# Resolve the (dotted) field on dicts OR objects, so `--sort` also reaches attributes like
+		# `_group_count` set by --group on the representative OutputType (dicts don't carry it).
+		val = item
+		for part in field.split('.'):
+			if isinstance(val, dict):
+				val = val.get(part)
+			else:
+				val = getattr(val, part, None)
+			if val is None:
+				break
+		return val
+
+	for _type, items in results.items():
+		keyed = [(_key(it), it) for it in items]
+		try:
+			keyed.sort(key=lambda kv: (kv[0] is None, kv[0]), reverse=reverse)
+		except TypeError:
+			# Mixed/incomparable field types -> stable string ordering.
+			keyed.sort(key=lambda kv: (kv[0] is None, str(kv[0])), reverse=reverse)
+		results[_type] = [it for _, it in keyed]
+
+
+def _aggregate_values(results, count=False, uniq=False, sort_given=False):
+	"""Post-format aggregation of --format output values, per type (backend-agnostic: runs on the
+	already-fetched, formatted rows). `uniq` drops duplicate values (first-seen order). `count`
+	groups identical values into ``"<count>  <value>"`` rows — ordered most-frequent-first by
+	default (classic top-N), or, when --sort was given, kept in the sorted (value) order the
+	findings arrived in."""
+	out = {}
+	for _type, values in results.items():
+		svals = [str(v) for v in values]
+		if count:
+			items = list(Counter(svals).items())  # (value, count), first-seen insertion order
+			if not sort_given:
+				items.sort(key=lambda kv: kv[1], reverse=True)  # top-N: most frequent first
+			width = max((len(str(c)) for _, c in items), default=1)
+			out[_type] = [f'{str(c).rjust(width)}  {v}' for v, c in items]
+		elif uniq:
+			out[_type] = list(dict.fromkeys(svals))
+		else:
+			out[_type] = svals
+	return out
+
+
+def run_report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe, limit, output_folder=None, sort=None, count=False, uniq=False, group=None):  # noqa: E501
 	"""Build and send a consolidated report. Shared by `report show` and `query`.
 
 	REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3).
@@ -1490,9 +1549,13 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	# 6. Build and send report via QueryEngine
 	dedupe_effective = CONFIG.runners.remove_duplicates if dedupe is None else dedupe
 	report = Report(runner, title=f'Consolidated report - {current}', exporters=exporters)
-	report.build(query=full_query, dedupe=dedupe_effective, limit=limit)
+	# Fetch the FULL set when reshaping/capping the output — --group / --sort / --uniq / --count
+	# operate post-query, so limiting the backend fetch first would group/sort/dedupe/count only a
+	# partial slice. --limit is then applied to the finished output below.
+	aggregating = bool(sort or count or uniq or group is not None)
+	report.build(query=full_query, dedupe=dedupe_effective, limit=(0 if aggregating else limit))
 
-	# Group findings by field(s) with auto-aggregation (processing-side, post-query).
+	# 1. Group findings by field(s) with auto-aggregation (processing-side, post-query).
 	# `group is None` => disabled; `group == ''` => per-type defaults; else explicit field(s).
 	grouped_types = []
 	if group is not None and not fmt:
@@ -1515,8 +1578,16 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	elif group is not None and fmt:
 		console.print(Warning(message='--group is ignored when --format is used'))
 
+	# 2. Sort findings by a field, AFTER grouping — so `--sort -_group_count` orders the groups
+	# (top-N most/least frequent), which is the ordering --group lacks on its own.
+	if sort:
+		_sort_results_by_field(report.data['results'], sort)
 	if fmt:
 		report.data['results'] = _apply_format(report.data['results'], fmt)
+	if count or uniq:
+		report.data['results'] = _aggregate_values(report.data['results'], count=count, uniq=uniq, sort_given=bool(sort))
+	if aggregating and limit:
+		report.data['results'] = {t: items[:limit] for t, items in report.data['results'].items()}
 	report.send()
 	total_results = sum(len(items) for items in report.data['results'].values())
 	emit_query_warnings(query_warnings)
@@ -1554,11 +1625,14 @@ def run_ai_chat(ctx, prompt, workspace):
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api', 'sqlite']), default=None, help='Query backend driver')  # noqa: E501
 @click.option('--dedupe/--no-dedupe', default=None, help='Deduplicate findings (defaults to config value)')
 @click.option('-l', '--limit', type=int, default=0, help='Limit number of results (0 = no limit)')
+@click.option('--sort', 'sort', type=str, default=None, help='Sort results by a field (numeric-aware; prefix with - for descending), e.g. --sort port or --sort -severity_score')  # noqa: E501
+@click.option('--count', 'count', is_flag=True, default=False, help='Group identical --format values with an occurrence count (most frequent first; --sort orders by value instead)')  # noqa: E501
+@click.option('--uniq', 'uniq', is_flag=True, default=False, help='Drop duplicate --format values')
 @click.option('--group', is_flag=False, flag_value='', default=None, help='Group findings by field(s) (comma-separated) with auto-aggregation. Bare --group uses per-type defaults.')  # noqa: E501
 @click.pass_context
-def report_show(ctx, report_query, output, output_folder, time_delta, query, fmt, workspace, driver, dedupe, limit, group):  # noqa: E501
+def report_show(ctx, report_query, output, output_folder, time_delta, query, fmt, workspace, driver, dedupe, limit, sort, count, uniq, group):  # noqa: E501
 	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""
-	run_report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe, limit, output_folder, group)
+	run_report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe, limit, output_folder, sort=sort, count=count, uniq=uniq, group=group)  # noqa: E501
 
 
 def _load_report_data(path):

--- a/tests/unit/test_query_aggregate.py
+++ b/tests/unit/test_query_aggregate.py
@@ -1,0 +1,98 @@
+"""`secator q` --sort / --count / --uniq post-processing.
+
+These run on the already-fetched, formatted results dict (after report.build + --format), so they
+are backend-agnostic: json, sqlite, mongodb and api all feed the SAME `{type: [items]}` structure
+into these helpers, so proving the helpers proves every backend. The user's target
+`secator q port -f port --sort port --limit 15 --count` is the sort-then-count flow below.
+"""
+import unittest
+
+from secator.cli import _aggregate_values, _sort_results_by_field
+
+
+class TestSortResultsByField(unittest.TestCase):
+
+	def test_numeric_sort_is_not_lexical(self):
+		results = {'port': [{'port': 443}, {'port': 22}, {'port': 80}]}
+		_sort_results_by_field(results, 'port')
+		self.assertEqual([d['port'] for d in results['port']], [22, 80, 443])  # not ['22','443','80']
+
+	def test_descending_prefix(self):
+		results = {'port': [{'port': 22}, {'port': 443}, {'port': 80}]}
+		_sort_results_by_field(results, '-port')
+		self.assertEqual([d['port'] for d in results['port']], [443, 80, 22])
+
+	def test_missing_values_sort_last(self):
+		results = {'port': [{'port': 80}, {}, {'port': 22}]}
+		_sort_results_by_field(results, 'port')
+		self.assertEqual([d.get('port') for d in results['port']], [22, 80, None])
+
+	def test_nested_dotted_field(self):
+		results = {'x': [{'a': {'b': 3}}, {'a': {'b': 1}}]}
+		_sort_results_by_field(results, 'a.b')
+		self.assertEqual([d['a']['b'] for d in results['x']], [1, 3])
+
+	def test_mixed_types_do_not_crash(self):
+		results = {'x': [{'v': 5}, {'v': 'z'}, {'v': 1}]}
+		_sort_results_by_field(results, 'v')  # falls back to string ordering, must not raise
+		self.assertEqual(len(results['x']), 3)
+
+
+class TestAggregateValues(unittest.TestCase):
+
+	def test_count_most_frequent_first_by_default(self):
+		results = {'port': ['443', '443', '80', '443', '80', '22']}
+		out = _aggregate_values(results, count=True)
+		self.assertEqual(out['port'], ['3  443', '2  80', '1  22'])  # top-N: count desc
+
+	def test_count_keeps_value_order_when_sort_given(self):
+		# findings already ordered by --sort -> keep that (value) order, don't re-sort by count.
+		results = {'port': ['22', '443', '443', '80', '80', '80']}
+		out = _aggregate_values(results, count=True, sort_given=True)
+		self.assertEqual(out['port'], ['1  22', '2  443', '3  80'])
+
+	def test_count_column_is_width_aligned(self):
+		results = {'port': ['80'] * 12 + ['22']}   # counts 12 and 1 -> width 2
+		out = _aggregate_values(results, count=True)
+		self.assertEqual(out['port'], ['12  80', ' 1  22'])
+
+	def test_uniq_dedupes_preserving_order(self):
+		results = {'port': ['443', '80', '443', '22', '80']}
+		out = _aggregate_values(results, uniq=True)
+		self.assertEqual(out['port'], ['443', '80', '22'])
+
+	def test_cli_options_registered_on_both_commands(self):
+		from secator.cli import query, report_show
+		for cmd in (query, report_show):
+			names = {p.name for p in cmd.params}
+			self.assertTrue({'sort', 'count', 'uniq'} <= names, f'missing options on {cmd.name}: {names}')
+
+	def test_sort_then_count_flow_matches_example(self):
+		# The `-f port --sort port --count` path: sort findings by port, extract, count, keep order.
+		results = {'port': [{'port': 443}, {'port': 22}, {'port': 443}, {'port': 80}, {'port': 443}, {'port': 80}]}
+		_sort_results_by_field(results, 'port')
+		formatted = {'port': [str(d['port']) for d in results['port']]}   # simulates -f port
+		out = _aggregate_values(formatted, count=True, sort_given=True)
+		self.assertEqual(out['port'], ['1  22', '2  80', '3  443'])   # by port asc, with counts
+
+
+class TestGroupSortComposition(unittest.TestCase):
+	"""--sort composes with --group: `--group name --sort -_group_count --limit N` = top-N groups
+	by frequency (the ordering --group lacks on its own)."""
+
+	def _vuln(self, name):
+		return {'_type': 'vulnerability', 'name': name, 'matched_at': f'{name}-u', 'severity': 'info'}
+
+	def test_sort_by_group_count_orders_groups_for_top_n(self):
+		from secator.query.utils import group_findings
+		# B is seen first, but A occurs more often -> -_group_count must rank A ahead of B.
+		items = [self._vuln('B'), self._vuln('A'), self._vuln('A'), self._vuln('A'), self._vuln('B')]
+		results = {'vulnerability': group_findings(items, ['name'], 'matched_at')}
+		_sort_results_by_field(results, '-_group_count')
+		ordered = [(r.name, r._group_count) for r in results['vulnerability']]
+		self.assertEqual(ordered, [('A', 3), ('B', 2)])
+		self.assertEqual(results['vulnerability'][0].name, 'A')  # --limit 1 -> top group
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Replaces the `secator q ... | cut | sort | uniq -c | head` pipeline with first-class options on `secator q` and `secator report show`. All post-query and **backend-agnostic** — they run on the same `{type: [items]}` dict every backend (local/mongodb/api/sqlite) returns, so proving the helpers proves every backend.

## Options
- `--sort <field>` — order findings by a field. Numeric-aware (`443` sorts after `80`, not lexically), `-field` for descending, missing values last, dotted paths (`a.b`) supported. Also reaches object attributes like `_group_count`.
- `--count` — group identical `--format` values into `"<count>  <value>"` rows, **most-frequent-first** (top-N) by default, or in value order when `--sort` is given.
- `--uniq` — drop duplicate `--format` values.
- `--limit` is applied to the **aggregated output** (the full set is fetched first, so sort/count/dedupe see everything).

The target from the issue works:
```
secator q port -f port --sort port --count --limit 15    # top-15 ports with counts, by port value
secator q port -f port --count --limit 15                # top-15 ports by frequency
```

## Relationship to #1304 (`--group`)
Complementary, not overlapping: `--group` aggregates **findings** (groups by field, keeps newest + `_group_count`), while `--count`/`--uniq` aggregate **`--format` output values**. They compose cleanly — verified locally — via one ordering layer:
- `--group name --sort -_group_count --limit 5` → **top-5 groups by frequency** (the ordering `--group` lacks on its own; `--sort` reaches `_group_count`).

The two PRs touch the same `run_report_show` region, so they conflict in `cli.py`; the resolution is the pipeline **build → group → sort → format → count/uniq → limit**. Recommend merging #1304 first, then rebasing this on top with that integration (worked out and tested).

## Tests
`tests/unit/test_query_aggregate.py`: numeric/desc/missing/nested/mixed sort, count ordering + width alignment, uniq, the sort-then-count flow matching the example, and CLI option registration on both commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commands defined as shell aliases are now recognized and executed correctly, including aliases used with `sudo`.
  * Commands are no longer automatically installed when they are available through a shell alias.
  * Command availability checks now work more reliably when searching the system PATH.

* **Tests**
  * Added coverage for Bash and Zsh alias formats, missing shells, command errors, alias substitution, and PATH-based availability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->