### PR TITLE
feat(cli): workspace summary counts UNIQUE vulnerabilities by default

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -895,13 +895,13 @@ DEFAULT_SUMMARY_TEMPLATE = """\
 [bold cyan]Top URLs[/]
 {{ query('url', fmt='url', count=True, limit=15) }}
 
-[bold red3]Vulnerabilities by severity[/]
-{{ query('vulnerability', fmt='severity', count=True) }}
+[bold red3]Unique vulnerabilities by severity[/]
+{{ query('vulnerability', group=True, fmt='severity', count=True) }}
 
-[bold red3]Vulnerabilities by status[/]
-{{ query('vulnerability', fmt='status', count=True) }}
+[bold red3]Unique vulnerabilities by status[/]
+{{ query('vulnerability', group=True, fmt='status', count=True) }}
 
-[bold red3]Top vulnerabilities[/]
+[bold red3]Top vulnerabilities (by targets hit)[/]
 {{ query('vulnerability', fmt='name', count=True, limit=15) }}
 """
 
@@ -919,19 +919,30 @@ def _summary_query_engine(workspace, driver):
 	return engine, workspace_name
 
 
-def _summary_query(engine, type_or_expr, fmt=None, count=False, uniq=False, sort=None, limit=0):
+def _summary_query(engine, type_or_expr, fmt=None, count=False, uniq=False, sort=None, limit=0, group=False):
 	"""Run one summary query and return rendered rows (newline-joined). Exposed to summary
-	templates as `query(...)`; mirrors the `secator q` pipeline (sort -> format -> count/uniq ->
-	limit) on the fetched findings, so it is backend-agnostic. Row values are rich-escaped so a
-	finding value containing brackets can't corrupt the rendered markup."""
+	templates as `query(...)`; mirrors the `secator q` pipeline (group -> sort -> format ->
+	count/uniq -> limit) on the fetched findings, so it is backend-agnostic. Row values are
+	rich-escaped so a finding value containing brackets can't corrupt the rendered markup.
+
+	`group=True` first collapses findings by each type's default `_group_by` (aggregating its
+	`_group_aggregate`), so a subsequent count reflects UNIQUE findings — e.g. a vulnerability
+	hitting many targets counts once."""
 	from rich.markup import escape
-	from secator.query.utils import python_expr_to_mongo
+	from secator.query.utils import python_expr_to_mongo, group_findings
 	q = python_expr_to_mongo(type_or_expr)
-	aggregating = bool(sort or count or uniq)
+	aggregating = bool(sort or count or uniq or group)
 	findings = engine.search(q, limit=(0 if aggregating else limit), dedupe=CONFIG.runners.remove_duplicates)
 	results = {}
 	for f in findings:
 		results.setdefault(f.get('_type', str(type_or_expr)), []).append(f)
+	if group:
+		type_map = {cls.get_name(): cls for cls in FINDING_TYPES}
+		for _tname, _items in list(results.items()):
+			cls = type_map.get(_tname)
+			group_by = list(getattr(cls, '_group_by', ()) or ()) if cls else []
+			if group_by:
+				results[_tname] = group_findings(_items, group_by, getattr(cls, '_group_aggregate', None))
 	if sort:
 		_sort_results_by_field(results, sort)
 	if fmt:

--- a/tests/unit/test_workspace_summary.py
+++ b/tests/unit/test_workspace_summary.py
@@ -34,6 +34,20 @@ class TestSummaryQuery(unittest.TestCase):
 		out = _summary_query(FakeEngine([]), 'vulnerability', fmt='status', count=True)
 		self.assertEqual(out, '[dim](none)[/]')
 
+	def test_group_collapses_to_unique_before_count(self):
+		# Same vuln (name) on two targets -> group by name collapses to ONE, so the severity count
+		# reflects UNIQUE vulns (1 high), not instances (2). matched_at is the aggregate field.
+		findings = [
+			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'},
+			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'b'},
+			{'_type': 'vulnerability', 'name': 'SQLi', 'severity': 'critical', 'matched_at': 'c'},
+		]
+		grouped = _summary_query(FakeEngine(findings), 'vulnerability', group=True, fmt='severity', count=True)
+		self.assertEqual(grouped, '1  high\n1  critical')     # unique: XSS counted once
+		# Without group it counts instances (2 high) — proves group changes the result.
+		ungrouped = _summary_query(FakeEngine(findings), 'vulnerability', fmt='severity', count=True)
+		self.assertEqual(ungrouped, '2  high\n1  critical')
+
 	def test_row_values_are_markup_escaped(self):
 		# A finding value with brackets must not corrupt the rendered rich markup.
 		findings = [{'_type': 'vulnerability', 'name': 'CVE [test]', 'severity': 'high'}]


### PR DESCRIPTION
Follow-up to #1383: the workspace summary now reports **unique** vulnerability counts by default (a vulnerability hitting many targets counts once, not once per target).

## Change
- `_summary_query` (the template `query()` helper) gains `group=True`, which collapses findings by each type's default `_group_by` (aggregating `_group_aggregate`, e.g. vulns by `name` with `matched_at`) **before** format/count.
- The built-in template groups vulnerabilities before counting:
  - **Unique vulnerabilities by severity**: `query('vulnerability', group=True, fmt='severity', count=True)`
  - **Unique vulnerabilities by status**: same with `status`
  - **Top vulnerabilities (by targets hit)**: `query('vulnerability', fmt='name', count=True)` — each unique name with its target count (unchanged)

## Verified
- Unit: `group=True` collapses XSS×2 → one, so `by severity` = `1 high / 1 critical` (vs `2 high` ungrouped).
- E2E (local backend, seeded XSS×2 + SQLi): `Unique vulnerabilities by severity → 1 high / 1 critical`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace vulnerability summaries now report unique findings by severity and status.
  * “Top vulnerabilities” rankings now reflect the number of affected targets, avoiding duplicate counts across targets.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->