### PR TITLE
fix+perf(query): --uniq/--count/--group render correctly and stream (memory-bounded)

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1475,16 +1475,8 @@ def _apply_format(results, fmt):
 					if val is not None:
 						formatted.append(str(val))
 			else:
-				_otype_map = {cls.get_name(): cls for cls in FINDING_TYPES}
-				otype_cls = _otype_map.get(_type)
-				for item in items:
-					if isinstance(item, dict) and otype_cls:
-						try:
-							formatted.append(str(otype_cls.load(item)))
-						except Exception:
-							formatted.append(json.dumps(item))
-					else:
-						formatted.append(str(item))
+				# No matching field — render each finding via its OutputType (primary-field repr).
+				formatted = [_render_finding(item, _type) for item in items]
 			new_results[_type] = formatted
 
 	return new_results
@@ -1522,25 +1514,49 @@ def _sort_results_by_field(results, sort):
 		results[_type] = [it for _, it in keyed]
 
 
+def _render_finding(item, _type):
+	"""Render a finding to its display string — the OutputType's __str__ (what the console shows),
+	falling back to JSON. Used when aggregating WITHOUT --format so raw finding dicts aren't shown
+	as Python-dict / JSON reprs. Already-formatted strings pass through unchanged."""
+	if not isinstance(item, dict):
+		return str(item)
+	otype_cls = {cls.get_name(): cls for cls in FINDING_TYPES}.get(_type)
+	if otype_cls:
+		try:
+			return str(otype_cls.load(item))
+		except Exception:
+			return json.dumps(item)
+	return json.dumps(item)
+
+
 def _aggregate_values(results, count=False, uniq=False, sort_given=False):
-	"""Post-format aggregation of --format output values, per type (backend-agnostic: runs on the
-	already-fetched, formatted rows). `uniq` drops duplicate values (first-seen order). `count`
-	groups identical values into ``"<count>  <value>"`` rows — ordered most-frequent-first by
-	default (classic top-N), or, when --sort was given, kept in the sorted (value) order the
-	findings arrived in."""
+	"""Post-fetch aggregation of results, per type (backend-agnostic). `uniq` drops duplicate rows
+	(first-seen order); `count` groups identical rows into ``"<count>  <value>"`` — most-frequent
+	first by default, or in the sorted order the findings arrived in when --sort was given.
+
+	Rows may be already-formatted strings (from --format) or raw finding dicts (no --format). For
+	`uniq` the ORIGINAL item is kept (so raw findings still render richly via their OutputType, not
+	as str(dict) JSON lines); the dedup key is the finding's display string."""
 	out = {}
 	for _type, values in results.items():
-		svals = [str(v) for v in values]
-		if count:
+		if uniq and not count:
+			seen = set()
+			kept = []
+			for v in values:
+				key = v if isinstance(v, str) else _render_finding(v, _type)
+				if key not in seen:
+					seen.add(key)
+					kept.append(v)   # keep original -> dicts render richly, strings stay strings
+			out[_type] = kept
+		elif count:
+			svals = [v if isinstance(v, str) else _render_finding(v, _type) for v in values]
 			items = list(Counter(svals).items())  # (value, count), first-seen insertion order
 			if not sort_given:
 				items.sort(key=lambda kv: kv[1], reverse=True)  # top-N: most frequent first
 			width = max((len(str(c)) for _, c in items), default=1)
 			out[_type] = [f'{str(c).rjust(width)}  {v}' for v, c in items]
-		elif uniq:
-			out[_type] = list(dict.fromkeys(svals))
 		else:
-			out[_type] = svals
+			out[_type] = list(values)
 	return out
 
 

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -1560,6 +1560,87 @@ def _aggregate_values(results, count=False, uniq=False, sort_given=False):
 	return out
 
 
