### PR TITLE
feat(query): --group flag with per-type defaults + composes with --format

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1128,7 +1128,7 @@ def list_aliases(silent):
 @click.option('--sort', 'sort', type=str, default=None, help='Sort results by a field (numeric-aware; prefix with - for descending), e.g. --sort port or --sort -severity_score')  # noqa: E501
 @click.option('--count', 'count', is_flag=True, default=False, help='Group identical --format values with an occurrence count (most frequent first; --sort orders by value instead)')  # noqa: E501
 @click.option('--uniq', 'uniq', is_flag=True, default=False, help='Drop duplicate --format values')
-@click.option('--group', is_flag=False, flag_value='', default=None, help='Group findings by field(s) (comma-separated) with auto-aggregation. Bare --group uses per-type defaults.')  # noqa: E501
+@click.option('--group', is_flag=True, default=False, help="Group findings by each output type's default field(s), aggregating a related field (e.g. vulnerabilities by name with their matched_at targets).")  # noqa: E501
 @click.option('--save', 'save', type=str, default=None, help='Save the query expression ARG under this name for later reuse (e.g. --save vuln_high)')  # noqa: E501
 @click.pass_context
 def query(ctx, arg, output, output_folder, time_delta, fmt, workspace, report_filter, driver, dedupe, limit, sort, count, uniq, group, save):  # noqa: E501
@@ -1555,28 +1555,24 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	aggregating = bool(sort or count or uniq or group is not None)
 	report.build(query=full_query, dedupe=dedupe_effective, limit=(0 if aggregating else limit))
 
-	# 1. Group findings by field(s) with auto-aggregation (processing-side, post-query).
-	# `group is None` => disabled; `group == ''` => per-type defaults; else explicit field(s).
+	# 1. Group findings by each type's DEFAULT field(s) with auto-aggregation (processing-side,
+	# post-query). --group is a flag: types with no `_group_by` default are left ungrouped.
 	grouped_types = []
-	if group is not None and not fmt:
+	if group:
 		from secator.query.utils import group_findings
-		user_group_by = [f.strip() for f in group.split(',') if f.strip()]
 		type_map = {cls.get_name(): cls for cls in FINDING_TYPES}
 		for type_name, items in report.data['results'].items():
 			cls = type_map.get(type_name)
 			if not items or cls is None:
 				continue
-			group_by = user_group_by or list(getattr(cls, '_group_by', ()) or ())
+			group_by = list(getattr(cls, '_group_by', ()) or ())
 			if not group_by:
 				continue
 			aggregate_field = getattr(cls, '_group_aggregate', None)
 			report.data['results'][type_name] = group_findings(items, group_by, aggregate_field)
 			grouped_types.append((type_name, ', '.join(group_by)))
 		if not grouped_types:
-			group_desc = f' "{group}"' if group else ''
-			console.print(Warning(message=f'--group{group_desc}: no groupable finding types in results'))
-	elif group is not None and fmt:
-		console.print(Warning(message='--group is ignored when --format is used'))
+			console.print(Warning(message='--group: no groupable finding types in results'))
 
 	# 2. Sort findings by a field, AFTER grouping — so `--sort -_group_count` orders the groups
 	# (top-N most/least frequent), which is the ordering --group lacks on its own.
@@ -1628,7 +1624,7 @@ def run_ai_chat(ctx, prompt, workspace):
 @click.option('--sort', 'sort', type=str, default=None, help='Sort results by a field (numeric-aware; prefix with - for descending), e.g. --sort port or --sort -severity_score')  # noqa: E501
 @click.option('--count', 'count', is_flag=True, default=False, help='Group identical --format values with an occurrence count (most frequent first; --sort orders by value instead)')  # noqa: E501
 @click.option('--uniq', 'uniq', is_flag=True, default=False, help='Drop duplicate --format values')
-@click.option('--group', is_flag=False, flag_value='', default=None, help='Group findings by field(s) (comma-separated) with auto-aggregation. Bare --group uses per-type defaults.')  # noqa: E501
+@click.option('--group', is_flag=True, default=False, help="Group findings by each output type's default field(s), aggregating a related field (e.g. vulnerabilities by name with their matched_at targets).")  # noqa: E501
 @click.pass_context
 def report_show(ctx, report_query, output, output_folder, time_delta, query, fmt, workspace, driver, dedupe, limit, sort, count, uniq, group):  # noqa: E501
 	"""Show report results. REPORT_QUERY: comma-separated runner paths (e.g. scans/5,tasks/3)."""

--- a/secator/output_types/exploit.py
+++ b/secator/output_types/exploit.py
@@ -38,6 +38,8 @@ class Exploit(OutputType):
 		REFERENCE,
 	]
 	_sort_by = ('matched_at', 'name')
+	_group_by = (NAME,)          # collapse an exploit across its targets into one row
+	_group_aggregate = MATCHED_AT
 
 	def __str__(self):
 		return self.name

--- a/secator/output_types/port.py
+++ b/secator/output_types/port.py
@@ -32,6 +32,8 @@ class Port(OutputType):
 
 	_table_fields = [IP, PORT, HOST, CPES, EXTRA_DATA]
 	_sort_by = (PORT, IP)
