### PR TITLE
feat(cli): secator workspace summary (template-driven findings summary)

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -874,6 +874,102 @@ def workspace_current():
 	console.print(Info(message=f'Current workspace: [bold gold3]{current}[/]. Use [bold green4]secator ws use <workspace>[/] to switch.'))  # noqa: E501
 
 
+# Built-in `workspace summary` template. It is template-DRIVEN: it calls the `query(...)` helper
+# (exposed in the render context) which runs a real query with the same --format/--count/--sort/
+# --uniq/--limit surface as `secator q`. Override the whole thing with `--template <file>`.
+DEFAULT_SUMMARY_TEMPLATE = """\
+[bold gold3]:clipboard: Workspace summary — {{ workspace }}[/]
+
+[bold cyan]Top ports[/]
+{{ query('port', fmt='port', count=True, limit=15) }}
+
+[bold cyan]Top hosts (IPs)[/]
+{{ query('ip', fmt='ip', count=True, limit=15) }}
+
+[bold cyan]Top subdomains[/]
+{{ query('subdomain', fmt='host', count=True, limit=15) }}
+
+[bold cyan]Top technologies[/]
+{{ query('technology', fmt='product', count=True, limit=15) }}
+
+[bold cyan]Top URLs[/]
+{{ query('url', fmt='url', count=True, limit=15) }}
+
+[bold red3]Vulnerabilities by severity[/]
+{{ query('vulnerability', fmt='severity', count=True) }}
+
+[bold red3]Vulnerabilities by status[/]
+{{ query('vulnerability', fmt='status', count=True) }}
+
+[bold red3]Top vulnerabilities[/]
+{{ query('vulnerability', fmt='name', count=True, limit=15) }}
+"""
+
+
+def _summary_query_engine(workspace, driver):
+	"""Resolve the workspace + query backend for `workspace summary` (mirrors run_report_show)."""
+	workspace_name = workspace or CONFIG.workspaces.current or 'default'
+	effective_driver = QueryEngine.resolve_backend(driver)
+	drivers = [effective_driver] if effective_driver != 'local' else []
+	workspace_id = workspace_name
+	if effective_driver == 'api':
+		from secator.hooks.api import resolve_workspace
+		workspace_id, workspace_name = resolve_workspace(workspace_name)
+	engine = QueryEngine(workspace_id, context={'drivers': drivers, 'workspace_name': workspace_name})
+	return engine, workspace_name
+
+
+def _summary_query(engine, type_or_expr, fmt=None, count=False, uniq=False, sort=None, limit=0):
+	"""Run one summary query and return rendered rows (newline-joined). Exposed to summary
+	templates as `query(...)`; mirrors the `secator q` pipeline (sort -> format -> count/uniq ->
+	limit) on the fetched findings, so it is backend-agnostic. Row values are rich-escaped so a
+	finding value containing brackets can't corrupt the rendered markup."""
+	from rich.markup import escape
+	from secator.query.utils import python_expr_to_mongo
+	q = python_expr_to_mongo(type_or_expr)
+	aggregating = bool(sort or count or uniq)
+	findings = engine.search(q, limit=(0 if aggregating else limit), dedupe=CONFIG.runners.remove_duplicates)
+	results = {}
+	for f in findings:
+		results.setdefault(f.get('_type', str(type_or_expr)), []).append(f)
+	if sort:
+		_sort_results_by_field(results, sort)
+	if fmt:
+		results = _apply_format(results, fmt)
+	if count or uniq:
+		results = _aggregate_values(results, count=count, uniq=uniq, sort_given=bool(sort))
+	rows = [escape(str(x)) for items in results.values() for x in items]
+	if aggregating and limit:
+		rows = rows[:limit]
+	return '\n'.join(rows) if rows else '[dim](none)[/]'
+
+
+@workspace.command('summary')
+@click.option('-w', '-ws', '--workspace', 'workspace_opt', type=str, default=None, help='Workspace name (default: current)')  # noqa: E501
+@click.option('--driver', type=click.Choice(['local', 'mongodb', 'api', 'sqlite']), default=None, help='Query backend driver')  # noqa: E501
+@click.option('--template', 'template_path', type=str, default=None, help='Path to a Jinja2 summary template overriding the built-in one')  # noqa: E501
+def workspace_summary(workspace_opt, driver, template_path):
+	"""Summarize a workspace's findings (top ports/hosts/tech/URLs + vulnerabilities).
+
+	Renders a Jinja2 template that calls `query(type, fmt=.., count=.., uniq=.., sort=.., limit=..)`
+	against the workspace (same surface as `secator q`). Override with --template <file>.
+	"""
+	engine, workspace_name = _summary_query_engine(workspace_opt, driver)
+	if template_path:
+		try:
+			template_str = Path(template_path).read_text(encoding='utf-8')
+		except OSError as e:
+			raise click.UsageError(f'Could not read --template "{template_path}": {e}')
+	else:
+		template_str = DEFAULT_SUMMARY_TEMPLATE
+
+	def _query(type_or_expr, **kwargs):
+		return _summary_query(engine, type_or_expr, **kwargs)
+
+	rendered = Template(template_str).render(workspace=workspace_name, query=_query, q=_query)
+	console.print(rendered)
+
+
 @workspace.command(name='rm', aliases=['remove', 'delete'])
 @click.argument('name')
 @click.option('--driver', type=click.Choice(['local', 'mongodb', 'api', 'sqlite']), default=None, help='Query backend driver')  # noqa: E501

