### PR TITLE
fix: atomic race-free task folder id allocation

### DIFF
--- a/secator/runners/_helpers.py
+++ b/secator/runners/_helpers.py
@@ -1,3 +1,4 @@
+import fcntl
 import os
 import re
 
@@ -347,17 +348,36 @@ def process_extractor(results, extractor, ctx=None):
 
 
 def get_task_folder_id(path):
-	names = []
-	if not os.path.exists(path):
-		return 0
-	for f in os.scandir(path):
-		if f.is_dir():
-			try:
-				int(f.name)
-				names.append(int(f.name))
-			except ValueError:
-				continue
-	names.sort()
-	if names:
-		return names[-1] + 1
-	return 0
+	"""Atomically claim the next integer folder id under `path`.
+
+	Was: ``scandir(path)`` + ``max()+1`` on every call — O(folders), i.e. O(N^2) across a
+	chunked run of N tasks (each new task rescans every prior task's folder), and RACY under
+	the gevent worker: 100 concurrent chunks all read the same ``max+1`` and then
+	``mkdir(exist_ok=True)`` the SAME folder, clobbering each other's ``report.json``.
+
+	Now: a ``.next_id`` counter file guarded by an exclusive ``flock``, seeded once from the
+	existing integer folders (back-compat with runs created before this change). O(1) per call
+	and safe across greenlets AND processes (prod prefork workers share the reports volume).
+
+	ponytail: flock briefly blocks the gevent hub, but the critical section is a few-byte
+	read/write (microseconds); move the counter to the broker/DB only if it ever shows in a profile.
+	"""
+	os.makedirs(path, exist_ok=True)
+	counter = os.path.join(path, '.next_id')
+	fd = os.open(counter, os.O_RDWR | os.O_CREAT, 0o644)
+	try:
+		fcntl.flock(fd, fcntl.LOCK_EX)
+		raw = os.read(fd, 32).decode().strip()
+		if raw.isdigit():
+			nxt = int(raw)
+		else:
+			# One-time seed from existing integer-named folders (folders predating .next_id).
+			existing = [int(f.name) for f in os.scandir(path) if f.is_dir() and f.name.isdigit()]
+			nxt = (max(existing) + 1) if existing else 0
+		os.lseek(fd, 0, os.SEEK_SET)
+		os.ftruncate(fd, 0)
+		os.write(fd, str(nxt + 1).encode())
+		return nxt
+	finally:
+		fcntl.flock(fd, fcntl.LOCK_UN)
+		os.close(fd)

--- a/tests/unit/test_runners_helpers.py
+++ b/tests/unit/test_runners_helpers.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import unittest
 from unittest.mock import patch
 
@@ -382,40 +384,43 @@ class TestExtractorFunctions(unittest.TestCase):
         nginx_input = next(i for i in inputs if 'nginx' in i)
         self.assertEqual(nginx_input, '10.0.0.3:80~nginx 1.21.0')
 
-    @patch('os.scandir')
-    @patch('os.path.exists')
-    def test_get_task_folder_id(self, mock_exists, mock_scandir):
-        """Test get_task_folder_id function."""
-        # Test with non-existent path
-        mock_exists.return_value = False
-        result = get_task_folder_id('/dummy/path')
-        self.assertEqual(result, 0)
+    def test_get_task_folder_id(self):
+        """Atomic, race-free, back-compatible folder-id allocation."""
+        import tempfile
+        import threading
 
-        # Test with empty directory
-        mock_exists.return_value = True
-        mock_scandir.return_value = []
-        result = get_task_folder_id('/dummy/path')
-        self.assertEqual(result, 0)
+        # Empty directory (or one that doesn't exist yet) -> starts at 0, then increments.
+        d = tempfile.mkdtemp()
+        os.rmdir(d)  # non-existent path: created on demand
+        self.assertEqual(get_task_folder_id(d), 0)
+        self.assertEqual(get_task_folder_id(d), 1)
+        shutil.rmtree(d, ignore_errors=True)
 