+def _num_key(s):
+	"""Numeric-aware sort key for a rendered value string: numbers sort numerically (so '80' <
+	'443'), non-numbers fall back to string order."""
+	try:
+		return (0, float(s))
+	except (TypeError, ValueError):
+		return (1, str(s))
+
+
+def _aggregate_streamed(sv, _type, cls, fmt=None, sort=None, count=False, uniq=False, group=False, limit=0):
+	"""Aggregate a type's StreamView with peak memory bounded by the RESULT size, not the number of
+	findings — safe for 100k+.
+
+	- --group: group_findings() consumes the cursor in a single streaming pass (memory ~ #groups),
+	  then the small rep set is finished with the normal helpers.
+	- --count / --uniq: collapse the stream incrementally (Counter / seen-set), batching through
+	  _apply_format only for the --format path; memory ~ #distinct values / #unique rows.
+	- --sort alone: a correct global sort needs the whole set, so it materializes (inherent; combine
+	  with --count/--group to stay bounded, or push down in a future pass).
+	"""
+	from secator.query.utils import group_findings
+
+	def _finish(items):
+		res = {_type: items}
+		if sort:
+			_sort_results_by_field(res, sort)
+		if fmt:
+			res = _apply_format(res, fmt)
+		if count or uniq:
+			res = _aggregate_values(res, count=count, uniq=uniq, sort_given=bool(sort))
+		rows = res[_type]
+		return rows[:limit] if limit else rows
+
+	if group and cls is not None and getattr(cls, '_group_by', None):
+		reps = group_findings(sv, list(cls._group_by), getattr(cls, '_group_aggregate', None))
+		return _finish(reps)
+
+	if count or uniq:
+		counter, seen, kept, batch = Counter(), set(), [], []
+
+		def _flush():
+			if not batch:
+				return
+			if fmt:
+				for v in _apply_format({_type: list(batch)}, fmt).get(_type, []):
+					if count:
+						counter[v] += 1
+					elif v not in seen:
+						seen.add(v)
+						kept.append(v)
+			else:
+				for it in batch:
+					v = _render_finding(it, _type)
+					if count:
+						counter[v] += 1
+					elif v not in seen:
+						seen.add(v)
+						kept.append(it)   # keep the finding -> renders richly, not str(dict)
+			batch.clear()
+
+		for item in sv:
+			batch.append(item)
+			if len(batch) >= 2000:
+				_flush()
+		_flush()
+
+		if uniq:
+			return kept[:limit] if limit else kept
+		items = list(counter.items())
+		if sort:
+			items.sort(key=lambda kv: _num_key(kv[0]), reverse=sort.strip().startswith('-'))
+		else:
+			items.sort(key=lambda kv: kv[1], reverse=True)   # most-frequent-first
+		width = max((len(str(c)) for _, c in items), default=1)
+		rows = [f'{str(c).rjust(width)}  {v}' for v, c in items]
+		return rows[:limit] if limit else rows
+
+	# --sort alone: full ordering needs the whole set.
+	return _finish(list(sv))
+
+
 def run_report_show(report_query, output, time_delta, query, fmt, workspace, driver, dedupe, limit, output_folder=None, sort=None, count=False, uniq=False, group=None):  # noqa: E501
 	"""Build and send a consolidated report. Shared by `report show` and `query`.
 
@@ -1672,41 +1753,27 @@ def run_report_show(report_query, output, time_delta, query, fmt, workspace, dri
 	# 6. Build and send report via QueryEngine
 	dedupe_effective = CONFIG.runners.remove_duplicates if dedupe is None else dedupe
 	report = Report(runner, title=f'Consolidated report - {current}', exporters=exporters)
-	# Fetch the FULL set when reshaping/capping the output — --group / --sort / --uniq / --count
-	# operate post-query, so limiting the backend fetch first would group/sort/dedupe/count only a
-	# partial slice. --limit is then applied to the finished output below.
-	aggregating = bool(sort or count or uniq or group is not None)
-	report.build(query=full_query, dedupe=dedupe_effective, limit=(0 if aggregating else limit))
-
-	# 1. Group findings by each type's DEFAULT field(s) with auto-aggregation (processing-side,
-	# post-query). --group is a flag: types with no `_group_by` default are left ungrouped.
+	# --group / --sort / --uniq / --count reshape or cap the output post-query. STREAM the findings
+	# (stream=True yields per-type StreamViews — nothing materialized) and aggregate incrementally,
+	# so peak memory is bounded by the RESULT size, not the finding count (safe for 100k+). --limit
+	# applies to the finished output, inside _aggregate_streamed.
+	aggregating = bool(sort or count or uniq or group)
 	grouped_types = []
-	if group:
-		from secator.query.utils import group_findings
+	if aggregating:
+		report.build(query=full_query, dedupe=dedupe_effective, limit=0, stream=True)
 		type_map = {cls.get_name(): cls for cls in FINDING_TYPES}
-		for type_name, items in report.data['results'].items():
+		for type_name, sv in list(report.data['results'].items()):
 			cls = type_map.get(type_name)
-			if not items or cls is None:
-				continue
-			group_by = list(getattr(cls, '_group_by', ()) or ())
-			if not group_by:
-				continue
-			aggregate_field = getattr(cls, '_group_aggregate', None)
-			report.data['results'][type_name] = group_findings(items, group_by, aggregate_field)
-			grouped_types.append((type_name, ', '.join(group_by)))
-		if not grouped_types:
+			report.data['results'][type_name] = _aggregate_streamed(
+				sv, type_name, cls, fmt=fmt, sort=sort, count=count, uniq=uniq, group=group, limit=limit)
+			if group and cls is not None and getattr(cls, '_group_by', None) and report.data['results'][type_name]:
+				grouped_types.append((type_name, ', '.join(cls._group_by)))
+		if group and not grouped_types:
 			console.print(Warning(message='--group: no groupable finding types in results'))
-
-	# 2. Sort findings by a field, AFTER grouping — so `--sort -_group_count` orders the groups
-	# (top-N most/least frequent), which is the ordering --group lacks on its own.
-	if sort:
-		_sort_results_by_field(report.data['results'], sort)
-	if fmt:
-		report.data['results'] = _apply_format(report.data['results'], fmt)
-	if count or uniq:
-		report.data['results'] = _aggregate_values(report.data['results'], count=count, uniq=uniq, sort_given=bool(sort))
-	if aggregating and limit:
-		report.data['results'] = {t: items[:limit] for t, items in report.data['results'].items()}
+	else:
+		report.build(query=full_query, dedupe=dedupe_effective, limit=limit)
+		if fmt:
+			report.data['results'] = _apply_format(report.data['results'], fmt)
 	report.send()
 	total_results = sum(len(items) for items in report.data['results'].values())
 	emit_query_warnings(query_warnings)

--- a/tests/unit/test_query_aggregate.py
+++ b/tests/unit/test_query_aggregate.py
@@ -61,6 +61,29 @@ class TestAggregateValues(unittest.TestCase):
 		out = _aggregate_values(results, uniq=True)
 		self.assertEqual(out['port'], ['443', '80', '22'])
 
+	def test_uniq_without_format_keeps_dicts_for_rich_render(self):
+		# Raw finding dicts (no --format): --uniq keeps the DICTS (so they render richly, not as
+		# str(dict)/JSON), deduped by their OutputType display string.
+		results = {'vulnerability': [
+			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'},
+			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'},  # dup
+			{'_type': 'vulnerability', 'name': 'SQLi', 'severity': 'critical', 'matched_at': 'b'},
+		]}
+		out = _aggregate_values(results, uniq=True)
+		self.assertEqual(len(out['vulnerability']), 2)                       # deduped
+		self.assertTrue(all(isinstance(x, dict) for x in out['vulnerability']))  # still dicts -> rich
+
+	def test_count_without_format_renders_via_outputtype(self):
+		# --count without --format tallies the OutputType display string, not str(dict).
+		results = {'vulnerability': [
+			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'},
+			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'},
+		]}
+		out = _aggregate_values(results, count=True)
+		self.assertEqual(len(out['vulnerability']), 1)
+		self.assertTrue(out['vulnerability'][0].startswith('2  '))           # "2  <rendered>"
+		self.assertNotIn("{'_type'", out['vulnerability'][0])                # not a raw dict repr
+
 	def test_cli_options_registered_on_both_commands(self):
 		from secator.cli import query, report_show
 		for cmd in (query, report_show):

--- a/tests/unit/test_query_aggregate.py
+++ b/tests/unit/test_query_aggregate.py
@@ -74,15 +74,12 @@ class TestAggregateValues(unittest.TestCase):
 		self.assertTrue(all(isinstance(x, dict) for x in out['vulnerability']))  # still dicts -> rich
 
 	def test_count_without_format_renders_via_outputtype(self):
-		# --count without --format tallies the OutputType display string, not str(dict).
-		results = {'vulnerability': [
-			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'},
-			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'},
-		]}
-		out = _aggregate_values(results, count=True)
-		self.assertEqual(len(out['vulnerability']), 1)
-		self.assertTrue(out['vulnerability'][0].startswith('2  '))           # "2  <rendered>"
-		self.assertNotIn("{'_type'", out['vulnerability'][0])                # not a raw dict repr
+		# --count without --format tallies the exact OutputType display string, not str(dict).
+		from secator.output_types import Vulnerability
+		v = {'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'}
+		out = _aggregate_values({'vulnerability': [dict(v), dict(v)]}, count=True)
+		expected = f'2  {str(Vulnerability.load(dict(v)))}'   # asserting the exact render catches a
+		self.assertEqual(out['vulnerability'], [expected])    # lookup/load failure (JSON fallback)
 
 	def test_cli_options_registered_on_both_commands(self):
 		from secator.cli import query, report_show

--- a/tests/unit/test_query_aggregate.py
+++ b/tests/unit/test_query_aggregate.py
@@ -117,5 +117,49 @@ class TestGroupSortComposition(unittest.TestCase):
 		self.assertEqual(results['vulnerability'][0].name, 'A')  # --limit 1 -> top group
 
 
+class TestStreamingAggregation(unittest.TestCase):
+	"""_aggregate_streamed consumes a ONE-SHOT iterator (like a StreamView cursor) and keeps peak
+	memory bounded by the result size, not the finding count."""
+
+	def _stream(self, items):
+		for it in items:      # a generator: proves we never require list()/len()/indexing
+			yield it
+
+	def test_count_streams(self):
+		from secator.cli import _aggregate_streamed
+		s = self._stream([{'_type': 'port', 'port': 443}, {'_type': 'port', 'port': 443}, {'_type': 'port', 'port': 80}])
+		self.assertEqual(_aggregate_streamed(s, 'port', None, fmt='port', count=True, limit=15), ['2  443', '1  80'])
+
+	def test_uniq_streams_and_keeps_dicts(self):
+		from secator.cli import _aggregate_streamed
+		items = [
+			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'},
+			{'_type': 'vulnerability', 'name': 'XSS', 'severity': 'high', 'matched_at': 'a'},
+			{'_type': 'vulnerability', 'name': 'SQLi', 'severity': 'critical', 'matched_at': 'b'},
+		]
+		rows = _aggregate_streamed(self._stream(items), 'vulnerability', None, uniq=True)
+		self.assertEqual(len(rows), 2)
+		self.assertTrue(all(isinstance(x, dict) for x in rows))   # kept as findings -> rich render
+
+	def test_group_streams(self):
+		from secator.cli import _aggregate_streamed
+		from secator.output_types import Vulnerability
+		items = [
+			{'_type': 'vulnerability', 'name': 'XSS', 'matched_at': 'a', 'severity': 'high'},
+			{'_type': 'vulnerability', 'name': 'XSS', 'matched_at': 'b', 'severity': 'high'},
+		]
+		rows = _aggregate_streamed(self._stream(items), 'vulnerability', Vulnerability, group=True)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(getattr(rows[0], '_group_count', None), 2)
+
+	def test_count_is_bounded_over_a_huge_stream(self):
+		# 200k findings but only 3 distinct ports -> result stays 3 rows (memory ~ #distinct).
+		from secator.cli import _aggregate_streamed
+		big = ({'_type': 'port', 'port': (443, 80, 22)[i % 3]} for i in range(200000))
+		rows = _aggregate_streamed(big, 'port', None, fmt='port', count=True)
+		self.assertEqual(len(rows), 3)
+		self.assertTrue(rows[0].endswith('443') or rows[0].endswith('80') or rows[0].endswith('22'))
+
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Two related changes to the query aggregation path.

## 1. Correct rendering (the reported bug)
`secator q "name ~= 'FTP Service'" --uniq` returned JSON/dict-repr lines instead of the rich findings deduplicated, because raw finding dicts were stringified with `str()`. Now:
- **`--uniq`** keeps the original findings (deduped by their OutputType display string) → rendered richly, just deduplicated.
- **`--count`** without `--format` tallies the OutputType display string, not `str(dict)`.

## 2. Streaming aggregation (memory efficiency for 100k+)
Aggregation used `report.build(stream=False, limit=0)` → `engine.search` **materialized every finding** into one list before grouping/counting — O(findings) memory.

Now it uses `report.build(stream=True)` (per-type `StreamView`s — batched cursor, nothing materialized) + `_aggregate_streamed`, which collapses the stream incrementally so peak memory is bounded by the **result size**:
| flag | strategy | memory |
|---|---|---|
| `--group` | `group_findings()` consumes the cursor in one pass | ~ #groups |
| `--count` | incremental `Counter`, `--format` applied per 2k batch | ~ #distinct values |
| `--uniq` | incremental seen-set, keeps the finding for rich render | ~ #unique rows |
| `--sort` alone | materializes (a correct global sort needs the whole set) | O(findings) — combine with `--count`/`--group` to bound; push-down is a future pass |

Non-aggregating queries keep the existing display (materialized) path.

## Verified
- Unit: a **200k-finding / 3-distinct-port** stream → **3 rows** (bounded); streaming count/uniq/group consume a one-shot generator; `--uniq` keeps dicts.
- E2E (local backend): `--count` → `3 443 / 1 80 / 1 22`; `--uniq` → rich deduped `🚨 [XSS] [high] / 🚨 [SQLi] [critical]`; `--group` → `(count: 2)` etc.; `--sort port --count` → numeric `1 22 / 1 80 / 3 443`.