### PR TITLE
feat(query): backend-agnostic on-demand duplicate tagging for --dedupe

### DIFF
--- a/secator/cli.py
+++ b/secator/cli.py
@@ -946,6 +946,9 @@ def _summary_query(engine, type_or_expr, fmt=None, count=False, uniq=False, sort
 	# Store-side dedup (mirrors report.build's stream path). MUST nest in `$and`: a top-level
 	# `_context.workspace_duplicate` is a PROTECTED_FIELD and gets stripped by _merge_query.
 	dup = {'_context.workspace_duplicate': {'$ne': True}} if CONFIG.runners.remove_duplicates else None
+	if dup:  # nothing tags duplicates at scan time anymore — tag on demand (api excepted)
+		from secator.hooks._dedup import maybe_tag_duplicates
+		maybe_tag_duplicates(engine)
 	aggregating = bool(sort or count or uniq or group)
 	# STREAM per concrete type (never materialize all N); _aggregate_streamed collapses incrementally
 	# so peak memory is bounded by the result size, not the finding count — safe for 100k+.

--- a/secator/hooks/_dedup.py
+++ b/secator/hooks/_dedup.py
@@ -1,6 +1,45 @@
 # secator/hooks/_dedup.py
 
 
+def tag_duplicates(engine, ws_id, exclude_types=(), max_items=0, copy_fields=None):
+	"""Tag duplicate findings in a workspace via a QueryEngine — backend-agnostic.
+
+	Reads/writes through the backend's raw `_execute_search`/`_execute_update` (bypassing the
+	base-query PROTECTED_FIELDS strip, so `_context.workspace_duplicate` and `_tagged` are usable)
+	and keys every update on the uniform `_uuid` that every backend now surfaces.
+
+	Full evaluation (not incremental): the incremental `_tagged:{$in:[False,None]}` filter relies on
+	Mongo's null-matching, which SQL `IN`/`!=` don't share — so we re-evaluate the whole workspace,
+	capped by `max_items`. On-demand (CLI `--dedupe` / `workspace summary`), correctness over speed.
+	Returns the number of findings updated.
+	# ponytail: full scan each call; add per-backend incremental (NULL-safe untagged filter) only if
+	# dedupe becomes a hot path.
+	"""
+	from secator.output_types._base import load_output_types
+	b = engine.backend
+	ws = {'_context.workspace_id': str(ws_id)}
+	keep = lambda f: f._type not in exclude_types  # noqa: E731
+	mains = [f for f in load_output_types(
+		b._execute_search({**ws, '_context.workspace_duplicate': False, '_tagged': True}, limit=0)
+	) if keep(f)]
+	untagged = [f for f in load_output_types(
+		b._execute_search(dict(ws), limit=max_items or 0)
+	) if keep(f)]
+	updates = compute_duplicate_updates(mains, untagged, copy_fields)
+	for uuid_, upd in updates.items():
+		if uuid_:
+			b._execute_update({'_uuid': uuid_}, {'$set': upd})
+	return len(updates)
+
+
+def maybe_tag_duplicates(engine, ws_id=None, **kwargs):
+	"""Tag duplicates for on-demand dedup, unless the backend is `api` (the cloud server tags its
+	own store — client-side tagging would be chatty and race it). Returns the number updated."""
+	if engine.backend.name == 'api':
+		return 0
+	return tag_duplicates(engine, ws_id or engine.backend.workspace_id, **kwargs)
+
+
 def compute_duplicate_updates(workspace_findings, untagged_findings, copy_fields=None):
 	"""Compute duplicate-tagging updates for a set of findings (backend-agnostic).
 

--- a/secator/query/json.py
+++ b/secator/query/json.py
@@ -95,6 +95,19 @@ def get_nested_field(item, key: str) -> Any:
 	return value
 
 
+def _set_nested(item: dict, key: str, value) -> None:
+	"""Set a dot-notation field (e.g. '_context.workspace_duplicate'), creating intermediate dicts,
+	so `get_nested_field` reads it back. A bare key is a plain assignment."""
+	keys = key.split('.')
+	for k in keys[:-1]:
+		nxt = item.get(k)
+		if not isinstance(nxt, dict):
+			nxt = {}
+			item[k] = nxt
+		item = nxt
+	item[keys[-1]] = value
+
+
 def match_query(item: dict, query: dict) -> bool:
 	"""Check if item matches MongoDB-style query."""
 	if '$and' in query:
@@ -318,7 +331,8 @@ class JsonBackend(QueryBackend):
 					if isinstance(bucket, list):
 						for item in bucket:
 							if match_query(item, query):
-								item.update(set_fields)
+								for k, v in set_fields.items():
+									_set_nested(item, k, v)   # dotted key -> nested, so get_nested_field reads it back
 								count += 1
 		return count
 

--- a/secator/query/mongodb.py
+++ b/secator/query/mongodb.py
@@ -9,6 +9,15 @@ from secator.rich import console
 RUNNER_COLLECTIONS = ('tasks', 'workflows', 'scans')
 
 
+def _carry_uuid(doc):
+	"""Drop the native `_id` but surface it as `_uuid` — the backend-agnostic finding id every
+	backend returns, so callers (dedup, updates) can key on one field across mongodb/sqlite/json."""
+	_id = doc.pop('_id', None)
+	if _id is not None and not doc.get('_uuid'):
+		doc['_uuid'] = str(_id)
+	return doc
+
+
 class MongoDBBackend(QueryBackend):
 	"""Query backend for MongoDB."""
 
@@ -46,7 +55,7 @@ class MongoDBBackend(QueryBackend):
 
 			results = []
 			for doc in cursor:
-				doc.pop('_id', None)
+				_carry_uuid(doc)
 				results.append(doc)
 
 			return results
@@ -61,7 +70,7 @@ class MongoDBBackend(QueryBackend):
 			db = client.main
 			batch = []
 			for doc in db.findings.find(query).batch_size(batch_size):
-				doc.pop('_id', None)
+				_carry_uuid(doc)
 				batch.append(doc)
 				if len(batch) >= batch_size:
 					yield batch
@@ -83,8 +92,15 @@ class MongoDBBackend(QueryBackend):
 			return 0
 
 	def _execute_update(self, query: dict, update: dict) -> int:
-		"""Update documents matching query in MongoDB."""
+		"""Update documents matching query in MongoDB. A `_uuid` predicate is translated to the native
+		`_id` — findings are keyed on ObjectId; `_uuid` is the backend-agnostic id surfaced by
+		search/iterate (see `_carry_uuid`)."""
+		from bson import ObjectId
 		client = self._get_client()
+		uid = query.get('_uuid')
+		if uid is not None and ObjectId.is_valid(uid):
+			query = {k: v for k, v in query.items() if k != '_uuid'}
+			query['_id'] = ObjectId(uid)
 		result = client.main.findings.update_one(query, update)
 		return result.modified_count
 

--- a/secator/report.py
+++ b/secator/report.py
@@ -111,8 +111,15 @@ class Report:
 			# iterates its type's cursor, so peak stays flat through report generation. Dedup is
 			# store-side (tag_duplicates flags duplicates), excluded by query.
 			if dedupe:
+				# The stream can't dedup in memory (that's the materialized path's `remove_duplicates`),
+				# so it filters on the stored `_context.workspace_duplicate` flag — which nothing marks
+				# at scan time anymore, so tag on demand first (api excepted; its server tags itself).
+				from secator.hooks._dedup import maybe_tag_duplicates
+				maybe_tag_duplicates(engine, workspace_id)
+				# MUST nest in `$and`: a top-level `_context.workspace_duplicate` is a PROTECTED_FIELD
+				# stripped by _merge_query, so a bare merge would silently drop the dedup filter.
 				dup = {'_context.workspace_duplicate': {'$ne': True}}
-				query = {'$and': [query, dup]} if (query and set(query) & set(dup)) else {**query, **dup}
+				query = {'$and': [query, dup]}
 			for output_type in list(FINDING_TYPES) + [Target]:
 				name = output_type.get_name()
 				type_q = {'$and': [query, {'_type': name}]} if '_type' in query else {**query, '_type': name}

--- a/tests/unit/test_dedup_backend_agnostic.py
+++ b/tests/unit/test_dedup_backend_agnostic.py
@@ -1,0 +1,87 @@
+"""Backend-agnostic on-demand duplicate tagging (`_dedup.tag_duplicates(engine, ws_id)`).
+
+The generic core reads via `backend._execute_search` and writes each update keyed on the uniform
+`_uuid` via `backend._execute_update` — so a fake backend (dicts + the json matcher/setter, the same
+primitives every real backend implements) proves the behavior for all of them.
+"""
+import unittest
+
+from secator.query.json import match_query, _set_nested, get_nested_field
+from secator.query.mongodb import _carry_uuid
+from secator.hooks._dedup import tag_duplicates, maybe_tag_duplicates
+
+
+class FakeBackend:
+	name = 'fake'
+
+	def __init__(self, findings, ws='ws1'):
+		self.docs = findings
+		self.workspace_id = ws
+
+	def _execute_search(self, query, limit=0):
+		out = [d for d in self.docs if match_query(d, query)]
+		return out[:limit] if limit else out
+
+	def _execute_update(self, query, update):
+		n = 0
+		for d in self.docs:
+			if match_query(d, query):
+				for k, v in update.get('$set', {}).items():
+					_set_nested(d, k, v)
+				n += 1
+		return n
+
+
+class FakeEngine:
+	def __init__(self, backend):
+		self.backend = backend
+
+
+def _vuln(name, matched_at, uuid):
+	return {
+		'_type': 'vulnerability', 'name': name, 'matched_at': matched_at, 'severity': 'high',
+		'_uuid': uuid, '_context': {'workspace_id': 'ws1'},
+	}
+
+
+class TestGenericTagDuplicates(unittest.TestCase):
+
+	def test_marks_exactly_one_of_a_duplicate_pair(self):
+		# Two identical XSS (same name+matched_at, different uuid) + one distinct SQLi, none tagged.
+		findings = [_vuln('XSS', 'a', 'u1'), _vuln('XSS', 'a', 'u2'), _vuln('SQLi', 'b', 'u3')]
+		n = tag_duplicates(FakeEngine(FakeBackend(findings)), 'ws1')
+		self.assertEqual(n, 3)                                   # all three get a tagging update
+		dup = [d for d in findings if get_nested_field(d, '_context.workspace_duplicate') is True]
+		self.assertEqual(len(dup), 1)                            # exactly one XSS flagged duplicate
+		kept = [d for d in findings if get_nested_field(d, '_context.workspace_duplicate') is not True]
+		self.assertEqual({d['name'] for d in kept}, {'XSS', 'SQLi'})   # one XSS main + the SQLi survive
+
+	def test_api_backend_is_skipped(self):
+		findings = [_vuln('XSS', 'a', 'u1'), _vuln('XSS', 'a', 'u2')]
+		be = FakeBackend(findings)
+		be.name = 'api'
+		self.assertEqual(maybe_tag_duplicates(FakeEngine(be), 'ws1'), 0)   # server tags its own store
+		self.assertTrue(all('workspace_duplicate' not in d.get('_context', {}) for d in findings))
+
+
+class TestBackendIdHelpers(unittest.TestCase):
+
+	def test_mongo_carry_uuid_surfaces_native_id(self):
+		doc = _carry_uuid({'_id': 'abc123', '_type': 'port'})
+		self.assertEqual(doc.get('_uuid'), 'abc123')
+		self.assertNotIn('_id', doc)                             # native id dropped, uniform id surfaced
+
+	def test_mongo_carry_uuid_keeps_existing_uuid(self):
+		doc = _carry_uuid({'_id': 'x', '_uuid': 'keep', '_type': 'port'})
+		self.assertEqual(doc['_uuid'], 'keep')
+
+	def test_json_set_nested_creates_path(self):
+		d = {}
+		_set_nested(d, '_context.workspace_duplicate', True)
+		self.assertEqual(d, {'_context': {'workspace_duplicate': True}})
+		_set_nested(d, '_tagged', True)
+		self.assertIs(d['_tagged'], True)                        # bare key = plain assignment
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/unit/test_workspace_summary.py
+++ b/tests/unit/test_workspace_summary.py
@@ -61,12 +61,25 @@ class TestSummaryQuery(unittest.TestCase):
 		self.assertIn(r'\[test]', out)          # escaped, not a live markup tag
 
 
+class _StubBackend:
+	"""Minimal backend for the maybe_tag_duplicates() call in the dedup path (no findings to tag)."""
+	name = 'fake'
+	workspace_id = 'ws1'
+
+	def _execute_search(self, query, limit=0):
+		return []
+
+	def _execute_update(self, query, update):
+		return 0
+
+
 class RecordingEngine:
 	"""Filters findings by the query's _type clause (top-level or $and-nested) and records the
 	queries passed to iterate(), so tests can assert on the query shape (dedup nesting)."""
 	def __init__(self, findings):
 		self._f = findings
 		self.queries = []
+		self.backend = _StubBackend()
 
 	def _type_of(self, q):
 		if isinstance(q.get('_type'), str):


### PR DESCRIPTION
## Why

Scans no longer tag duplicates at write time (it could take forever on large workspaces). But the **stream** query path can't dedup in memory the way the materialized path does (`remove_duplicates`) — it filters on the stored `_context.workspace_duplicate` flag. With nothing marking that flag, `secator q --dedupe` and `workspace summary` **silently kept duplicates**.

This wires **on-demand** duplicate tagging into the dedup path, working across every query backend.

## What

- **`_dedup.tag_duplicates(engine, ws_id)`** — a generic tagger built on the backends' raw `_execute_search`/`_execute_update`, keyed on a uniform `_uuid`. Reuses the already-shared `compute_duplicate_updates`. Full evaluation, `max_items`-capped (the incremental `_tagged:{$in:[False,None]}` filter relies on Mongo's null-matching that SQL `IN`/`!=` don't share, so it's not portable). `maybe_tag_duplicates` **skips `api`** — the cloud server tags its own store.
- **mongodb backend** — `_execute_search`/`_execute_iterate` now surface the native `_id` as `_uuid` (`_carry_uuid`) so every backend returns one uniform id; `_execute_update` translates a `_uuid` predicate back to `_id`.
- **json backend** — `_execute_update` now expands dotted `$set` keys into nested dicts (`_set_nested`); it previously wrote a flat `"_context.workspace_duplicate"` key that the nested-reading filter never saw.
- **report.build (stream) + `_summary_query`** — tag on demand before filtering, and **nest the dedup predicate in `$and`** (a top-level `_context.workspace_duplicate` is a `PROTECTED_FIELD` stripped by `_merge_query`, so a bare merge silently dropped the filter).

## Scope note

The optimized **incremental worker-path** taggers in `hooks/{mongodb,sqlite}.py` are left as-is — they already share `compute_duplicate_updates`, and Mongo's version is an index-seekable incremental scan. This PR adds the on-demand path without downgrading the prod scan path.

## Tests

- `test_dedup_backend_agnostic.py` — generic tagger marks exactly one of a duplicate pair; `api` is skipped; `_carry_uuid` / `_set_nested` helpers.
- Verified sqlite `_build_where` emits correct nested SQL for the dedup queries + `_uuid` update key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate finding handling during live scans and result streaming.
  * Duplicate findings are now identified and tagged consistently across supported backends.
  * Preserved reliable finding updates and identifiers across database backends.
  * Ensured nested finding metadata is stored and retrieved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->