+	_group_by = (HOST,)          # collapse a host's ports into one row
+	_group_aggregate = PORT
 
 	def __gt__(self, other):
 		# favor nmap over other port detection tools

--- a/secator/output_types/subdomain.py
+++ b/secator/output_types/subdomain.py
@@ -32,6 +32,8 @@ class Subdomain(OutputType):
 		SOURCES
 	]
 	_sort_by = (HOST,)
+	_group_by = (DOMAIN,)        # collapse a domain's subdomains into one row
+	_group_aggregate = HOST
 
 	def __str__(self):
 		return self.host

--- a/secator/output_types/url.py
+++ b/secator/output_types/url.py
@@ -61,6 +61,8 @@ class Url(OutputType):
 		'screenshot_path',
 	]
 	_sort_by = (URL,)
+	_group_by = ('host',)        # collapse a host's URLs into one row
+	_group_aggregate = URL
 
 	def __post_init__(self):
 		super().__post_init__()

--- a/secator/output_types/vulnerability.py
+++ b/secator/output_types/vulnerability.py
@@ -45,7 +45,7 @@ class Vulnerability(OutputType):
 
 	_table_fields = [MATCHED_AT, SEVERITY, CONFIDENCE, NAME, ID, CVSS_SCORE, STATUS, TAGS, EXTRA_DATA, REFERENCE]
 	_sort_by = ('confidence_nb', 'severity_nb', 'matched_at', 'cvss_score')
-	_group_by = (NAME,)
+	_group_by = (NAME,)  # id == name when an id exists; name is the stable grouping key
 	_group_aggregate = MATCHED_AT
 
 	@staticmethod

--- a/tests/unit/test_query_group.py
+++ b/tests/unit/test_query_group.py
@@ -45,6 +45,26 @@ class TestGroupFindings(unittest.TestCase):
 		reps = group_findings(items, ['name', 'matched_at'])          # (A,u1)x2, (A,u2)x1
 		self.assertEqual(sorted(r._group_count for r in reps), [1, 2])
 
+	def test_matched_at_aggregated_across_targets(self):
+		# The core use case: one vulnerability hitting many targets collapses to a single row whose
+		# matched_at lists all its targets.
+		items = [_vuln('XSS', 'a'), _vuln('XSS', 'b'), _vuln('XSS', 'c')]
+		reps = group_findings(items, ['name'], aggregate_field='matched_at')
+		self.assertEqual(len(reps), 1)
+		self.assertEqual(reps[0]._group_count, 3)
+		self.assertEqual(sorted(reps[0].matched_at.split(', ')), ['a', 'b', 'c'])
+
+	def test_per_type_group_defaults(self):
+		# Each type's default group field + aggregate field (used by the `--group` flag).
+		from secator.output_types import Vulnerability, Exploit, Port, Url, Subdomain, Tag, Technology
+		self.assertEqual((tuple(Vulnerability._group_by), Vulnerability._group_aggregate), (('name',), 'matched_at'))
+		self.assertEqual((tuple(Exploit._group_by), Exploit._group_aggregate), (('name',), 'matched_at'))
+		self.assertEqual((tuple(Port._group_by), Port._group_aggregate), (('host',), 'port'))
+		self.assertEqual((tuple(Url._group_by), Url._group_aggregate), (('host',), 'url'))
+		self.assertEqual((tuple(Subdomain._group_by), Subdomain._group_aggregate), (('domain',), 'host'))
+		self.assertEqual((tuple(Tag._group_by), Tag._group_aggregate), (('category', 'name'), 'match'))
+		self.assertEqual((tuple(Technology._group_by), Technology._group_aggregate), (('product',), 'match'))
+
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Revises `--group` per feedback: it's a **flag** (no field value) that groups each output type by its **default** field(s) with a default aggregation — matching the API's grouped-endpoint model (collapse duplicates, aggregate a related field). And it now **composes with `--format`**.

## `--group` is a flag
No `--group <field>` value anymore — each output type declares its own default `group_by` + aggregate. Types without a default are left ungrouped.

## Composes with `--format`
Grouping runs first, then the pipeline (sort → format → count/uniq → limit) applies to the grouped representatives. So a vulnerability hitting many targets counts **once**:
```
secator q vulnerability --group -f severity --count   # → "1 high / 1 critical" (XSS×2 collapsed)
secator q vulnerability --group                        # → "XSS (count: 2)" with matched_at aggregated
```

## Per-type defaults (`group_by → aggregate`)
| type | group by | aggregate |
|---|---|---|
| vulnerability | `name` | `matched_at` |
| exploit | `name` | `matched_at` |
| port | `host` | `port` |
| url | `host` | `url` |
| subdomain | `domain` | `host` |
| tag | `category, name` | `match` |
| technology | `product` | `match` |

Vulnerabilities group by `name` (an `id`, when present, equals the name; `id` was API-historical). Reverts the earlier `id`-or-`name` `$cond` — no longer needed.

## Tests
`tests/unit/test_query_group.py`: matched_at aggregated across targets, the per-type default table, plus the existing grouping/newest-rep/truncation tests.