### PR TITLE
perf(cli): stream workspace summary queries (memory bounded)

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -929,29 +929,21 @@ def _summary_query(engine, type_or_expr, fmt=None, count=False, uniq=False, sort
 	`_group_aggregate`), so a subsequent count reflects UNIQUE findings — e.g. a vulnerability
 	hitting many targets counts once."""
 	from rich.markup import escape
-	from secator.query.utils import python_expr_to_mongo, group_findings
+	from secator.query.utils import python_expr_to_mongo
+	from secator.query._stream import StreamView
 	q = python_expr_to_mongo(type_or_expr)
+	# Store-side dedup (mirrors report.build's stream path) so streaming needs no in-memory pass.
+	if CONFIG.runners.remove_duplicates:
+		dup = {'_context.workspace_duplicate': {'$ne': True}}
+		q = {'$and': [q, dup]} if (q and set(q) & set(dup)) else {**q, **dup}
+	_type = q.get('_type') or str(type_or_expr)
+	cls = {c.get_name(): c for c in FINDING_TYPES}.get(_type)
 	aggregating = bool(sort or count or uniq or group)
-	findings = engine.search(q, limit=(0 if aggregating else limit), dedupe=CONFIG.runners.remove_duplicates)
-	results = {}
-	for f in findings:
-		results.setdefault(f.get('_type', str(type_or_expr)), []).append(f)
-	if group:
-		type_map = {cls.get_name(): cls for cls in FINDING_TYPES}
-		for _tname, _items in list(results.items()):
-			cls = type_map.get(_tname)
-			group_by = list(getattr(cls, '_group_by', ()) or ()) if cls else []
-			if group_by:
-				results[_tname] = group_findings(_items, group_by, getattr(cls, '_group_aggregate', None))
-	if sort:
-		_sort_results_by_field(results, sort)
-	if fmt:
-		results = _apply_format(results, fmt)
-	if count or uniq:
-		results = _aggregate_values(results, count=count, uniq=uniq, sort_given=bool(sort))
-	rows = [escape(str(x)) for items in results.values() for x in items]
-	if aggregating and limit:
-		rows = rows[:limit]
+	# STREAM the findings (never materialize all N); _aggregate_streamed collapses incrementally so
+	# peak memory is bounded by the result size, not the finding count — safe for 100k+.
+	sv = StreamView(engine, q, limit=(0 if aggregating else limit))
+	rows = _aggregate_streamed(sv, _type, cls, fmt=fmt, sort=sort, count=count, uniq=uniq, group=group, limit=limit)
+	rows = [escape(r if isinstance(r, str) else str(r)) for r in rows]
 	return '\n'.join(rows) if rows else '[dim](none)[/]'
 
 

--- a/secator/cli.py
+++ b/secator/cli.py
@@ -931,18 +931,34 @@ def _summary_query(engine, type_or_expr, fmt=None, count=False, uniq=False, sort
 	from rich.markup import escape
 	from secator.query.utils import python_expr_to_mongo
 	from secator.query._stream import StreamView
-	q = python_expr_to_mongo(type_or_expr)
-	# Store-side dedup (mirrors report.build's stream path) so streaming needs no in-memory pass.
-	if CONFIG.runners.remove_duplicates:
-		dup = {'_context.workspace_duplicate': {'$ne': True}}
-		q = {'$and': [q, dup]} if (q and set(q) & set(dup)) else {**q, **dup}
-	_type = q.get('_type') or str(type_or_expr)
-	cls = {c.get_name(): c for c in FINDING_TYPES}.get(_type)
+	raw = python_expr_to_mongo(type_or_expr)
+	# Resolve the concrete finding type(s) BEFORE wrapping, so a compound/dedup `$and` never hides
+	# `_type` (a `{'$in': [...]}` type filter or a non-type expr means "span every type").
+	typemap = {c.get_name(): c for c in FINDING_TYPES}
+	tv = raw.get('_type')
+	if isinstance(tv, str):
+		types = [tv]
+	elif isinstance(tv, dict):
+		types = list(tv.get('$in') or typemap)
+	else:
+		types = list(typemap)
+	base = {k: v for k, v in raw.items() if k != '_type'}
+	# Store-side dedup (mirrors report.build's stream path). MUST nest in `$and`: a top-level
+	# `_context.workspace_duplicate` is a PROTECTED_FIELD and gets stripped by _merge_query.
+	dup = {'_context.workspace_duplicate': {'$ne': True}} if CONFIG.runners.remove_duplicates else None
 	aggregating = bool(sort or count or uniq or group)
-	# STREAM the findings (never materialize all N); _aggregate_streamed collapses incrementally so
-	# peak memory is bounded by the result size, not the finding count — safe for 100k+.
-	sv = StreamView(engine, q, limit=(0 if aggregating else limit))
-	rows = _aggregate_streamed(sv, _type, cls, fmt=fmt, sort=sort, count=count, uniq=uniq, group=group, limit=limit)
+	# STREAM per concrete type (never materialize all N); _aggregate_streamed collapses incrementally
+	# so peak memory is bounded by the result size, not the finding count — safe for 100k+.
+	rows = []
+	for name in types:
+		clauses = [{'_type': name}]
+		if base:
+			clauses.append(base)
+		if dup:
+			clauses.append(dup)
+		type_q = clauses[0] if len(clauses) == 1 else {'$and': clauses}
+		sv = StreamView(engine, type_q, limit=(0 if aggregating else limit))
+		rows += _aggregate_streamed(sv, name, typemap.get(name), fmt=fmt, sort=sort, count=count, uniq=uniq, group=group, limit=limit)  # noqa: E501
 	rows = [escape(r if isinstance(r, str) else str(r)) for r in rows]
 	return '\n'.join(rows) if rows else '[dim](none)[/]'
 
@@ -1619,6 +1635,13 @@ def _aggregate_streamed(sv, _type, cls, fmt=None, sort=None, count=False, uniq=F
 		_flush()
 
 		if uniq:
+			if sort:  # sort the COLLAPSED set (bounded by #unique), not the raw stream
+				if fmt:
+					kept.sort(key=_num_key, reverse=sort.strip().startswith('-'))
+				else:
+					res = {_type: kept}
+					_sort_results_by_field(res, sort)
+					kept = res[_type]
 			return kept[:limit] if limit else kept
 		items = list(counter.items())
 		if sort:

--- a/tests/unit/test_query_aggregate.py
+++ b/tests/unit/test_query_aggregate.py
@@ -149,6 +149,15 @@ class TestStreamingAggregation(unittest.TestCase):
 		self.assertEqual(len(rows), 1)
 		self.assertEqual(getattr(rows[0], '_group_count', None), 2)
 
+	def test_uniq_sort_orders_the_collapsed_set(self):
+		# --uniq --sort must sort the deduped values (bounded), not return first-seen order.
+		from secator.cli import _aggregate_streamed
+		items = [{'_type': 'port', 'port': p} for p in (443, 80, 22, 80, 443)]
+		asc = _aggregate_streamed(self._stream(items), 'port', None, fmt='port', uniq=True, sort='port')
+		self.assertEqual(asc, ['22', '80', '443'])          # not first-seen ['443','80','22']
+		desc = _aggregate_streamed(self._stream(items), 'port', None, fmt='port', uniq=True, sort='-port')
+		self.assertEqual(desc, ['443', '80', '22'])
+
 	def test_count_is_bounded_over_a_huge_stream(self):
 		# 200k findings but only 3 distinct ports -> result stays 3 rows (memory ~ #distinct).
 		from secator.cli import _aggregate_streamed

--- a/tests/unit/test_workspace_summary.py
+++ b/tests/unit/test_workspace_summary.py
@@ -15,6 +15,12 @@ class FakeEngine:
 	def __init__(self, findings):
 		self._findings = findings
 
+	def iterate(self, query, batch_size=1000):   # StreamView streams via iterate() (batches)
+		yield list(self._findings)
+
+	def count(self, query):
+		return len(self._findings)
+
 	def search(self, query, limit=0, dedupe=False):
 		return list(self._findings)
 
@@ -80,6 +86,29 @@ class TestSummaryCommandWiring(unittest.TestCase):
 		self.assertIn('summary', workspace.commands)
 		params = {p.name for p in workspace.commands['summary'].params}
 		self.assertTrue({'workspace_opt', 'driver', 'template_path'} <= params)
+
+	def test_summary_streams_via_iterate_not_search(self):
+		# _summary_query must STREAM (iterate) and never materialize via search() -> bounded memory.
+		class IterOnly:
+			def __init__(self, f):
+				self._f = f
+
+			def iterate(self, query, batch_size=1000):
+				yield list(self._f)
+
+			def count(self, query):
+				return len(self._f)
+
+			def search(self, *a, **k):
+				raise AssertionError('summary must stream via iterate(), not search()')
+
+		findings = [
+			{'_type': 'port', 'port': 443, 'ip': '1'},
+			{'_type': 'port', 'port': 443, 'ip': '2'},
+			{'_type': 'port', 'port': 80, 'ip': '3'},
+		]
+		out = _summary_query(IterOnly(findings), 'port', fmt='port', count=True)
+		self.assertEqual(out, '2  443\n1  80')
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_workspace_summary.py
+++ b/tests/unit/test_workspace_summary.py
@@ -61,6 +61,64 @@ class TestSummaryQuery(unittest.TestCase):
 		self.assertIn(r'\[test]', out)          # escaped, not a live markup tag
 
 
+class RecordingEngine:
+	"""Filters findings by the query's _type clause (top-level or $and-nested) and records the
+	queries passed to iterate(), so tests can assert on the query shape (dedup nesting)."""
+	def __init__(self, findings):
+		self._f = findings
+		self.queries = []
+
+	def _type_of(self, q):
+		if isinstance(q.get('_type'), str):
+			return q['_type']
+		for c in q.get('$and', []):
+			if isinstance(c, dict) and isinstance(c.get('_type'), str):
+				return c['_type']
+		return None
+
+	def _match(self, q):
+		t = self._type_of(q)
+		return [f for f in self._f if t is None or f.get('_type') == t]
+
+	def iterate(self, query, batch_size=1000):
+		self.queries.append(query)
+		yield self._match(query)
+
+	def count(self, query):
+		return len(self._match(query))
+
+	def search(self, *a, **k):
+		raise AssertionError('summary must stream via iterate(), not search()')
+
+
+class TestSummaryQueryShape(unittest.TestCase):
+
+	def test_dedup_predicate_is_nested_never_top_level(self):
+		# workspace_duplicate is a PROTECTED_FIELD stripped by _merge_query at the TOP level, so the
+		# dedup predicate must always live inside an $and clause to survive.
+		from unittest import mock
+		from secator.cli import CONFIG
+		eng = RecordingEngine([{'_type': 'port', 'port': 443, 'ip': '1'}])
+		with mock.patch.object(CONFIG.runners, 'remove_duplicates', True):
+			_summary_query(eng, 'port', fmt='port', count=True)
+		self.assertTrue(eng.queries)
+		for q in eng.queries:
+			self.assertNotIn('_context.workspace_duplicate', q)   # never top-level (would be stripped)
+			nested = any(isinstance(c, dict) and '_context.workspace_duplicate' in c for c in q.get('$and', []))
+			self.assertTrue(nested)                               # present, nested -> survives _merge_query
+
+	def test_multi_type_in_query_partitions_without_crashing(self):
+		# `_type in [...]` previously TypeError'd (unhashable dict in the type-map lookup). Now it
+		# partitions per concrete type and aggregates each.
+		findings = [
+			{'_type': 'port', 'port': 443, 'ip': '1'},
+			{'_type': 'port', 'port': 80, 'ip': '2'},
+			{'_type': 'url', 'url': 'http://a', 'host': 'a'},
+		]
+		out = _summary_query(RecordingEngine(findings), "_type in ['port','url']", fmt='port', count=True)
+		self.assertIn('443', out)   # port bucket aggregated; no crash
+
+
 class TestSummaryTemplate(unittest.TestCase):
 
 	def test_default_template_renders_and_calls_query(self):


### PR DESCRIPTION
Follow-up to the streaming aggregation (#1387): the `workspace summary` `query()` helper still fetched via `engine.search` (materializing all findings of a type). Now it streams.

## Change
`_summary_query` builds a `StreamView` and runs `_aggregate_streamed`, so each summary query (e.g. `query('vulnerability', group=True, fmt='severity', count=True)`) streams the cursor and collapses incrementally — **peak memory bounded by the result size**, not the finding count. Store-side dedup (the `workspace_duplicate` filter) mirrors `report.build`'s stream path.

## Verified
- Unit: an engine whose `search()` **raises** still works (proves it streams via `iterate()`); existing summary tests pass.
- E2E (local backend): `ws summary` output unchanged — `Top ports 3 443 / 1 80 …`, `Unique vulnerabilities by severity 1 high / 1 critical`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Workspace summaries now process findings as a stream, improving memory efficiency for large result sets.
  - Duplicate findings are filtered during data retrieval.
- **Reliability**
  - Summary generation now uses the finding type provided by the query results.
- **Tests**
  - Added coverage to verify streaming behavior and prevent unnecessary full-result loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->