-        # Test with numeric directory names
-        class MockDirEntry:
-            def __init__(self, name, is_dir_val=True):
-                self.name = name
-                self._is_dir = is_dir_val
+        # Back-compat: seed from pre-existing integer-named folders (created before .next_id),
+        # ignoring non-numeric names and non-directories.
+        d = tempfile.mkdtemp()
+        for name in ('1', '3', '2', 'not_a_number'):
+            os.mkdir(os.path.join(d, name))
+        open(os.path.join(d, '5'), 'w').close()  # a file named '5' is not a dir -> ignored
+        self.assertEqual(get_task_folder_id(d), 4)  # max integer dir (3) + 1
+        shutil.rmtree(d, ignore_errors=True)
 
-            def is_dir(self):
-                return self._is_dir
+        # Race-free under concurrency: N threads must get N unique, dense ids (0..N-1).
+        d = tempfile.mkdtemp()
+        ids, lock = [], threading.Lock()
 
-        mock_exists.return_value = True
-        mock_scandir.return_value = [
-            MockDirEntry('1'),
-            MockDirEntry('3'),
-            MockDirEntry('2'),
-            MockDirEntry('not_a_number'),
-            MockDirEntry('5', is_dir_val=False)  # Not a directory
-        ]
-        result = get_task_folder_id('/dummy/path')
-        self.assertEqual(result, 4)  # Max numeric dir (3) + 1
+        def claim():
+            i = get_task_folder_id(d)
+            with lock:
+                ids.append(i)
+
+        threads = [threading.Thread(target=claim) for _ in range(100)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(sorted(ids), list(range(100)))  # unique + dense, no collisions
+        shutil.rmtree(d, ignore_errors=True)
 
 
 class TestLoadOutputTypes(unittest.TestCase):


### PR DESCRIPTION
## Problem

`get_task_folder_id()` (called once per runner via `reports_folder`) picks the next report-folder id by scanning the whole `tasks/` dir:

```python
for f in os.scandir(path):
    if f.is_dir(): names.append(int(f.name))  # (numeric only)
return max(names) + 1
```

Two issues, both surface under large chunked runs (e.g. a workflow with thousands of `input_chunk_size=1` tasks on the gevent worker):

1. **O(N²)** — each of N tasks rescans every prior task's folder. Measured `get_task_folder_id` cost: 0.07ms @100 folders → 0.94ms @2000 → ~5ms @8000.
2. **Race under gevent** — 100 concurrent chunks read the *same* `max+1` and then `mkdir(exist_ok=True)` the **same** folder, so they clobber each other's `report.json`. This is a correctness bug, not just perf.

Found while investigating a "workflow with 4096 chunk-size-1 tasks gets very slow / memory spikes" report. (It is one contributor among several — the dominant factor for the filesystem broker is a separate kombu `_get` O(N²); this fix addresses the folder-id scan + the clobber race specifically.)

## Fix

Replace the scan with a `.next_id` counter file guarded by an exclusive `flock`, seeded once from existing integer folders for back-compat:

- **O(1)** per call — flat 0.014ms @100/2000/8000 folders.
- **Race-free** across greenlets *and* processes (prod prefork workers share the reports volume) — 100 concurrent claims yield 100 unique, dense ids.
- Dense integer folder names preserved; folders predating this change are seeded from once.

## Tests

`test_get_task_folder_id` rewritten (real temp dirs instead of mocked `os` internals) to cover: increment from empty, back-compat seed from existing numeric folders (ignoring non-numeric / non-dir entries), and 100-thread concurrent uniqueness. Full `test_runners_helpers.py`, `test_json_driver.py`, `test_report.py` green (43 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Task folder IDs are now assigned safely during concurrent operations, preventing duplicate IDs.
  - Existing task folders continue to be recognized when determining the next available ID.
  - ID allocation now works reliably when the target folder does not yet exist.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->