--- a/tests/unit/test_workspace_summary.py
+++ b/tests/unit/test_workspace_summary.py
@@ -1,0 +1,72 @@
+"""`secator workspace summary` — template-driven workspace findings summary.
+
+The summary renders a Jinja2 template that calls a `query(...)` helper (same --format/--count/
+--sort/--limit surface as `secator q`). The query helper is backend-agnostic (runs on fetched
+findings), so a fake engine proves the behavior for every backend.
+"""
+import unittest
+
+from jinja2 import Template
+
+from secator.cli import DEFAULT_SUMMARY_TEMPLATE, _summary_query, workspace
+
+
+class FakeEngine:
+	def __init__(self, findings):
+		self._findings = findings
+
+	def search(self, query, limit=0, dedupe=False):
+		return list(self._findings)
+
+
+class TestSummaryQuery(unittest.TestCase):
+
+	def test_count_fmt_produces_top_rows(self):
+		findings = [
+			{'_type': 'port', 'port': 443, 'ip': '1'},
+			{'_type': 'port', 'port': 443, 'ip': '2'},
+			{'_type': 'port', 'port': 80, 'ip': '3'},
+		]
+		out = _summary_query(FakeEngine(findings), 'port', fmt='port', count=True, limit=15)
+		self.assertEqual(out, '2  443\n1  80')   # 443 x2 then 80 x1, most-frequent-first
+
+	def test_empty_returns_none_marker(self):
+		out = _summary_query(FakeEngine([]), 'vulnerability', fmt='status', count=True)
+		self.assertEqual(out, '[dim](none)[/]')
+
+	def test_row_values_are_markup_escaped(self):
+		# A finding value with brackets must not corrupt the rendered rich markup.
+		findings = [{'_type': 'vulnerability', 'name': 'CVE [test]', 'severity': 'high'}]
+		out = _summary_query(FakeEngine(findings), 'vulnerability', fmt='name', count=True)
+		self.assertIn(r'\[test]', out)          # escaped, not a live markup tag
+
+
+class TestSummaryTemplate(unittest.TestCase):
+
+	def test_default_template_renders_and_calls_query(self):
+		calls = []
+
+		def q(type_or_expr, **kwargs):
+			calls.append(type_or_expr)
+			return f'ROWS({type_or_expr})'
+
+		out = Template(DEFAULT_SUMMARY_TEMPLATE).render(workspace='ws1', query=q, q=q)
+		self.assertIn('Workspace summary — ws1', out)
+		self.assertIn('Top ports', out)
+		self.assertIn('ROWS(port)', out)
+		self.assertIn('ROWS(vulnerability)', out)
+		# every confirmed section type is queried
+		for t in ('port', 'ip', 'subdomain', 'technology', 'url', 'vulnerability'):
+			self.assertIn(t, calls)
+
+
+class TestSummaryCommandWiring(unittest.TestCase):
+
+	def test_summary_registered_with_options(self):
+		self.assertIn('summary', workspace.commands)
+		params = {p.name for p in workspace.commands['summary'].params}
+		self.assertTrue({'workspace_opt', 'driver', 'template_path'} <= params)
+
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
Adds `secator workspace summary` (`ws summary`) — a summary of a workspace's findings, built on the query aggregation surface from #1304 (`--group`) and #1381 (`--sort`/`--count`/`--uniq`).

## Template-driven
The command renders a **Jinja2 template** that calls a `query(...)` helper exposed in the render context — so the template itself decides what to query and how to show it, using the same options as `secator q`:

```jinja
[bold cyan]Top ports[/]
{{ query('port', fmt='port', count=True, limit=15) }}

[bold red3]Vulnerabilities by severity[/]
{{ query('vulnerability', fmt='severity', count=True) }}
```

`query(type_or_expr, fmt=, count=, uniq=, sort=, limit=)` runs the `secator q` pipeline (sort → format → count/uniq → limit) on the fetched findings and returns rendered rows. It's **backend-agnostic** (runs post-fetch) and rich-escapes row values.

Override the whole layout/content with `--template <file>`.

## Built-in summary
Top-15 **ports / hosts (IPs) / subdomains / technologies / URLs**, and **vulnerabilities by severity, by status, and top names** (the sections confirmed for the default).

## Verified
- Unit: `query()` count+fmt produces most-frequent-first rows; empty → `(none)`; row values markup-escaped; the default template renders + calls `query()` for every section; command wired with `--workspace`/`--driver`/`--template`.
- E2E (local backend): empty workspace → all `(none)`; seeded workspace → `Top ports: 3 443 / 1 80 / 1 22`, `by severity: 2 high / 1 critical`, `by status: 2 NEW / 1`, `top vulns: 2 XSS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `workspace summary` command for generating concise reports of workspace findings.
  - Summaries include top ports, hosts, subdomains, technologies, URLs, and vulnerabilities grouped by severity, status, or name.
  - Supports selecting a workspace and query driver, with filtering, sorting, counting, deduplication, formatting, and result limits.
  - Added support for custom summary templates, while providing a built-in default template for immediate use.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->