### PR TITLE
fix(runners): don't record query-task inputs as phantom Targets

### DIFF
--- a/secator/runners/_base.py
+++ b/secator/runners/_base.py
@@ -78,6 +78,12 @@ class Runner:
 	# Input field (mostly for tests and CLI)
 	input_types = []
 
+	# Whether the runner's inputs are real targets that should be persisted as
+	# Target findings. True for every real task; the built-in `command` task sets
+	# this False because its "inputs" are raw shell commands, not targets (else
+	# they pollute the workspace target list).
+	enable_targets = True
+
 	# Output types
 	output_types = []
 
@@ -218,7 +224,7 @@ class Runner:
 		self.debug(f'resolving inputs with {len(self.dynamic_opts)} dynamic opts', obj=self.dynamic_opts, sub='init')
 		self.inputs = [inputs] if not isinstance(inputs, list) else inputs
 		self.inputs = list(dict.fromkeys(self.inputs))
-		if self.caller != 'Task':
+		if self.caller != 'Task' and self.enable_targets:
 			targets = [Target(name=target) for target in self.inputs]
 			for target in targets:
 				self.add_result(target, print=False, output=False)

--- a/secator/tasks/search_vulns.py
+++ b/secator/tasks/search_vulns.py
@@ -21,6 +21,9 @@ class search_vulns(Vuln):
 	tags = ['vuln', 'recon']
 	input_flag = '-q'
 	input_chunk_size = 1
+	# Inputs are product/CPE query strings (fan-in: `matched_at~product version`),
+	# not targets — never persist them as phantom Target findings.
+	enable_targets = False
 	item_loaders = [JSONSerializer()]
 	json_flag = '-f json'
 	version_flag = '-V'

--- a/secator/tasks/searchsploit.py
+++ b/secator/tasks/searchsploit.py
@@ -20,6 +20,8 @@ class searchsploit(Command):
 	output_types = [Exploit]
 	tags = ['exploit', 'recon']
 	input_chunk_size = 1
+	# Inputs are product/CPE query strings (fan-in: `matched_at~id`), not targets.
+	enable_targets = False
 	json_flag = '--json'
 	version_flag = OPT_NOT_SUPPORTED
 	opts = {

--- a/tests/unit/test_input_targets.py
+++ b/tests/unit/test_input_targets.py
@@ -1,0 +1,60 @@
+"""Tests for enable_targets: query-type tasks must not record their inputs as Targets."""
+import unittest
+
+from secator.decorators import task
+from secator.runners import PythonRunner
+from secator.output_types import Info
+from secator.tasks.search_vulns import search_vulns
+from secator.tasks.searchsploit import searchsploit
+from secator.tasks.nmap import nmap
+
+
+class TestEnableTargets(unittest.TestCase):
+	"""A runner records its inputs as Target findings by default (enable_targets=True),
+	but a query-type task (enable_targets=False) must not — otherwise the
+	search_vulns/searchsploit fan-in query string (`<matched_at>~<product>`) is
+	persisted as a phantom Target that pollutes the workspace target list."""
+
+	def test_default_task_emits_input_targets(self):
+		@task()
+		class TargetEmittingTask(PythonRunner):
+			input_types = None
+			output_types = [Info]
+
+			def yielder(self):
+				yield Info(message="ok")
+
+		results = TargetEmittingTask(inputs=['scanme.example.com']).run()
+		targets = [r for r in results if r._type == 'target']
+		self.assertTrue(
+			any(t.name == 'scanme.example.com' for t in targets),
+			"a normal task should record its input as a Target",
+		)
+
+	def test_query_task_does_not_emit_input_targets(self):
+		@task()
+		class QueryTask(PythonRunner):
+			input_types = None
+			output_types = [Info]
+			enable_targets = False
+
+			def yielder(self):
+				yield Info(message="ok")
+
+		# The exact shape of a search_vulns fan-in input — must NOT become a Target.
+		blob = '1.2.3.4:80,1.2.3.4:443~nginx 1.31.5'
+		results = QueryTask(inputs=[blob]).run()
+		targets = [r for r in results if r._type == 'target']
+		self.assertEqual(targets, [], "a query-type task must not record input Targets")
+
+	def test_query_tasks_have_targets_disabled(self):
+		self.assertFalse(search_vulns.enable_targets)
+		self.assertFalse(searchsploit.enable_targets)
+
+	def test_target_tasks_keep_targets_enabled(self):
+		self.assertTrue(nmap.enable_targets)
+		self.assertTrue(PythonRunner.enable_targets)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
## Problem
`search_vulns` / `searchsploit` inputs are **product/CPE query strings**, and the fan-in encodes them as `<matched_at>~<product>`. But the runner records every input as a `Target` finding — so the whole comma+`~` blob (e.g. `178.79.134.182:80,...,https://pentest-ground.com~nginx 1.31.5`) was persisted as a **phantom Target**, then surfaced in the Targets tab, Suggestions, scope coverage and counts.

## Fix
Reuse the existing **`enable_targets`** runner flag (default `True`; the built-in `command` task already sets it `False` so raw shell command inputs aren't recorded — same class of bug). Set `enable_targets = False` on `search_vulns` / `searchsploit`, read directly via `self.enable_targets` at the Target-emission guard in `_base.py` — exactly like `input_types` / `output_types` / `profile`. No lookup helper, no new flag.

Delimiter-independent (never inspects the input), so real `PATH`/host/URL targets (incl. `~/folder/file.txt` for gitleaks/trivy) are untouched. The vuln→host linkage is unaffected (`matched_at` is split independently in `on_json_loaded`).

> Note: `enable_targets` (the base default + guard) also lands via the AI branch's `command`-task fix; the additions here are byte-identical, so the eventual merge is conflict-free.

## Tests
`tests/unit/test_input_targets.py` — a query-type task emits no Target for a `~` fan-in blob; a normal task still records its input; the real query tasks carry `enable_targets=False`. flake8 clean; runner tests pass.

## Follow-up (not in this PR)
One-off cleanup query to purge phantom Targets already persisted in existing workspaces (secator-api / Mongo).